### PR TITLE
[CCXDEV-8755] Expect servicelog configuration too

### DIFF
--- a/features/steps/notification_service.py
+++ b/features/steps/notification_service.py
@@ -162,7 +162,8 @@ def check_configuration_info_from_ccx_notification_service(context):
         "Storage configuration",
         "Logging configuration",
         "Notifications configuration",
-        "Metrics configuration"
+        "Metrics configuration",
+        "ServiceLog configuration"
     ]
 
     for item in expected_info:


### PR DESCRIPTION
# Description

Expect servicelog configuration too

Fixes #CCXDEV-8755

## Type of change

- Non-breaking change in test steps implementation

## Testing steps

Locally tested.

## Checklist
* [ ] Pylint passes for Python sources
* [ ] sources has been pre-processed by Black
* [ ] updated documentation wherever necessary
