### PR TITLE
Modify Service Log BDD tests

### DIFF
--- a/config/notification_service.toml
+++ b/config/notification_service.toml
@@ -15,6 +15,9 @@ event_filter = "totalRisk >= totalRiskThreshold"
 
 [service_log]
 enabled = false
+offline_token = "TEST_TOKEN"
+token_refreshment_url = "http://localhost:8001/auth/realms/redhat-external/protocol/openid-connect/token"
+url = "localhost:8000/api/service_logs/v1/cluster_logs/"
 likelihood_threshold = 0
 impact_threshold = 0
 severity_threshold = 0
@@ -34,6 +37,8 @@ log_sql_queries = true
 [dependencies]
 content_server = "localhost:8082"
 content_endpoint = "/api/v1/content"
+template_renderer_server = "localhost:8083"
+template_renderer_endpoint = "/rendered_reports"
 
 [notifications]
 insights_advisor_url = "https://console.redhat.com/openshift/insights/advisor/clusters/{cluster_id}"

--- a/features/ccx-notification-service/service_log.feature
+++ b/features/ccx-notification-service/service_log.feature
@@ -33,3 +33,15 @@ Feature: Service Log
           | CCX_NOTIFICATION_SERVICE__SERVICE_LOG__ENABLED  | true |
      Then it should have sent 1 notification events to Service Log
       And the process should exit with status code set to 0
+
+  Scenario: Check that notification service doesn't send message to service log if it is not important
+    Given Postgres is running
+      And service-log service is empty
+     When I insert 1 report with low total risk for the following clusters
+          | org id |  account number | cluster name                         |
+          | 1      |  1              | 5d5892d4-2g85-4ccf-02bg-548dfc9767aa |
+      And I start the CCX Notification Service with the --instant-reports command line flag
+          | val                                             | var   |
+          | CCX_NOTIFICATION_SERVICE__SERVICE_LOG__ENABLED  | true |
+     Then it should have sent 0 notification events to Service Log
+      And the process should exit with status code set to 0

--- a/features/steps/notification_service.py
+++ b/features/steps/notification_service.py
@@ -29,15 +29,19 @@ test_output = "test"
 # using {max_age:d} {age_unit:w}, but at least this way it is clear when it
 # gets unexpected values
 def parse_max_age(max_age):
-    assert isinstance(max_age, str), \
-        f"expected max_age to be a string with 2 parts: the value and the unit. Got {type(max_age)} - {max_age} "  # noqa E501
-    items = max_age.replace('"', '').split(" ")
-    assert len(items) == 2, \
-        f"expected max_age to have 2 parts: the value and the unit. Got {max_age}"
-    assert items[0].isdigit(), \
-        f"expected max_age to start with an integer, got {items[0]}"
-    assert items[1].isalpha(), \
-        f"expected max_age to contain an alpha string for the max_age unit, got {items[1]}"
+    assert isinstance(
+        max_age, str
+    ), f"expected max_age to be a string with 2 parts: the value and the unit. Got {type(max_age)} - {max_age} "  # noqa E501
+    items = max_age.replace('"', "").split(" ")
+    assert (
+        len(items) == 2
+    ), f"expected max_age to have 2 parts: the value and the unit. Got {max_age}"
+    assert items[
+        0
+    ].isdigit(), f"expected max_age to start with an integer, got {items[0]}"
+    assert items[
+        1
+    ].isalpha(), f"expected max_age to contain an alpha string for the max_age unit, got {items[1]}"
     return max_age
 
 
@@ -58,12 +62,14 @@ def process_ccx_notification_service_output(context, out, return_codes):
     assert stdout is not None, "No output from application"
 
     # check the return code of a process
-    assert out.returncode == 0 or out.returncode in return_codes, \
-        "Return code is {}. Check the logs:\nvvvvv\n{}\n^^^^^\n".format(
-            out.returncode, stdout.decode('utf-8'))
+    assert (
+        out.returncode == 0 or out.returncode in return_codes
+    ), "Return code is {}. Check the logs:\nvvvvv\n{}\n^^^^^\n".format(
+        out.returncode, stdout.decode("utf-8")
+    )
 
     # try to decode output
-    output = stdout.decode('utf-8').split("\n")
+    output = stdout.decode("utf-8").split("\n")
 
     assert output is not None
 
@@ -106,22 +112,28 @@ def start_ccx_notification_service_with_flag(context, flag):
         for row in context.table:
             env[row["val"]] = row["var"]
 
-    out = subprocess.Popen(params,
-                           stdout=subprocess.PIPE,
-                           stderr=subprocess.STDOUT,
-                           env=env)
-
+    out = subprocess.Popen(
+        params, stdout=subprocess.PIPE, stderr=subprocess.STDOUT, env=env
+    )
     assert out is not None
     process_ccx_notification_service_output(context, out, context.return_codes)
 
 
 def check_help_from_ccx_notification_service(context):
     """Check if help is displayed by CCX Notification Service."""
-    expected_output = ["  -cleanup-on-startup", "  -instant-reports", "  -max-age string",
-                       "  -new-reports-cleanup", "  -old-reports-cleanup",
-                       "  -print-new-reports-for-cleanup", "  -print-old-reports-for-cleanup",
-                       "  -show-authors", "  -show-configuration", "  -show-version",
-                       "  -weekly-reports"]
+    expected_output = [
+        "  -cleanup-on-startup",
+        "  -instant-reports",
+        "  -max-age string",
+        "  -new-reports-cleanup",
+        "  -old-reports-cleanup",
+        "  -print-new-reports-for-cleanup",
+        "  -print-old-reports-for-cleanup",
+        "  -show-authors",
+        "  -show-configuration",
+        "  -show-version",
+        "  -weekly-reports",
+    ]
 
     # preliminary checks
     assert context.output is not None
@@ -138,8 +150,9 @@ def check_version_from_ccx_notification_service(context):
     assert type(context.output) is list, "wrong type of output"
 
     # check the output
-    assert "Notification service version 1.0" in context.output, \
-        "Caught output: {}".format(context.output)
+    assert (
+        "Notification service version 1.0" in context.output
+    ), "Caught output: {}".format(context.output)
 
 
 def check_authors_info_from_ccx_notification_service(context):
@@ -149,8 +162,9 @@ def check_authors_info_from_ccx_notification_service(context):
     assert type(context.output) is list, "wrong type of output"
 
     # check the output
-    assert "Pavel Tisnovsky, Papa Bakary Camara, Red Hat Inc." in context.output, \
-        "Caught output: {}".format(context.output)
+    assert (
+        "Pavel Tisnovsky, Papa Bakary Camara, Red Hat Inc." in context.output
+    ), "Caught output: {}".format(context.output)
 
 
 @then("I should see the current configuration displayed on standard output")
@@ -173,14 +187,17 @@ def check_configuration_info_from_ccx_notification_service(context):
         "Logging configuration",
         "Notifications configuration",
         "Metrics configuration",
-        "ServiceLog configuration"
+        "ServiceLog configuration",
     ]
 
     for item in expected_info:
         assert item in stdout, "Caught output: {}".format(stdout)
 
 
-@then("I should see info about not notified reports older than {max_age:Age} displayed on standard output")  # noqa E501
+@then(
+    "I should see info about not notified reports older "
+    "than {max_age:Age} displayed on standard output"
+)  # noqa E501
 def check_print_new_reports_for_cleanup(context, max_age):
     """Check if information about new reports for cleanup is displayed by CCX Notification Service."""  # noqa E501
     # preliminary checks
@@ -191,12 +208,17 @@ def check_print_new_reports_for_cleanup(context, max_age):
     assert stdout is not None, "stdout object should exist"
     assert type(stdout) is str, "wrong type of stdout object"
 
-    assert "PrintReportsForCleanup operation" in stdout, "Caught output: {}".format(stdout)
+    assert "PrintReportsForCleanup operation" in stdout, "Caught output: {}".format(
+        stdout
+    )
     assert "FROM new_reports" in stdout, "Caught output: {}".format(stdout)
     assert max_age in stdout, "Caught output: {}".format(stdout)
 
 
-@then("I should see info about cleaned up not notified reports older than {max_age:Age} displayed on standard output")  # noqa E501
+@then(
+    "I should see info about cleaned up not notified reports "
+    "older than {max_age:Age} displayed on standard output"
+)  # noqa E501
 def check_new_reports_cleanup(context, max_age):
     """Check if information about not notified reports cleanup is displayed by CCX Notification Service."""  # noqa E501
     # preliminary checks
@@ -207,13 +229,20 @@ def check_new_reports_cleanup(context, max_age):
     assert stdout is not None, "stdout object should exist"
     assert type(stdout) is str, "wrong type of stdout object"
 
-    assert "Cleanup operation for all organizations" in stdout, "Caught output: {}".format(stdout)
+    assert (
+        "Cleanup operation for all organizations" in stdout
+    ), "Caught output: {}".format(stdout)
     assert "FROM new_reports" in stdout, "Caught output: {}".format(stdout)
     assert max_age in stdout, "Caught output: {}".format(stdout)
-    assert "Cleanup `new_reports` finished" in stdout, "Caught output: {}".format(stdout)
+    assert "Cleanup `new_reports` finished" in stdout, "Caught output: {}".format(
+        stdout
+    )
 
 
-@then("I should see info about notified reports older than {max_age:d} {age_unit:w} displayed on standard output")  # noqa E501
+@then(
+    "I should see info about notified reports older "
+    "than {max_age:d} {age_unit:w} displayed on standard output"
+)  # noqa E501
 def check_print_old_reports_for_cleanup(context, max_age, age_unit):
     """Check if information about notified reports for cleanup is displayed by CCX Notification Service."""  # noqa E501
     # preliminary checks
@@ -224,12 +253,17 @@ def check_print_old_reports_for_cleanup(context, max_age, age_unit):
     assert stdout is not None, "stdout object should exist"
     assert type(stdout) is str, "wrong type of stdout object"
 
-    assert "PrintReportsForCleanup operation" in stdout, "Caught output: {}".format(stdout)
+    assert "PrintReportsForCleanup operation" in stdout, "Caught output: {}".format(
+        stdout
+    )
     assert "FROM reported" in stdout, "Caught output: {}".format(stdout)
     assert str(max_age) + " " + age_unit in stdout, "Caught output: {}".format(stdout)
 
 
-@then("I should see info about cleaned up notified reports older than {max_age:d} {age_unit:w} displayed on standard output")  # noqa E501
+@then(
+    "I should see info about cleaned up notified reports older "
+    "than {max_age:d} {age_unit:w} displayed on standard output"
+)  # noqa E501
 def check_old_reports_cleanup(context, max_age, age_unit):
     """Check if information about notified reports for cleanup is displayed by CCX Notification Service."""  # noqa E501
     # preliminary checks
@@ -240,7 +274,9 @@ def check_old_reports_cleanup(context, max_age, age_unit):
     assert stdout is not None, "stdout object should exist"
     assert type(stdout) is str, "wrong type of stdout object"
 
-    assert "Cleanup operation for all organizations" in stdout, "Caught output: {}".format(stdout)
+    assert (
+        "Cleanup operation for all organizations" in stdout
+    ), "Caught output: {}".format(stdout)
     assert "FROM reported" in stdout, "Caught output: {}".format(stdout)
     assert str(max_age) + " " + age_unit in stdout, "Caught output: {}".format(stdout)
     assert "Cleanup `reported` finished" in stdout, "Caught output: {}".format(stdout)
@@ -258,7 +294,9 @@ def check_old_reports_in_table(context, table):
     assert stdout is not None, "stdout object should exist"
     assert type(stdout) is str, "wrong type of stdout object"
 
-    assert f"Old report from `{table}` table" in stdout, "Caught output: {}".format(stdout)
+    assert f"Old report from `{table}` table" in stdout, "Caught output: {}".format(
+        stdout
+    )
     for row in context.table:
         assert row["org id"] in stdout, "Caught output: {}".format(stdout)
         assert row["account number"] in stdout, "Caught output: {}".format(stdout)
@@ -277,7 +315,9 @@ def check_no_old_reports_in_table(context, table):
     assert stdout is not None, "stdout object should exist"
     assert type(stdout) is str, "wrong type of stdout object"
 
-    assert f"Old report from `{table}` table" not in stdout, "Caught output: {}".format(stdout)
+    assert f"Old report from `{table}` table" not in stdout, "Caught output: {}".format(
+        stdout
+    )
     assert "ClusterName" not in stdout
 
 
@@ -285,9 +325,11 @@ def check_no_old_reports_in_table(context, table):
 def check_status_code(context, expected_code):
     """Check the status code of the last started process."""
     # check the return code of a process
-    assert context.returncode == expected_code, \
-        "Return code is {}, but {} is expected. Check the logs:\n{}".format(
-            context.returncode, expected_code, context.stdout.decode("utf-8"))
+    assert (
+        context.returncode == expected_code
+    ), "Return code is {}, but {} is expected. Check the logs:\n{}".format(
+        context.returncode, expected_code, context.stdout.decode("utf-8")
+    )
 
 
 @then("It should clean items in {table:w} table older than {max_age:Age}")
@@ -301,7 +343,9 @@ def check_cleaned_items_on_standard_output(context, table, max_age):
     assert stdout is not None, "stdout object should exist"
     assert type(stdout) is str, "wrong type of stdout object"
 
-    assert "Cleanup operation for all organizations" in stdout, "Caught output: {}".format(stdout)
+    assert (
+        "Cleanup operation for all organizations" in stdout
+    ), "Caught output: {}".format(stdout)
     assert f"Cleanup `{table}` finished" in stdout, "Caught output: {}".format(stdout)
     assert max_age in stdout, "Caught output: {}".format(stdout)
 
@@ -314,13 +358,22 @@ def get_events_kafka(num_event):
     address = "localhost:9092"
     topic = "platform.notifications.ingress"
 
-    params = ["kafkacat", "-b", address, "-C",
-              "-t", topic, "-c", str(num_event), "-o", str(-num_event), "-e"]
+    params = [
+        "kafkacat",
+        "-b",
+        address,
+        "-C",
+        "-t",
+        topic,
+        "-c",
+        str(num_event),
+        "-o",
+        str(-num_event),
+        "-e",
+    ]
 
     print("subprocess: ", params)
-    out = subprocess.Popen(params,
-                           stdout=subprocess.PIPE,
-                           stderr=subprocess.STDOUT)
+    out = subprocess.Popen(params, stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
 
     # check if call was correct
     assert out is not None
@@ -330,19 +383,21 @@ def get_events_kafka(num_event):
     stdout, stderr = out.communicate()
 
     # try to decode output
-    output = stdout.decode('utf-8')
+    output = stdout.decode("utf-8")
 
     if "Unknown topic or partition" in output:
         return []
 
-    return [i for i in output.split('\n') if i and i[0] == "{"]
+    return [i for i in output.split("\n") if i and i[0] == "{"]
 
 
 @then("it should have sent {num_event:d} notification events to Kafka")
 def count_notification_events_kafka(context, num_event):
     """Get events from kafka topic and count them to check if matches"""
     events = get_events_kafka(num_event)
-    assert len(events) == num_event, f"Retrieved {len(events)} events when {num_event} was expected"
+    assert (
+        len(events) == num_event
+    ), f"Retrieved {len(events)} events when {num_event} was expected"
 
 
 @then("it should have sent the following {num_event:d} notification events to Kafka")
@@ -360,23 +415,31 @@ def retrieve_notification_events_kafka(context, num_event):
         assert encoded is not None
 
         # let's verify the data
-        assert "bundle" in encoded and encoded[
-            "bundle"] == "openshift", "Expected event to contain the `openshift` bundle"
-        assert "application" in encoded and encoded[
-            "application"] == "advisor", "Expected event to contain the `advisor` application"
-        assert "event_type" in encoded and encoded[
-            "event_type"] == "new-recommendation", \
-            "Expected event to contain the `new-recommendation` event type"
-        assert "account_id" in encoded, "Expected `account_id` to be included in the event"
+        assert (
+            "bundle" in encoded and encoded["bundle"] == "openshift"
+        ), "Expected event to contain the `openshift` bundle"
+        assert (
+            "application" in encoded and encoded["application"] == "advisor"
+        ), "Expected event to contain the `advisor` application"
+        assert (
+            "event_type" in encoded and encoded["event_type"] == "new-recommendation"
+        ), "Expected event to contain the `new-recommendation` event type"
+        assert (
+            "account_id" in encoded
+        ), "Expected `account_id` to be included in the event"
 
         account_id = context.table[index]["account number"]
         cluster_id = context.table[index]["cluster name"]
         total_risk = context.table[index]["total risk"]
-        assert account_id == encoded["account_id"], f"Expected account id to be {account_id}"
-        assert cluster_id in encoded["context"], \
-            f"Expected cluster name in event to be {cluster_id}."
-        assert f'"total_risk":"{total_risk}"' in encoded["events"][0][
-            'payload'], f'"total_risk":"{total_risk}" not in {encoded["events"][0]["payload"]}'
+        assert (
+            account_id == encoded["account_id"]
+        ), f"Expected account id to be {account_id}"
+        assert (
+            cluster_id in encoded["context"]
+        ), f"Expected cluster name in event to be {cluster_id}."
+        assert (
+            f'"total_risk":"{total_risk}"' in encoded["events"][0]["payload"]
+        ), f'"total_risk":"{total_risk}" not in {encoded["events"][0]["payload"]}'
 
 
 def get_events_service_log():
@@ -384,9 +447,12 @@ def get_events_service_log():
     address = "http://localhost:8000"
     x = requests.get(
         address + "/api/service_logs/v1/cluster_logs",
-        headers={'Authorization': 'TEST_TOKEN'})
-    assert x.status_code == 200, f'unexpected status code: got "{x.status_code}" want "200"'
-    return x.json()['items']
+        headers={"Authorization": "TEST_TOKEN"},
+    )
+    assert (
+        x.status_code == 200
+    ), f'unexpected status code: got "{x.status_code}" want "200"'
+    return x.json()["items"]
 
 
 @given("service-log service is empty")
@@ -396,16 +462,21 @@ def remove_service_log_logs(context):
     logs = get_events_service_log()
     for log in logs:
         x = requests.delete(
-            address + "/api/service_logs/v1/cluster_logs/" + log.id,
-            headers={'Authorization': 'TEST_TOKEN'})
-        assert x.status_code == 204, f'unexpected status code: got "{x.status_code}" want "204"'
+            address + "/api/service_logs/v1/cluster_logs/" + log["id"],
+            headers={"Authorization": "TEST_TOKEN"},
+        )
+        assert (
+            x.status_code == 204
+        ), f'unexpected status code: got "{x.status_code}" want "204"'
 
 
 @then("it should have sent {num_event:d} notification events to Service Log")
 def count_notification_events_service_log(context, num_event):
     """Get events from kafka topic and count them to check if matches"""
     events = get_events_service_log()
-    assert len(events) == num_event, f"Retrieved {len(events)} events when {num_event} was expected"
+    assert (
+        len(events) == num_event
+    ), f"Retrieved {len(events)} events when {num_event} was expected"
 
 
 @then("the logs should match")
@@ -418,7 +489,7 @@ def check_logs(context):
     | this one should't match  | no       |
     """
 
-    output = context.stdout.decode('utf-8')
+    output = context.stdout.decode("utf-8")
 
     for row in context.table:
         log, contains = row["log"], row["contains"]

--- a/features/steps/notification_service_dependencies.py
+++ b/features/steps/notification_service_dependencies.py
@@ -25,7 +25,7 @@ def check_content_service_availability(context, host, port):
 
     if not str(host).startswith("http"):
         host = "http://" + host
-    x = requests.get(f'{host}:{port}/api/v1/openapi.json')
+    x = requests.get(f"{host}:{port}/api/v1/openapi.json")
     assert x.status_code == 200
     context.content_service_available = True
 
@@ -37,8 +37,9 @@ def check_service_log_availability(context, host, port):
     if not str(host).startswith("http"):
         host = "http://" + host
     x = requests.get(
-        f'{host}:{port}/api/service_logs/v1/cluster_logs',
-        headers={'Authorization': 'TEST_TOKEN'})
+        f"{host}:{port}/api/service_logs/v1/cluster_logs",
+        headers={"Authorization": "TEST_TOKEN"},
+    )
     assert x.status_code == 200, "service log is not up"
 
 
@@ -56,7 +57,7 @@ def check_push_gateway_availability(context, host, port):
 
     if not str(host).startswith("http"):
         host = "http://" + host
-    x = requests.get(f'{host}:{port}/metrics')
+    x = requests.get(f"{host}:{port}/metrics")
     assert x.status_code == 200
     context.push_gateway_available = True
 

--- a/mocks/content-template-renderer/content_template_renderer.py
+++ b/mocks/content-template-renderer/content_template_renderer.py
@@ -1,0 +1,82 @@
+# Copyright 2022 Red Hat, Inc
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Mock of the content-template-renderer service. The original service is used to
+interpolate rule templates from content-service with report details.
+
+The input is in this form (some additional data are optional, but not used by this service):
+
+{
+    "content": ... output from content-service ...,
+    "report_data": {
+        "clusters": ["d484b150-3106-4d6a-96b4-e03c327a2f66"],
+        "reports: {
+            "d484b150-3106-4d6a-96b4-e03c327a2f66": [
+                {
+                    "rule_id": "tutorial_rule|TUTORIAL_ERROR_KEY",
+                    "component": "ccx_rules_ocp.external.rules.tutorial_rule.report",
+                    "type": "rule",
+                    "details" {
+                        "some_detail": "detail data"
+                    }
+                }
+            ]
+        }
+    }
+}
+
+Output is in this form:
+
+{
+    "clusters": ["d484b150-3106-4d6a-96b4-e03c327a2f66"],
+    "reports": {
+        "d484b150-3106-4d6a-96b4-e03c327a2f66": [
+            {
+                "rule_id": "ccx_rules_ocp.external.rules.tutorial_rule",
+                "error_key": "TUTORIAL_ERROR_KEY",
+                "description": "detailed description",
+                "reason": "detailed reason",
+                "resolution": "detailed resolution"
+            }
+        ]
+    }
+}
+"""
+from fastapi import FastAPI, Request
+
+app = FastAPI()
+
+
+@app.post("/rendered_reports")
+async def render_reports(request: Request):
+    data = await request.json()
+
+    reports = []
+    for cluster_id, cluster_data in data["report_data"]["reports"].items():
+        for report in cluster_data["reports"]:
+            reports.append(
+                {
+                    "rule_id": report["component"][0: report["component"].rfind(".")],
+                    "error_key": report["key"],
+                    "description": "detailed description",
+                    "reason": "detailed report",
+                    "resolution": "detailed resolution",
+                }
+            )
+
+    return {
+        "clusters": data["report_data"]["clusters"],
+        "reports": {data["report_data"]["clusters"][0]: reports},
+    }

--- a/mocks/service-log/service_log.py
+++ b/mocks/service-log/service_log.py
@@ -77,7 +77,7 @@ You can also query using:
 
 from typing import Union
 
-from fastapi import FastAPI, Request
+from fastapi import FastAPI, Request, Response, status
 from fastapi.exceptions import RequestValidationError
 from starlette.responses import JSONResponse
 from pydantic import BaseModel
@@ -205,7 +205,7 @@ def delete_logs(id: str, request: Request):
     for i, log in enumerate(log_storage):
         if log.id == id:
             log_storage.pop(i)
-            return 204
+            return Response(status_code=status.HTTP_204_NO_CONTENT)
     return ReturnError(
         id=id,
         kind="Error",

--- a/mocks/token-refreshment/token_refreshment.py
+++ b/mocks/token-refreshment/token_refreshment.py
@@ -1,0 +1,36 @@
+# Copyright 2022 Red Hat, Inc
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from fastapi import FastAPI, Request, Form
+from starlette.responses import JSONResponse
+from pydantic import BaseModel
+
+app = FastAPI()
+
+
+class ReturnError(BaseModel):
+    error: str
+    error_description: str
+
+
+@app.post("/auth/realms/redhat-external/protocol/openid-connect/token")
+def get_access_token(refresh_token: str = Form()):
+    if refresh_token != "TEST_TOKEN":
+        return JSONResponse(
+            ReturnError(
+                error="invalid grant", error_description="Invalid refresh token"
+            ).dict(),
+            status_code=401,
+        )
+    return {"access_token": "ACCESS_TOKEN"}

--- a/requirements/mocks.txt
+++ b/requirements/mocks.txt
@@ -1,2 +1,3 @@
 fastapi
 uvicorn[standard]
+python-multipart


### PR DESCRIPTION
# Description

Changes here add mocks for additional dependencies neccessary for testing Service Log integration in notification service. New scenario is also added, and cleanup phase in `notification_service_tests.sh` has been changed (didn't work properly before).

## Type of change

- Bug fix (non-breaking change which fixes an issue)
- New test scenario added into existing feature file
- Non-breaking change in test steps implementation

## Testing steps

I run the tests in `service_log.feature` individually one by one in mock settings. Without mock settings it currently fails, because API of service log container is not accessible from the outside (probably because of wrong binding address of the service).

## Checklist
* [ ] Pylint passes for Python sources
* [x] sources has been pre-processed by Black
* [ ] updated documentation wherever necessary
