### PR TITLE
[CCXDEV-9220][ccx-notification-service] Don't update reported table is disabled

### DIFF
--- a/features/ccx-notification-service/customer_notifications.feature
+++ b/features/ccx-notification-service/customer_notifications.feature
@@ -26,6 +26,8 @@ Feature: Customer Notifications
           | log                              | contains   |
           | Report with high impact detected | yes        |
           | No new issues to notify          | no         |
+     When I select all rows from table reported
+     Then I should get 0 rows
 
   Scenario: Check that notification service produces instant notifications with the expected content if all dependencies are available
     Given Postgres is running
@@ -40,7 +42,8 @@ Feature: Customer Notifications
           |  account number | cluster name                         | total risk |
           |  1              | 5d5892d4-2g85-4ccf-02bg-548dfc9767aa | 3          |
       And the process should exit with status code set to 0
-
+     When I select all rows from table reported
+     Then I should get 1 rows
 
   Scenario: Check that notification service produces instant notifications multiple events same cluster
     Given Postgres is running

--- a/features/steps/notification_service.py
+++ b/features/steps/notification_service.py
@@ -88,7 +88,14 @@ def store_cleanup_flag(context):
 
 @when("I start the CCX Notification Service with the {flag} command line flag")
 def start_ccx_notification_service_with_flag(context, flag):
-    """Start the CCX Notification Service with given command-line flag."""
+    """
+    Start the CCX Notification Service with given command-line flag.
+
+    You can pass environment variables in a table with columns "val" and "var":
+
+        | val                                             | var   |
+        | CCX_NOTIFICATION_SERVICE__KAFKA_BROKER__ENABLED | false |
+    """
     params = ["ccx-notification-service", flag]
     if hasattr(context, "max_age"):
         params.append("--max-age=" + context.max_age)


### PR DESCRIPTION
# Description

Check that the reported table is not updated if no message is sent because the producer is disabled.

See https://github.com/RedHatInsights/ccx-notification-service/pull/266. 

## Type of change

- Update test scenario

## Testing steps

Locally.

## Checklist
* [ ] Pylint passes for Python sources
* [ ] sources has been pre-processed by Black
* [ ] updated documentation wherever necessary
