### PR TITLE
Change testing behavior with disabled Kafka - enable Service Log

### DIFF
--- a/features/ccx-notification-service/customer_notifications.feature
+++ b/features/ccx-notification-service/customer_notifications.feature
@@ -12,7 +12,7 @@ Feature: Customer Notifications
      Then the process should exit with status code set to 0
 
 
-  Scenario: Check that notification service does not send messages to kafka if the broker is disabled
+  Scenario: Check that notification service does not send messages to kafka if both broker is disabled and service log enabled
     Given Postgres is running
      When I insert 1 report with important total risk for the following clusters
           | org id |  account number | cluster name                         |
@@ -20,6 +20,7 @@ Feature: Customer Notifications
       And I start the CCX Notification Service with the --instant-reports command line flag
           | val                                             | var   |
           | CCX_NOTIFICATION_SERVICE__KAFKA_BROKER__ENABLED | false |
+          | CCX_NOTIFICATION_SERVICE__SERVICE_LOG__ENABLED  | true |
      Then it should have sent 0 notification events to Kafka
       And the process should exit with status code set to 0
       And the logs should match


### PR DESCRIPTION
# Description

The test with disabled sending notifications to Kafka failed, because if no notifications are sent both to Kafka and Service Log, notification exits with code 1. This change enables Service Log, so that the expected behavior matches the real one.

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Testing steps

Run the tests.

## Checklist
* [ ] Pylint passes for Python sources
* [ ] sources has been pre-processed by Black
* [ ] updated documentation wherever necessary
