### PR TITLE
Change mock of token refreshment to accept client credentials

### DIFF
--- a/config/notification_service.toml
+++ b/config/notification_service.toml
@@ -15,14 +15,15 @@ event_filter = "totalRisk >= totalRiskThreshold"
 
 [service_log]
 enabled = false
-offline_token = "TEST_TOKEN"
-token_refreshment_url = "http://localhost:8001/auth/realms/redhat-external/protocol/openid-connect/token"
-url = "localhost:8000/api/service_logs/v1/cluster_logs/"
+client_id = "CLIENT_ID"
+client_secret = "CLIENT_SECRET"
+token_url = "http://localhost:8001/auth/realms/redhat-external/protocol/openid-connect/token"
+url = "http://localhost:8000/api/service_logs/v1/cluster_logs/"
 likelihood_threshold = 0
 impact_threshold = 0
 severity_threshold = 0
 total_risk_threshold = 3
-event_filter = "totalRisk > totalRiskThreshold"
+event_filter = "totalRisk >= totalRiskThreshold"
 
 [storage]
 db_driver = "postgres"
@@ -35,9 +36,9 @@ pg_params = "sslmode=disable"
 log_sql_queries = true
 
 [dependencies]
-content_server = "localhost:8082"
+content_server = "http://localhost:8082"
 content_endpoint = "/api/v1/content"
-template_renderer_server = "localhost:8083"
+template_renderer_server = "http://localhost:8083"
 template_renderer_endpoint = "/rendered_reports"
 
 [notifications]

--- a/features/ccx-notification-service/service_log.feature
+++ b/features/ccx-notification-service/service_log.feature
@@ -30,7 +30,8 @@ Feature: Service Log
           | 1      |  1              | 5d5892d4-2g85-4ccf-02bg-548dfc9767aa |
       And I start the CCX Notification Service with the --instant-reports command line flag
           | val                                             | var   |
-          | CCX_NOTIFICATION_SERVICE__SERVICE_LOG__ENABLED  | true |
+          | CCX_NOTIFICATION_SERVICE__KAFKA_BROKER__ENABLED | false |
+          | CCX_NOTIFICATION_SERVICE__SERVICE_LOG__ENABLED  | true  |
      Then it should have sent 1 notification events to Service Log
       And the process should exit with status code set to 0
 


### PR DESCRIPTION
# Description

Modify mock of token refreshment server to accept client credentials instead of refresh token. Also modify notification service configuration and BDD test for service log integration.

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Testing steps

Run tests locally.

## Checklist
* [ ] Pylint passes for Python sources
* [ ] sources has been pre-processed by Black
* [ ] updated documentation wherever necessary
