### PR TITLE
Fix generating report JSON with correct rule key

### DIFF
--- a/features/steps/notification_database.py
+++ b/features/steps/notification_database.py
@@ -280,5 +280,5 @@ def generate_report_with_risk(risk):
         "moderate": "TEST_RULE_MODERATE_IMPACT",
         "low": "TEST_RULE_LOW_IMPACT"
     }
-    report.replace("<replace_me>", risk_rule_key_map[risk])
+    report = report.replace("<replace_me>", risk_rule_key_map[risk])
     return report


### PR DESCRIPTION
# Description

Result of `report.replace` was not assigned to `report`. This is a fix.

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Testing steps

N/A

## Checklist
* [ ] Pylint passes for Python sources
* [ ] sources has been pre-processed by Black
* [ ] updated documentation wherever necessary
