### PR TITLE
BDD scenarios and steps for Upgrade Risk Prediction Inference service

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,6 +16,9 @@ notification-service:
 notification-writer:
 	./notification_writer_tests.sh
 
+inference-service:
+	./ccx_upgrade_risk_inference_tests.sh
+
 code-style:
 	python3 tools/run_pycodestyle.py
 

--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,8 @@
-.PHONY: tests
+.PHONY: default tests code-style update-scenarios before_commit cleaner-tests exporter-tests notification-service notification-writer inference-service
 
 default: tests
 
-tests:	cleaner-tests exporter-tests
+tests:	cleaner-tests exporter-tests inference-service
 
 cleaner-tests:
 	./cleaner_tests.sh

--- a/ccx_upgrade_risk_inference_tests.sh
+++ b/ccx_upgrade_risk_inference_tests.sh
@@ -1,0 +1,68 @@
+#!/bin/bash -ex
+
+# Copyright 2022 Red Hat, Inc
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+dir_path=$(dirname $(realpath $0))
+export PATH=$PATH:$dir_path
+PATH_TO_LOCAL_INFERENCE_SERVICE=${PATH_TO_LOCAL_INFERENCE_SERVICE:="../ccx-inference-service"}
+
+#set NOVENV is current environment is not a python virtual env
+[ "$VIRTUAL_ENV" != "" ] || NOVENV=1
+
+function install_reqs() {
+    python3 $(which pip3) install -r requirements.txt
+}
+
+function prepare_venv() {
+    echo "Preparing environment"
+    # shellcheck disable=SC1091
+    virtualenv -p python3 venv && source venv/bin/activate && python3 "$(which pip3)" install -r requirements/upgrades_inference_service.txt
+    echo "Environment ready"
+}
+
+function install_inference_service() {
+    python3 "$(which pip3)" install $PATH_TO_LOCAL_INFERENCE_SERVICE
+    add_exit_trap 'python3 "$(which pip3)" uninstall -y ccx-upgrades-inference'
+}
+
+# mechanism to chain more trap commands added in different parts of this script
+exit_trap_command=""
+function cleanup {
+    eval "$exit_trap_command"
+}
+trap cleanup EXIT
+
+function add_exit_trap {
+    local to_add=$1
+    if [[ -z "$exit_trap_command" ]]
+    then
+        exit_trap_command="$to_add"
+    else
+        exit_trap_command="$exit_trap_command; $to_add"
+    fi
+}
+
+[ "$NOVENV" != "1" ] && install_reqs || prepare_venv || exit 1
+
+# Copy the binary and configuration to this folder
+install_inference_service
+
+# shellcheck disable=SC2068
+PYTHONDONTWRITEBYTECODE=1 python3 "$(which behave)" \
+    --no-capture \
+    --format=progress2 \
+    --tags=-skip --tags=-managed \
+    -D dump_errors=true @test_list/upgrades_inference_service.txt "$@"

--- a/features/README.md
+++ b/features/README.md
@@ -73,6 +73,11 @@ Directory where feature files with scenarios and scenario outlines are stored.
 
 * Displaying single rule page in OCM UI
 
+## `OCP_WebConsole/filter_managed_rules.feature`
+
+* Managed rules are not shown in OCP WebConsole
+* Non-managed rules are shown, but managed rules are not in OCP WebConsole
+
 ## `OCP_WebConsole/insights.feature`
 
 * Insights on OCP WebConsole for a cluster without any issue
@@ -420,8 +425,9 @@ Directory where feature files with scenarios and scenario outlines are stored.
 ## `ccx-notification-service/customer_notifications.feature`
 
 * Check that notification service does not need kafka if database has no new report
+* Check that notification service does not send messages to kafka if both broker is disabled and service log enabled
 * Check that notification service produces instant notifications with the expected content if all dependencies are available
-* Check that notification service produces instant notifications multiple events same cluster
+* Check that notification service produces a single notification event for cluster with multiple new reports
 * Check that instant notification does not include the same reports as in previous notification
 * Check that notification service does not flood customer with unnecessary instant emails
 * Check that notification service resends notification after cooldown has passed
@@ -437,6 +443,16 @@ Directory where feature files with scenarios and scenario outlines are stored.
 * Check the ability to display old records from `reported` if the table contains only new reports.
 * Check the ability to display old records from `reported` if the table contains multiple old reports.
 * Check the ability to display old records from `reported` if the table contains old and new reports
+
+## `ccx-notification-service/service_log.feature`
+
+* Check that notification service does not send messages to service log if it is disabled
+* Check that notification service sends messages to service log if it is enabled
+* Check that notification service doesn't send message to service log if it is not important
+* Check that notification service doesn't send message that has been sent within cooldown
+* Check that notification service resends message after cooldown has passed
+* Check that notification service produces a single notification event for cluster with multiple new reports
+* Check that Kafka related rows in reported table do not affect notifications sent to service log
 
 ## `ccx-notification-service/smoketests.feature`
 
@@ -506,4 +522,16 @@ Directory where feature files with scenarios and scenario outlines are stored.
 * Check if ZooKeeper is running locally
 * Check if Kafka broker is running locally
 * Check if Kafka broker is running on expected port
+
+## `ccx-upgrades-inference/perform_inference.feature`
+
+* Check Inference Service response with no body is sent in the request
+* Check Inference Service response with an invalid body is used in the request
+* Check Inference Service response with an valid body with invalid data is used in the request
+* Check Inference Service response with an valid body with valid data is used in the request
+
+## `ccx-upgrades-inference/smoketests.feature`
+
+* Check if CCX Upgrade Risk Inference Service application is available
+* Check if CCX Upgrade Risk Inference Service can be run
 

--- a/features/README.md
+++ b/features/README.md
@@ -527,8 +527,8 @@ Directory where feature files with scenarios and scenario outlines are stored.
 
 * Check Inference Service response with no body is sent in the request
 * Check Inference Service response with an invalid body is used in the request
-* Check Inference Service response with an valid body with invalid data is used in the request
-* Check Inference Service response with an valid body with valid data is used in the request
+* Check Inference Service response with a valid body with invalid data is used in the request
+* Check Inference Service response with a valid body with valid data is used in the request
 
 ## `ccx-upgrades-inference/smoketests.feature`
 

--- a/features/ccx-upgrades-inference/perform_inference.feature
+++ b/features/ccx-upgrades-inference/perform_inference.feature
@@ -1,0 +1,50 @@
+Feature: Upgrade Risks Prediction inference - test well known values
+
+  Scenario: Empty body is used
+    Given The CCX Inference Service is running
+     When I request the upgrade-risks-prediction endpoint
+     Then The status code of the response is 422
+
+  Scenario: Invalid body is used
+    Given The CCX Inference Service is running
+     When I request the upgrade-risks-prediction endpoint with junk in the body
+     Then The status code of the response is 422
+    
+  Scenario: Invalid kind is used
+    Given The CCX Inference Service is running
+     When I request the upgrade-risks-prediction endpoint using the following data as risks
+          | kind | value     |
+          | foc  | some.foc  |
+          | junk | some.junk |
+     Then The status code of the response is 422
+
+  Scenario: Valid input risks are used
+    Given The CCX Inference Service is running
+     When I request the upgrade-risks-prediction endpoint using the following data as risks
+          | kind  | value       |
+          | foc   | some.foc1   |
+          | alert | some.alert1 |
+     Then The status code of the response is 200
+      And The body of the response has the following schema
+          """
+          {
+            "required": [
+              "upgrade_recommended",
+              "upgrade_risks_predictors"
+            ],
+            "type": "object",
+            "properties": {
+              "upgrade_recommended": {
+                "title": "Upgrade Recommended",
+                "type": "boolean"
+              },
+              "upgrade_risks_predictors": {
+                "title": "Upgrade Risks Predictors",
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+          """

--- a/features/ccx-upgrades-inference/perform_inference.feature
+++ b/features/ccx-upgrades-inference/perform_inference.feature
@@ -10,7 +10,7 @@ Feature: Upgrade Risks Prediction inference - test well known values
      When I request the upgrade-risks-prediction endpoint with junk in the body
      Then The status code of the response is 422
     
-  Scenario: Check Inference Service response with an valid body with invalid data is used in the request
+  Scenario: Check Inference Service response with a valid body with invalid data is used in the request
     Given The CCX Inference Service is running
      When I request the upgrade-risks-prediction endpoint using the following data as risks
           | kind | value     |
@@ -18,7 +18,7 @@ Feature: Upgrade Risks Prediction inference - test well known values
           | junk | some.junk |
      Then The status code of the response is 422
 
-  Scenario: Check Inference Service response with an valid body with valid data is used in the request
+  Scenario: Check Inference Service response with a valid body with valid data is used in the request
     Given The CCX Inference Service is running
      When I request the upgrade-risks-prediction endpoint using the following data as risks
           | kind  | value       |
@@ -48,3 +48,39 @@ Feature: Upgrade Risks Prediction inference - test well known values
             }
           }
           """
+
+# Scenario: Check Inference Service response with a valid body with valid data is used in the request that returns a success prediction
+#     Given The CCX Inference Service is running
+#      When I request the upgrade-risks-prediction endpoint using the following data as risks
+#           | kind  | value       |
+#      Then The status code of the response is 200
+#       And The body of the response has the following schema
+#           """
+#           {
+#             "required": [
+#               "upgrade_recommended",
+#               "upgrade_risks_predictors"
+#             ],
+#             "type": "object",
+#             "properties": {
+#               "upgrade_recommended": {
+#                 "title": "Upgrade Recommended",
+#                 "type": "boolean"
+#               },
+#               "upgrade_risks_predictors": {
+#                 "title": "Upgrade Risks Predictors",
+#                 "type": "array",
+#                 "items": {
+#                   "type": "string"
+#                 }
+#               }
+#             }
+#           }
+#           """
+#       And The body of the response is the following
+#           """
+#           {
+#             "upgrade_recommended": true,
+#             "upgrade_risks_predictors": []
+#           }
+#           """

--- a/features/ccx-upgrades-inference/perform_inference.feature
+++ b/features/ccx-upgrades-inference/perform_inference.feature
@@ -1,16 +1,16 @@
 Feature: Upgrade Risks Prediction inference - test well known values
 
-  Scenario: Empty body is used
+  Scenario: Check Inference Service response with no body is sent in the request
     Given The CCX Inference Service is running
      When I request the upgrade-risks-prediction endpoint
      Then The status code of the response is 422
 
-  Scenario: Invalid body is used
+  Scenario: Check Inference Service response with an invalid body is used in the request
     Given The CCX Inference Service is running
      When I request the upgrade-risks-prediction endpoint with junk in the body
      Then The status code of the response is 422
     
-  Scenario: Invalid kind is used
+  Scenario: Check Inference Service response with an valid body with invalid data is used in the request
     Given The CCX Inference Service is running
      When I request the upgrade-risks-prediction endpoint using the following data as risks
           | kind | value     |
@@ -18,7 +18,7 @@ Feature: Upgrade Risks Prediction inference - test well known values
           | junk | some.junk |
      Then The status code of the response is 422
 
-  Scenario: Valid input risks are used
+  Scenario: Check Inference Service response with an valid body with valid data is used in the request
     Given The CCX Inference Service is running
      When I request the upgrade-risks-prediction endpoint using the following data as risks
           | kind  | value       |

--- a/features/ccx-upgrades-inference/smoketests.feature
+++ b/features/ccx-upgrades-inference/smoketests.feature
@@ -1,0 +1,12 @@
+Feature: Basic set of smoke tests - checks if all required tools are available and all services are running.
+
+
+  Scenario: Check if CCX Upgrade Risk Inference Service application is available
+    Given the system is in default state
+     When I look for executable file uvicorn
+     Then I should find that file on PATH
+
+  Scenario: Check if CCX Upgrade Risk Inference Service can be run
+    Given The CCX Inference Service is running
+     When I request the openapi.json endpoint
+     Then The status code of the response is 200

--- a/features/steps/ccx_inference_service.py
+++ b/features/steps/ccx_inference_service.py
@@ -86,7 +86,7 @@ def check_response_body_schema(context):
     """Check that response body is compliant with a given schema."""
 
     schema = json.loads(context.text)
-    body = json.loads(context.response.text)
+    body = context.response.json()
 
     try:
         jsonschema.validate(
@@ -99,3 +99,12 @@ def check_response_body_schema(context):
 
     except jsonschema.SchemaError:
         assert False, "The provided schema is faulty"
+
+
+@then("The body of the response is the following")
+def check_prediction_result(context):
+    """Check the content of the response to be exactly the same."""
+
+    expected_body = json.loads(context.text)
+    result = context.response.json()
+    assert result == expected_body

--- a/features/steps/ccx_inference_service.py
+++ b/features/steps/ccx_inference_service.py
@@ -68,7 +68,7 @@ def request_endpoint_with_formatted_body(context, endpoint, key):
         kind = row["kind"]
         value = row["value"]
         values.append(f"{kind}|{value}")
-    
+
     data = {key: values}
     context.response = requests.get(
         f"http://localhost:8000/{endpoint}",
@@ -79,6 +79,7 @@ def request_endpoint_with_formatted_body(context, endpoint, key):
 @then("The status code of the response is {status}")
 def check_status_code(context, status):
     assert context.response.status_code == int(status)
+
 
 @then("The body of the response has the following schema")
 def check_response_body_schema(context):
@@ -92,9 +93,9 @@ def check_response_body_schema(context):
             instance=body,
             schema=schema,
         )
-    
+
     except jsonschema.ValidationError:
         assert False, "The response body doesn't fit the expected schema"
-    
+
     except jsonschema.SchemaError:
         assert False, "The provided schema is faulty"

--- a/features/steps/ccx_inference_service.py
+++ b/features/steps/ccx_inference_service.py
@@ -1,0 +1,100 @@
+# Copyright © 2023, José Luis Segura Lucas, Red Hat, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Implementation of test steps that run CCX Upgrade Risk Inference Service."""
+
+import json
+import os
+import socket
+import subprocess
+import time
+
+import requests
+import jsonschema
+
+
+@given("The CCX Inference Service is running")
+def start_ccx_inference_service(context):
+    """Run ccx-inference-service for a test and prepare its stop."""
+    params = ["uvicorn", "ccx_upgrades_inference.main:app"]
+    env = os.environ.copy()
+
+    popen = subprocess.Popen(
+        params, stdout=subprocess.PIPE, stderr=subprocess.STDOUT, env=env
+    )
+    assert popen is not None
+    time.sleep(0.5)
+    context.add_cleanup(popen.terminate)
+
+
+@when("I request the {endpoint} endpoint")
+def request_endpoint(context, endpoint):
+    """Perform a request to the local server to the given endpoint."""
+    context.response = requests.get(f"http://localhost:8000/{endpoint}")
+
+
+@when("I request the {endpoint} endpoint with {body} in the body")
+def request_endpoint_with_body(context, endpoint, body):
+    """Perform a request to the local server with a given body in the request."""
+    context.response = requests.get(
+        f"http://localhost:8000/{endpoint}",
+        data=body,
+    )
+
+
+@when("I request the {endpoint} endpoint using the following data as {key}")
+def request_endpoint_with_formatted_body(context, endpoint, key):
+    """Perform a request to the local server with a given set of data.
+
+    This method expects a table with the columns "kind" and "value".
+    Each row of the table will be converted into an element on an array
+    in the request body.
+    """
+
+    values = list()
+
+    for row in context.table:
+        kind = row["kind"]
+        value = row["value"]
+        values.append(f"{kind}|{value}")
+    
+    data = {key: values}
+    context.response = requests.get(
+        f"http://localhost:8000/{endpoint}",
+        data=json.dumps(data),
+    )
+
+
+@then("The status code of the response is {status}")
+def check_status_code(context, status):
+    assert context.response.status_code == int(status)
+
+@then("The body of the response has the following schema")
+def check_response_body_schema(context):
+    """Check that response body is compliant with a given schema."""
+
+    schema = json.loads(context.text)
+    body = json.loads(context.response.text)
+
+    try:
+        jsonschema.validate(
+            instance=body,
+            schema=schema,
+        )
+    
+    except jsonschema.ValidationError:
+        assert False, "The response body doesn't fit the expected schema"
+    
+    except jsonschema.SchemaError:
+        assert False, "The provided schema is faulty"

--- a/requirements/upgrades_inference_service.txt
+++ b/requirements/upgrades_inference_service.txt
@@ -1,0 +1,6 @@
+behave
+pytest
+requests
+psycopg2
+minio
+jsonschema

--- a/test_list/upgrades_inference_service.txt
+++ b/test_list/upgrades_inference_service.txt
@@ -1,0 +1,2 @@
+../features/ccx-upgrades-inference/smoketests.feature
+../features/ccx-upgrades-inference/perform_inference.feature

--- a/tools/gen_scenario_list.py
+++ b/tools/gen_scenario_list.py
@@ -39,6 +39,7 @@ SUBDIRECTORIES = (
     "insights-results-aggregator-exporter",
     "ccx-notification-service",
     "ccx-notification-writer",
+    "ccx-upgrades-inference",
 )
 
 # page header


### PR DESCRIPTION
# Description

New feature files and step implementations to run BDD tests over the new Upgrade Risk Predicion Inference service.

Fixes #CCXDEV-9841

## Type of change

- New test feature file
- Non-breaking change in test steps implementation
- This change requires a documentation update
- Configuration update

## Testing steps
`./ccx_upgrade_risk_inference_tests.sh`

## Checklist
* [ ] Pylint passes for Python sources
* [ ] sources has been pre-processed by Black
* [ ] updated documentation wherever necessary
