### PR TITLE
Add missing Advisor features (risk of change, category), fix existing issues in Advisor features

### DIFF
--- a/features/Insights_Advisor/affected_clusters_filtering.feature
+++ b/features/Insights_Advisor/affected_clusters_filtering.feature
@@ -31,13 +31,25 @@ Feature: Filtering on Advisor affected clusters page behaviour on Hybrid Cloud C
      When user looks at Hybrid Cloud Console main page
      Then menu on the left side should be displayed
       And the left menu might contain these top level items
+          | Left menu item                | Required for this test |
+          | Application and Data Services | no                     |
+          | OpenShift                     | yes                    |
+          | Red Hat Enterprise Linux      | no                     |
+          | Ansible Automation Platform   | no                     |
+     When user selects "OpenShift" from the left side menu
+     Then menu on the left side should be changed
+      And the left menu might contain these top level items
           | Left menu item           | Required for this test |
+          | Clusters                 | no                     |
           | Overview                 | no                     |
           | Releases                 | no                     |
+          | Developer Sandbox        | no                     |
           | Downloads                | no                     |
           | Advisor                  | yes                    |
+          | Vulnerability            | no                     |
           | Subscriptions            | no                     |
           | Cost Management          | no                     |
+          | Support Cases            | no                     |
           | Cluster Manager Feedback | no                     |
           | Red Hat Marketplace      | no                     |
           | Documentation            | no                     |
@@ -109,13 +121,25 @@ Feature: Filtering on Advisor affected clusters page behaviour on Hybrid Cloud C
      When user looks at Hybrid Cloud Console main page
      Then menu on the left side should be displayed
       And the left menu might contain these top level items
+          | Left menu item                | Required for this test |
+          | Application and Data Services | no                     |
+          | OpenShift                     | yes                    |
+          | Red Hat Enterprise Linux      | no                     |
+          | Ansible Automation Platform   | no                     |
+     When user selects "OpenShift" from the left side menu
+     Then menu on the left side should be changed
+      And the left menu might contain these top level items
           | Left menu item           | Required for this test |
+          | Clusters                 | no                     |
           | Overview                 | no                     |
           | Releases                 | no                     |
+          | Developer Sandbox        | no                     |
           | Downloads                | no                     |
           | Advisor                  | yes                    |
+          | Vulnerability            | no                     |
           | Subscriptions            | no                     |
           | Cost Management          | no                     |
+          | Support Cases            | no                     |
           | Cluster Manager Feedback | no                     |
           | Red Hat Marketplace      | no                     |
           | Documentation            | no                     |
@@ -215,13 +239,25 @@ Feature: Filtering on Advisor affected clusters page behaviour on Hybrid Cloud C
      When user looks at Hybrid Cloud Console main page
      Then menu on the left side should be displayed
       And the left menu might contain these top level items
+          | Left menu item                | Required for this test |
+          | Application and Data Services | no                     |
+          | OpenShift                     | yes                    |
+          | Red Hat Enterprise Linux      | no                     |
+          | Ansible Automation Platform   | no                     |
+     When user selects "OpenShift" from the left side menu
+     Then menu on the left side should be changed
+      And the left menu might contain these top level items
           | Left menu item           | Required for this test |
+          | Clusters                 | no                     |
           | Overview                 | no                     |
           | Releases                 | no                     |
+          | Developer Sandbox        | no                     |
           | Downloads                | no                     |
           | Advisor                  | yes                    |
+          | Vulnerability            | no                     |
           | Subscriptions            | no                     |
           | Cost Management          | no                     |
+          | Support Cases            | no                     |
           | Cluster Manager Feedback | no                     |
           | Red Hat Marketplace      | no                     |
           | Documentation            | no                     |
@@ -327,13 +363,25 @@ Feature: Filtering on Advisor affected clusters page behaviour on Hybrid Cloud C
      When user looks at Hybrid Cloud Console main page
      Then menu on the left side should be displayed
       And the left menu might contain these top level items
+          | Left menu item                | Required for this test |
+          | Application and Data Services | no                     |
+          | OpenShift                     | yes                    |
+          | Red Hat Enterprise Linux      | no                     |
+          | Ansible Automation Platform   | no                     |
+     When user selects "OpenShift" from the left side menu
+     Then menu on the left side should be changed
+      And the left menu might contain these top level items
           | Left menu item           | Required for this test |
+          | Clusters                 | no                     |
           | Overview                 | no                     |
           | Releases                 | no                     |
+          | Developer Sandbox        | no                     |
           | Downloads                | no                     |
           | Advisor                  | yes                    |
+          | Vulnerability            | no                     |
           | Subscriptions            | no                     |
           | Cost Management          | no                     |
+          | Support Cases            | no                     |
           | Cluster Manager Feedback | no                     |
           | Red Hat Marketplace      | no                     |
           | Documentation            | no                     |

--- a/features/Insights_Advisor/affected_clusters_filtering.feature
+++ b/features/Insights_Advisor/affected_clusters_filtering.feature
@@ -18,15 +18,15 @@ Feature: Filtering on Advisor affected clusters page behaviour on Hybrid Cloud C
           | 00000000-0000-0000-0000-fff000000000 |
           | 00000000-0000-0000-0000-ffff00000000 |
       And 1 issue is detected for following clusters
-          | Title    | Modified    | Total risk | Cluster name                         |
-          | Bug12345 | 10 days ago | Critical   | 00000000-0000-0000-aaaa-000000000000 |
-          | Bug12345 | 10 days ago | Critical   | 11111111-0000-0000-aaaa-000000000000 |
-          | Bug12345 | 10 days ago | Critical   | 22222222-0000-0000-aaaa-000000000000 |
-          | Bug12345 | 10 days ago | Critical   | 33333333-0000-0000-aaaa-000000000000 |
-          | Bug12345 | 10 days ago | Critical   | 00000000-0000-0000-bbbb-000000000000 |
-          | Bug12345 | 10 days ago | Critical   | 11111111-0000-0000-bbbb-000000000000 |
-          | Bug12345 | 10 days ago | Critical   | 22222222-0000-0000-bbbb-000000000000 |
-          | Bug12345 | 10 days ago | Critical   | 33333333-0000-0000-bbbb-000000000000 |
+          | Title    | Modified    | Category | Total risk | Risk of change | Cluster name                         |
+          | Bug12345 | 10 days ago | Security | Critical   | Moderate       | 00000000-0000-0000-aaaa-000000000000 |
+          | Bug12345 | 10 days ago | Security | Critical   | Moderate       | 11111111-0000-0000-aaaa-000000000000 |
+          | Bug12345 | 10 days ago | Security | Critical   | Moderate       | 22222222-0000-0000-aaaa-000000000000 |
+          | Bug12345 | 10 days ago | Security | Critical   | Moderate       | 33333333-0000-0000-aaaa-000000000000 |
+          | Bug12345 | 10 days ago | Security | Critical   | Moderate       | 00000000-0000-0000-bbbb-000000000000 |
+          | Bug12345 | 10 days ago | Security | Critical   | Moderate       | 11111111-0000-0000-bbbb-000000000000 |
+          | Bug12345 | 10 days ago | Security | Critical   | Moderate       | 22222222-0000-0000-bbbb-000000000000 |
+          | Bug12345 | 10 days ago | Security | Critical   | Moderate       | 33333333-0000-0000-bbbb-000000000000 |
       And the user USER1 is already logged in into Hybrid Cloud Console
      When user looks at Hybrid Cloud Console main page
      Then menu on the left side should be displayed
@@ -49,18 +49,19 @@ Feature: Filtering on Advisor affected clusters page behaviour on Hybrid Cloud C
           | Recommendations     | yes                    |
      When user select "Recommendations" menu item from this sub-menu
      Then an "Advisor recommendations" page should be displayed right of the left menu bar
-      And that table should contain following four rows in that order
-          | Name        | Modified    | Total risk | Clusters |
-          | Bug12345    | 10 days ago | Critical   | 8        |
+      And that table should contain following six rows in that order
+          | Name        | Modified    | Category | Total risk | Risk of change | Clusters |
+          | Bug12345    | 10 days ago | Security | Critical   | Moderate       | 8        |
      When user clicks on an "Bug12345" link
      Then new page with additional information about selected recommendation should be displayed
       And the following values needs to be displayed
-          | Value type  | Content             | Displayed as              | Optional |
-          | Description | Textual description | Text                      | no       |
-          | KB article  | Link to KB article  | Link                      | yes      |
-          | Total risk  | Important           | Widget (icon+label)       | no       |
-          | Likelihood  | High                | Widget (thermometer-like) | no       |
-          | Impact      | High                | Widget (thermometer-like) | no       |
+          | Value type     | Content             | Displayed as              | Optional |
+          | Description    | Textual description | Text                      | no       |
+          | KB article     | Link to KB article  | Link                      | yes      |
+          | Total risk     | Important           | Widget (icon+label)       | no       |
+          | Likelihood     | High                | Widget (thermometer-like) | no       |
+          | Impact         | High                | Widget (thermometer-like) | no       |
+          | Risk of change | Moderate            | Widget (icon+label)       | no       |
       And "Affected clusters" table needs to be displayed below additional info
           | Name                                 | Clickable (link) |
           | 00000000-0000-0000-aaaa-000000000000 | yes              |
@@ -95,15 +96,15 @@ Feature: Filtering on Advisor affected clusters page behaviour on Hybrid Cloud C
           | 00000000-0000-0000-0000-fff000000000 |
           | 00000000-0000-0000-0000-ffff00000000 |
       And 1 issue is detected for following clusters
-          | Title    | Modified    | Total risk | Cluster name                         |
-          | Bug12345 | 10 days ago | Critical   | 00000000-0000-0000-aaaa-000000000000 |
-          | Bug12345 | 10 days ago | Critical   | 11111111-0000-0000-aaaa-000000000000 |
-          | Bug12345 | 10 days ago | Critical   | 22222222-0000-0000-aaaa-000000000000 |
-          | Bug12345 | 10 days ago | Critical   | 33333333-0000-0000-aaaa-000000000000 |
-          | Bug12345 | 10 days ago | Critical   | 00000000-0000-0000-bbbb-000000000000 |
-          | Bug12345 | 10 days ago | Critical   | 11111111-0000-0000-bbbb-000000000000 |
-          | Bug12345 | 10 days ago | Critical   | 22222222-0000-0000-bbbb-000000000000 |
-          | Bug12345 | 10 days ago | Critical   | 33333333-0000-0000-bbbb-000000000000 |
+          | Title    | Modified    | Category | Total risk | Risk of change | Cluster name                         |
+          | Bug12345 | 10 days ago | Security | Critical   | Moderate       | 00000000-0000-0000-aaaa-000000000000 |
+          | Bug12345 | 10 days ago | Security | Critical   | Moderate       | 11111111-0000-0000-aaaa-000000000000 |
+          | Bug12345 | 10 days ago | Security | Critical   | Moderate       | 22222222-0000-0000-aaaa-000000000000 |
+          | Bug12345 | 10 days ago | Security | Critical   | Moderate       | 33333333-0000-0000-aaaa-000000000000 |
+          | Bug12345 | 10 days ago | Security | Critical   | Moderate       | 00000000-0000-0000-bbbb-000000000000 |
+          | Bug12345 | 10 days ago | Security | Critical   | Moderate       | 11111111-0000-0000-bbbb-000000000000 |
+          | Bug12345 | 10 days ago | Security | Critical   | Moderate       | 22222222-0000-0000-bbbb-000000000000 |
+          | Bug12345 | 10 days ago | Security | Critical   | Moderate       | 33333333-0000-0000-bbbb-000000000000 |
       And the user USER1 is already logged in into Hybrid Cloud Console
      When user looks at Hybrid Cloud Console main page
      Then menu on the left side should be displayed
@@ -126,18 +127,19 @@ Feature: Filtering on Advisor affected clusters page behaviour on Hybrid Cloud C
           | Recommendations     | yes                    |
      When user select "Recommendations" menu item from this sub-menu
      Then an "Advisor recommendations" page should be displayed right of the left menu bar
-      And that table should contain following four rows in that order
-          | Name        | Modified    | Total risk | Clusters |
-          | Bug12345    | 10 days ago | Critical   | 8        |
+      And that table should contain following six rows in that order
+          | Name        | Modified    | Category | Total risk | Risk of change | Clusters |
+          | Bug12345    | 10 days ago | Security | Critical   | Moderate       | 8        |
      When user clicks on an "Bug12345" link
      Then new page with additional information about selected recommendation should be displayed
       And the following values needs to be displayed
-          | Value type  | Content             | Displayed as              | Optional |
-          | Description | Textual description | Text                      | no       |
-          | KB article  | Link to KB article  | Link                      | yes      |
-          | Total risk  | Important           | Widget (icon+label)       | no       |
-          | Likelihood  | High                | Widget (thermometer-like) | no       |
-          | Impact      | High                | Widget (thermometer-like) | no       |
+          | Value type     | Content             | Displayed as              | Optional |
+          | Description    | Textual description | Text                      | no       |
+          | KB article     | Link to KB article  | Link                      | yes      |
+          | Total risk     | Important           | Widget (icon+label)       | no       |
+          | Likelihood     | High                | Widget (thermometer-like) | no       |
+          | Impact         | High                | Widget (thermometer-like) | no       |
+          | Risk of change | Moderate            | Widget (icon+label)       | no       |
       And "Affected clusters" table needs to be displayed below additional info
           | Name                                 | Clickable (link) |
           | 00000000-0000-0000-aaaa-000000000000 | yes              |
@@ -200,15 +202,15 @@ Feature: Filtering on Advisor affected clusters page behaviour on Hybrid Cloud C
           | 00000000-0000-0000-0000-fff000000000 |
           | 00000000-0000-0000-0000-ffff00000000 |
       And 1 issue is detected for following clusters
-          | Title    | Modified    | Total risk | Cluster name                         |
-          | Bug12345 | 10 days ago | Critical   | 00000000-0000-0000-aaaa-000000000000 |
-          | Bug12345 | 10 days ago | Critical   | 11111111-0000-0000-aaaa-000000000000 |
-          | Bug12345 | 10 days ago | Critical   | 22222222-0000-0000-aaaa-000000000000 |
-          | Bug12345 | 10 days ago | Critical   | 33333333-0000-0000-aaaa-000000000000 |
-          | Bug12345 | 10 days ago | Critical   | 00000000-0000-0000-bbbb-000000000000 |
-          | Bug12345 | 10 days ago | Critical   | 11111111-0000-0000-bbbb-000000000000 |
-          | Bug12345 | 10 days ago | Critical   | 22222222-0000-0000-bbbb-000000000000 |
-          | Bug12345 | 10 days ago | Critical   | 33333333-0000-0000-bbbb-000000000000 |
+          | Title    | Modified    | Category | Total risk | Risk of change | Cluster name                         |
+          | Bug12345 | 10 days ago | Security | Critical   | Moderate       | 00000000-0000-0000-aaaa-000000000000 |
+          | Bug12345 | 10 days ago | Security | Critical   | Moderate       | 11111111-0000-0000-aaaa-000000000000 |
+          | Bug12345 | 10 days ago | Security | Critical   | Moderate       | 22222222-0000-0000-aaaa-000000000000 |
+          | Bug12345 | 10 days ago | Security | Critical   | Moderate       | 33333333-0000-0000-aaaa-000000000000 |
+          | Bug12345 | 10 days ago | Security | Critical   | Moderate       | 00000000-0000-0000-bbbb-000000000000 |
+          | Bug12345 | 10 days ago | Security | Critical   | Moderate       | 11111111-0000-0000-bbbb-000000000000 |
+          | Bug12345 | 10 days ago | Security | Critical   | Moderate       | 22222222-0000-0000-bbbb-000000000000 |
+          | Bug12345 | 10 days ago | Security | Critical   | Moderate       | 33333333-0000-0000-bbbb-000000000000 |
       And the user USER1 is already logged in into Hybrid Cloud Console
      When user looks at Hybrid Cloud Console main page
      Then menu on the left side should be displayed
@@ -231,18 +233,19 @@ Feature: Filtering on Advisor affected clusters page behaviour on Hybrid Cloud C
           | Recommendations     | yes                    |
      When user select "Recommendations" menu item from this sub-menu
      Then an "Advisor recommendations" page should be displayed right of the left menu bar
-      And that table should contain following four rows in that order
-          | Name        | Modified    | Total risk | Clusters |
-          | Bug12345    | 10 days ago | Critical   | 8        |
+      And that table should contain following six rows in that order
+          | Name        | Modified    | Category | Total risk | Risk of change | Clusters |
+          | Bug12345    | 10 days ago | Security | Critical   | Moderate       | 8        |
      When user clicks on an "Bug12345" link
      Then new page with additional information about selected recommendation should be displayed
       And the following values needs to be displayed
-          | Value type  | Content             | Displayed as              | Optional |
-          | Description | Textual description | Text                      | no       |
-          | KB article  | Link to KB article  | Link                      | yes      |
-          | Total risk  | Important           | Widget (icon+label)       | no       |
-          | Likelihood  | High                | Widget (thermometer-like) | no       |
-          | Impact      | High                | Widget (thermometer-like) | no       |
+          | Value type     | Content             | Displayed as              | Optional |
+          | Description    | Textual description | Text                      | no       |
+          | KB article     | Link to KB article  | Link                      | yes      |
+          | Total risk     | Important           | Widget (icon+label)       | no       |
+          | Likelihood     | High                | Widget (thermometer-like) | no       |
+          | Impact         | High                | Widget (thermometer-like) | no       |
+          | Risk of change | Moderate            | Widget (icon+label)       | no       |
       And "Affected clusters" table needs to be displayed below additional info
           | Name                                 | Clickable (link) |
           | 00000000-0000-0000-aaaa-000000000000 | yes              |
@@ -311,15 +314,15 @@ Feature: Filtering on Advisor affected clusters page behaviour on Hybrid Cloud C
           | 00000000-0000-0000-0000-fff000000000 |
           | 00000000-0000-0000-0000-ffff00000000 |
       And 1 issue is detected for following clusters
-          | Title    | Modified    | Total risk | Cluster name                         |
-          | Bug12345 | 10 days ago | Critical   | 00000000-0000-0000-aaaa-000000000000 |
-          | Bug12345 | 10 days ago | Critical   | 11111111-0000-0000-aaaa-000000000000 |
-          | Bug12345 | 10 days ago | Critical   | 22222222-0000-0000-aaaa-000000000000 |
-          | Bug12345 | 10 days ago | Critical   | 33333333-0000-0000-aaaa-000000000000 |
-          | Bug12345 | 10 days ago | Critical   | 00000000-0000-0000-bbbb-000000000000 |
-          | Bug12345 | 10 days ago | Critical   | 11111111-0000-0000-bbbb-000000000000 |
-          | Bug12345 | 10 days ago | Critical   | 22222222-0000-0000-bbbb-000000000000 |
-          | Bug12345 | 10 days ago | Critical   | 33333333-0000-0000-bbbb-000000000000 |
+          | Title    | Modified    | Category | Total risk | Risk of change | Cluster name                         |
+          | Bug12345 | 10 days ago | Security | Critical   | Moderate       | 00000000-0000-0000-aaaa-000000000000 |
+          | Bug12345 | 10 days ago | Security | Critical   | Moderate       | 11111111-0000-0000-aaaa-000000000000 |
+          | Bug12345 | 10 days ago | Security | Critical   | Moderate       | 22222222-0000-0000-aaaa-000000000000 |
+          | Bug12345 | 10 days ago | Security | Critical   | Moderate       | 33333333-0000-0000-aaaa-000000000000 |
+          | Bug12345 | 10 days ago | Security | Critical   | Moderate       | 00000000-0000-0000-bbbb-000000000000 |
+          | Bug12345 | 10 days ago | Security | Critical   | Moderate       | 11111111-0000-0000-bbbb-000000000000 |
+          | Bug12345 | 10 days ago | Security | Critical   | Moderate       | 22222222-0000-0000-bbbb-000000000000 |
+          | Bug12345 | 10 days ago | Security | Critical   | Moderate       | 33333333-0000-0000-bbbb-000000000000 |
       And the user USER1 is already logged in into Hybrid Cloud Console
      When user looks at Hybrid Cloud Console main page
      Then menu on the left side should be displayed
@@ -342,18 +345,19 @@ Feature: Filtering on Advisor affected clusters page behaviour on Hybrid Cloud C
           | Recommendations     | yes                    |
      When user select "Recommendations" menu item from this sub-menu
      Then an "Advisor recommendations" page should be displayed right of the left menu bar
-      And that table should contain following four rows in that order
-          | Name        | Modified    | Total risk | Clusters |
-          | Bug12345    | 10 days ago | Critical   | 8        |
+      And that table should contain following six rows in that order
+          | Name        | Modified    | Category | Total risk | Risk of change | Clusters |
+          | Bug12345    | 10 days ago | Security | Critical   | Moderate       | 8        |
      When user clicks on an "Bug12345" link
      Then new page with additional information about selected recommendation should be displayed
       And the following values needs to be displayed
-          | Value type  | Content             | Displayed as              | Optional |
-          | Description | Textual description | Text                      | no       |
-          | KB article  | Link to KB article  | Link                      | yes      |
-          | Total risk  | Important           | Widget (icon+label)       | no       |
-          | Likelihood  | High                | Widget (thermometer-like) | no       |
-          | Impact      | High                | Widget (thermometer-like) | no       |
+          | Value type     | Content             | Displayed as              | Optional |
+          | Description    | Textual description | Text                      | no       |
+          | KB article     | Link to KB article  | Link                      | yes      |
+          | Total risk     | Important           | Widget (icon+label)       | no       |
+          | Likelihood     | High                | Widget (thermometer-like) | no       |
+          | Impact         | High                | Widget (thermometer-like) | no       |
+          | Risk of change | Moderate            | Widget (icon+label)       | no       |
       And "Affected clusters" table needs to be displayed below additional info
           | Name                                 | Clickable (link) |
           | 00000000-0000-0000-aaaa-000000000000 | yes              |

--- a/features/Insights_Advisor/affected_clusters_page.feature
+++ b/features/Insights_Advisor/affected_clusters_page.feature
@@ -134,7 +134,7 @@ Feature: Cluster view page with recommendations behaviour on Hybrid Cloud Consol
 
   Scenario: Pagination on "Affected clusters" page on Hybrid Cloud Console with more than 10 clusters
     Given user USER1 is part of account (organization) ACCOUNT1
-      And account (organization) ACCOUNT1 owns 2 clusters
+      And account (organization) ACCOUNT1 owns 12 clusters
           | Cluster name                         |
           | 00000000-0000-0000-0000-000000000000 |
           | 11111111-0000-0000-0000-000000000000 |

--- a/features/Insights_Advisor/affected_clusters_page.feature
+++ b/features/Insights_Advisor/affected_clusters_page.feature
@@ -42,13 +42,13 @@ Feature: Cluster view page with recommendations behaviour on Hybrid Cloud Consol
           | Clusters       |
       And that table should contain at least one row
           | Column name    | Value       |
-          | Name           | Bug1234     |
+          | Name           | Bug12345     |
           | Modified       | 10 days ago |
           | Category       | Security    |
           | Total risk     | Important   |
           | Risk of change | Moderate    |
           | Clusters       | 1           |
-     When user clicks on an "Bug1234" link
+     When user clicks on an "Bug12345" link
      Then new page with additional information about selected recommendation should be displayed
       And the following values needs to be displayed
           | Value type     | Content             | Displayed as              | Optional |
@@ -109,13 +109,13 @@ Feature: Cluster view page with recommendations behaviour on Hybrid Cloud Consol
           | Clusters       |
       And that table should contain at least one row
           | Column name    | Value       |
-          | Name           | Bug1234     |
+          | Name           | Bug12345     |
           | Modified       | 10 days ago |
           | Category       | Security    |
           | Total risk     | Important   |
           | Risk of change | Moderate    |
           | Clusters       | 1           |
-     When user clicks on an "Bug1234" link
+     When user clicks on an "Bug12345" link
      Then new page with additional information about selected recommendation should be displayed
       And the following values needs to be displayed
           | Value type     | Content             | Displayed as              | Optional |
@@ -182,13 +182,13 @@ Feature: Cluster view page with recommendations behaviour on Hybrid Cloud Consol
           | Clusters       |
       And that table should contain at least one row
           | Column name    | Value       |
-          | Name           | Bug1234     |
+          | Name           | Bug12345     |
           | Modified       | 10 days ago |
           | Category       | Security    |
           | Total risk     | Important   |
           | Risk of change | Moderate    |
           | Clusters       | 1           |
-     When user clicks on an "Bug1234" link
+     When user clicks on an "Bug12345" link
      Then new page with additional information about selected recommendation should be displayed
       And the following values needs to be displayed
           | Value type     | Content             | Displayed as              | Optional |

--- a/features/Insights_Advisor/affected_clusters_page.feature
+++ b/features/Insights_Advisor/affected_clusters_page.feature
@@ -7,8 +7,8 @@ Feature: Cluster view page with recommendations behaviour on Hybrid Cloud Consol
           | Cluster name                         |
           | 00000000-0000-0000-0000-000000000000 |
       And 1 issue is detected for cluster 00000000-0000-0000-0000-000000000000
-          | Title    | Modified    | Total risk | Likelihood | Impact |
-          | Bug12345 | 10 days ago | Important  | high       | high   |
+          | Title    | Modified    | Category | Total risk | Likelihood | Impact | Risk of change |
+          | Bug12345 | 10 days ago | Security | Important  | high       | high   | Moderate       |
       And the user USER1 is already logged in into Hybrid Cloud Console
      When user looks at Hybrid Cloud Console main page
      Then menu on the left side should be displayed
@@ -33,26 +33,31 @@ Feature: Cluster view page with recommendations behaviour on Hybrid Cloud Consol
      Then an "Advisor recommendations" page should be displayed right of the left menu bar
       And widget with filter settings should be displayed
       And table with several columns should be displayed
-          | Column name |
-          | Name        |
-          | Modified    |
-          | Total risk  |
-          | Clusters    |
+          | Column name    |
+          | Name           |
+          | Modified       |
+          | Category       |
+          | Total risk     |
+          | Risk of change |
+          | Clusters       |
       And that table should contain at least one row
-          | Column name | Value       |
-          | Name        | Bug1234     |
-          | Modified    | 10 days ago |
-          | Total risk  | Important   |
-          | Clusters    | 1           |
+          | Column name    | Value       |
+          | Name           | Bug1234     |
+          | Modified       | 10 days ago |
+          | Category       | Security    |
+          | Total risk     | Important   |
+          | Risk of change | Moderate    |
+          | Clusters       | 1           |
      When user clicks on an "Bug1234" link
      Then new page with additional information about selected recommendation should be displayed
       And the following values needs to be displayed
-          | Value type  | Content             | Displayed as              | Optional |
-          | Description | Textual description | Text                      | no       |
-          | KB article  | Link to KB article  | Link                      | yes      |
-          | Total risk  | Important           | Widget (icon+label)       | no       |
-          | Likelihood  | High                | Widget (thermometer-like) | no       |
-          | Impact      | High                | Widget (thermometer-like) | no       |
+          | Value type     | Content             | Displayed as              | Optional |
+          | Description    | Textual description | Text                      | no       |
+          | KB article     | Link to KB article  | Link                      | yes      |
+          | Total risk     | Important           | Widget (icon+label)       | no       |
+          | Likelihood     | High                | Widget (thermometer-like) | no       |
+          | Impact         | High                | Widget (thermometer-like) | no       |
+          | Risk of change | Moderate            | Widget (icon+label)       | no       |
       And "Affected clusters" table needs to be displayed below additional info
           | Name                                 | Clickable (link) |
           | 00000000-0000-0000-0000-000000000000 | yes              |
@@ -66,11 +71,11 @@ Feature: Cluster view page with recommendations behaviour on Hybrid Cloud Consol
           | 00000000-0000-0000-0000-000000000000 |
           | 11111111-0000-0000-0000-000000000000 |
       And 1 issue is detected for cluster 00000000-0000-0000-0000-000000000000
-          | Title    | Modified    | Total risk | Likelihood | Impact |
-          | Bug12345 | 10 days ago | Important  | high       | high   |
+          | Title    | Modified    | Category | Total risk | Likelihood | Impact | Risk of change |
+          | Bug12345 | 10 days ago | Security | Important  | high       | high   | Moderate       |
       And 1 issue is detected for cluster 11111111-0000-0000-0000-000000000000
-          | Title    | Modified    | Total risk | Likelihood | Impact |
-          | Bug12345 | 10 days ago | Important  | high       | high   |
+          | Title    | Modified    | Category | Total risk | Likelihood | Impact | Risk of change |
+          | Bug12345 | 10 days ago | Security | Important  | high       | high   | Moderate       |
       And the user USER1 is already logged in into Hybrid Cloud Console
      When user looks at Hybrid Cloud Console main page
      Then menu on the left side should be displayed
@@ -95,26 +100,31 @@ Feature: Cluster view page with recommendations behaviour on Hybrid Cloud Consol
      Then an "Advisor recommendations" page should be displayed right of the left menu bar
       And widget with filter settings should be displayed
       And table with several columns should be displayed
-          | Column name |
-          | Name        |
-          | Modified    |
-          | Total risk  |
-          | Clusters    |
+          | Column name    |
+          | Name           |
+          | Modified       |
+          | Category       |
+          | Total risk     |
+          | Risk of change |
+          | Clusters       |
       And that table should contain at least one row
-          | Column name | Value       |
-          | Name        | Bug1234     |
-          | Modified    | 10 days ago |
-          | Total risk  | Important   |
-          | Clusters    | 2           |
+          | Column name    | Value       |
+          | Name           | Bug1234     |
+          | Modified       | 10 days ago |
+          | Category       | Security    |
+          | Total risk     | Important   |
+          | Risk of change | Moderate    |
+          | Clusters       | 1           |
      When user clicks on an "Bug1234" link
      Then new page with additional information about selected recommendation should be displayed
       And the following values needs to be displayed
-          | Value type  | Content             | Displayed as              | Optional |
-          | Description | Textual description | Text                      | no       |
-          | KB article  | Link to KB article  | Link                      | yes      |
-          | Total risk  | Important           | Widget (icon+label)       | no       |
-          | Likelihood  | High                | Widget (thermometer-like) | no       |
-          | Impact      | High                | Widget (thermometer-like) | no       |
+          | Value type     | Content             | Displayed as              | Optional |
+          | Description    | Textual description | Text                      | no       |
+          | KB article     | Link to KB article  | Link                      | yes      |
+          | Total risk     | Important           | Widget (icon+label)       | no       |
+          | Likelihood     | High                | Widget (thermometer-like) | no       |
+          | Impact         | High                | Widget (thermometer-like) | no       |
+          | Risk of change | Moderate            | Widget (icon+label)       | no       |
       And "Affected clusters" table needs to be displayed below additional info
           | Name                                 | Clickable (link) |
           | 00000000-0000-0000-0000-000000000000 | yes              |
@@ -163,26 +173,31 @@ Feature: Cluster view page with recommendations behaviour on Hybrid Cloud Consol
      Then an "Advisor recommendations" page should be displayed right of the left menu bar
       And widget with filter settings should be displayed
       And table with several columns should be displayed
-          | Column name |
-          | Name        |
-          | Modified    |
-          | Total risk  |
-          | Clusters    |
+          | Column name    |
+          | Name           |
+          | Modified       |
+          | Category       |
+          | Total risk     |
+          | Risk of change |
+          | Clusters       |
       And that table should contain at least one row
-          | Column name | Value       |
-          | Name        | Bug1234     |
-          | Modified    | 10 days ago |
-          | Total risk  | Important   |
-          | Clusters    | 12          |
+          | Column name    | Value       |
+          | Name           | Bug1234     |
+          | Modified       | 10 days ago |
+          | Category       | Security    |
+          | Total risk     | Important   |
+          | Risk of change | Moderate    |
+          | Clusters       | 1           |
      When user clicks on an "Bug1234" link
      Then new page with additional information about selected recommendation should be displayed
       And the following values needs to be displayed
-          | Value type  | Content             | Displayed as              | Optional |
-          | Description | Textual description | Text                      | no       |
-          | KB article  | Link to KB article  | Link                      | yes      |
-          | Total risk  | Important           | Widget (icon+label)       | no       |
-          | Likelihood  | High                | Widget (thermometer-like) | no       |
-          | Impact      | High                | Widget (thermometer-like) | no       |
+          | Value type     | Content             | Displayed as              | Optional |
+          | Description    | Textual description | Text                      | no       |
+          | KB article     | Link to KB article  | Link                      | yes      |
+          | Total risk     | Important           | Widget (icon+label)       | no       |
+          | Likelihood     | High                | Widget (thermometer-like) | no       |
+          | Impact         | High                | Widget (thermometer-like) | no       |
+          | Risk of change | Moderate            | Widget (icon+label)       | no       |
       And "Affected clusters" table needs to be displayed below additional info
           | Name                                 | Clickable (link) |
           | 00000000-0000-0000-0000-000000000000 | yes              |

--- a/features/Insights_Advisor/affected_clusters_page.feature
+++ b/features/Insights_Advisor/affected_clusters_page.feature
@@ -13,13 +13,25 @@ Feature: Cluster view page with recommendations behaviour on Hybrid Cloud Consol
      When user looks at Hybrid Cloud Console main page
      Then menu on the left side should be displayed
       And the left menu might contain these top level items
+          | Left menu item                | Required for this test |
+          | Application and Data Services | no                     |
+          | OpenShift                     | yes                    |
+          | Red Hat Enterprise Linux      | no                     |
+          | Ansible Automation Platform   | no                     |
+     When user selects "OpenShift" from the left side menu
+     Then menu on the left side should be changed
+      And the left menu might contain these top level items
           | Left menu item           | Required for this test |
+          | Clusters                 | no                     |
           | Overview                 | no                     |
           | Releases                 | no                     |
+          | Developer Sandbox        | no                     |
           | Downloads                | no                     |
           | Advisor                  | yes                    |
+          | Vulnerability            | no                     |
           | Subscriptions            | no                     |
           | Cost Management          | no                     |
+          | Support Cases            | no                     |
           | Cluster Manager Feedback | no                     |
           | Red Hat Marketplace      | no                     |
           | Documentation            | no                     |
@@ -80,13 +92,25 @@ Feature: Cluster view page with recommendations behaviour on Hybrid Cloud Consol
      When user looks at Hybrid Cloud Console main page
      Then menu on the left side should be displayed
       And the left menu might contain these top level items
+          | Left menu item                | Required for this test |
+          | Application and Data Services | no                     |
+          | OpenShift                     | yes                    |
+          | Red Hat Enterprise Linux      | no                     |
+          | Ansible Automation Platform   | no                     |
+     When user selects "OpenShift" from the left side menu
+     Then menu on the left side should be changed
+      And the left menu might contain these top level items
           | Left menu item           | Required for this test |
+          | Clusters                 | no                     |
           | Overview                 | no                     |
           | Releases                 | no                     |
+          | Developer Sandbox        | no                     |
           | Downloads                | no                     |
           | Advisor                  | yes                    |
+          | Vulnerability            | no                     |
           | Subscriptions            | no                     |
           | Cost Management          | no                     |
+          | Support Cases            | no                     |
           | Cluster Manager Feedback | no                     |
           | Red Hat Marketplace      | no                     |
           | Documentation            | no                     |
@@ -153,13 +177,25 @@ Feature: Cluster view page with recommendations behaviour on Hybrid Cloud Consol
      When user looks at Hybrid Cloud Console main page
      Then menu on the left side should be displayed
       And the left menu might contain these top level items
+          | Left menu item                | Required for this test |
+          | Application and Data Services | no                     |
+          | OpenShift                     | yes                    |
+          | Red Hat Enterprise Linux      | no                     |
+          | Ansible Automation Platform   | no                     |
+     When user selects "OpenShift" from the left side menu
+     Then menu on the left side should be changed
+      And the left menu might contain these top level items
           | Left menu item           | Required for this test |
+          | Clusters                 | no                     |
           | Overview                 | no                     |
           | Releases                 | no                     |
+          | Developer Sandbox        | no                     |
           | Downloads                | no                     |
           | Advisor                  | yes                    |
+          | Vulnerability            | no                     |
           | Subscriptions            | no                     |
           | Cost Management          | no                     |
+          | Support Cases            | no                     |
           | Cluster Manager Feedback | no                     |
           | Red Hat Marketplace      | no                     |
           | Documentation            | no                     |

--- a/features/Insights_Advisor/affected_clusters_sorting.feature
+++ b/features/Insights_Advisor/affected_clusters_sorting.feature
@@ -10,26 +10,26 @@ Feature: Sorting on Advisor affected clusters page behaviour on Hybrid Cloud Con
           | 22222222-0000-0000-0000-000000000000 |
           | 33333333-0000-0000-0000-000000000000 |
       And 4 issues are detected for cluster 00000000-0000-0000-0000-000000000000
-          | Title    | Modified    | Total risk |
-          | Bug12345 | 10 days ago | Critical   |
-          | Abc12345 | 10 days ago | Important  |
-          | Xyz12345 | 10 days ago | Moderate   |
-          | Uvw12345 | 10 days ago | Low        |
+          | Title    | Modified    | Total risk | Risk of change | Category             |
+          | Bug12345 | 10 days ago | Critical   | High           | Service Availability |
+          | Abc12345 | 10 days ago | Important  | Moderate       | Performance          |
+          | Xyz12345 | 10 days ago | Moderate   | Low            | Fault Tolerance      |
+          | Uvw12345 | 10 days ago | Low        | Very low       | Security             |
       And 3 issues are detected for cluster 11111111-0000-0000-0000-000000000000
-          | Title    | Modified    | Total risk |
-          | Bug12345 | 10 days ago | Critical   |
-          | Abc12345 | 10 days ago | Important  |
-          | Xyz12345 | 10 days ago | Moderate   |
+          | Title    | Modified    | Total risk | Risk of change | Category             |
+          | Bug12345 | 10 days ago | Critical   | High           | Service Availability |
+          | Abc12345 | 10 days ago | Important  | Moderate       | Performance          |
+          | Xyz12345 | 10 days ago | Moderate   | Low            | Fault Tolerance      |
       And 2 issues are detected for cluster 22222222-0000-0000-0000-000000000000
-          | Title    | Modified    | Total risk |
-          | Bug12345 | 10 days ago | Critical   |
-          | Abc12345 | 10 days ago | Important  |
+          | Title    | Modified    | Total risk | Risk of change | Category             |
+          | Bug12345 | 10 days ago | Critical   | High           | Service Availability |
+          | Abc12345 | 10 days ago | Important  | Moderate       | Performance          |
       And 1 issue is detected for cluster 33333333-0000-0000-0000-000000000000
-          | Title    | Modified    | Total risk |
-          | Bug12345 | 10 days ago | Critical   |
+          | Title    | Modified    | Total risk | Risk of change | Category             |
+          | Bug12345 | 10 days ago | Critical   | High           | Service Availability |
       And 1 another issue without cluster hit exists
-          | Title    | Modified    | Total risk |
-          | Nohit    | 10 days ago | Critical   |
+          | Title    | Modified    | Total risk | Risk of change | Category             |
+          | Nohit    | 10 days ago | Critical   | High           | Service Availability |
       And the user USER1 is already logged in into Hybrid Cloud Console
      When user looks at Hybrid Cloud Console main page
      Then menu on the left side should be displayed
@@ -53,20 +53,21 @@ Feature: Sorting on Advisor affected clusters page behaviour on Hybrid Cloud Con
      When user select "Recommendations" menu item from this sub-menu
      Then an "Advisor recommendations" page should be displayed right of the left menu bar
       And that table should contain following four rows in that order
-          | Name        | Modified    | Total risk | Clusters |
-          | Bug12345    | 10 days ago | Critical   | 4        |
-          | Abc12345    | 10 days ago | Important  | 3        |
-          | Xyz12345    | 10 days ago | Moderate   | 2        |
-          | Uvw12345    | 10 days ago | Low        | 1        |
+          | Name        | Modified    | Category             | Total risk | Risk of change | Clusters |
+          | Bug12345    | 10 days ago | Service Availability | Critical   | High           | 4        |
+          | Abc12345    | 10 days ago | Performance          | Important  | Moderate       | 3        |
+          | Xyz12345    | 10 days ago | Fault Tolerance      | Moderate   | Low            | 2        |
+          | Uvw12345    | 10 days ago | Security             | Low        | Very Low       | 1        |
      When user clicks on an "Bug12345" link
      Then new page with additional information about selected recommendation should be displayed
       And the following values needs to be displayed
-          | Value type  | Content             | Displayed as              | Optional |
-          | Description | Textual description | Text                      | no       |
-          | KB article  | Link to KB article  | Link                      | yes      |
-          | Total risk  | Important           | Widget (icon+label)       | no       |
-          | Likelihood  | High                | Widget (thermometer-like) | no       |
-          | Impact      | High                | Widget (thermometer-like) | no       |
+          | Value type     | Content             | Displayed as              | Optional |
+          | Description    | Textual description | Text                      | no       |
+          | KB article     | Link to KB article  | Link                      | yes      |
+          | Total risk     | Important           | Widget (icon+label)       | no       |
+          | Likelihood     | High                | Widget (thermometer-like) | no       |
+          | Impact         | High                | Widget (thermometer-like) | no       |
+          | Risk of change | High                | Widget (icon+label)       | no       |
       And "Affected clusters" table needs to be displayed below additional info
           | Name                                 | Clickable (link) |
           | 33333333-0000-0000-0000-000000000000 | yes              |
@@ -86,26 +87,26 @@ Feature: Sorting on Advisor affected clusters page behaviour on Hybrid Cloud Con
           | 22222222-0000-0000-0000-000000000000 |
           | 33333333-0000-0000-0000-000000000000 |
       And 4 issues are detected for cluster 00000000-0000-0000-0000-000000000000
-          | Title    | Modified    | Total risk |
-          | Bug12345 | 10 days ago | Critical   |
-          | Abc12345 | 10 days ago | Important  |
-          | Xyz12345 | 10 days ago | Moderate   |
-          | Uvw12345 | 10 days ago | Low        |
+          | Title    | Modified    | Total risk | Risk of change | Category             |
+          | Bug12345 | 10 days ago | Critical   | High           | Service Availability |
+          | Abc12345 | 10 days ago | Important  | Moderate       | Performance          |
+          | Xyz12345 | 10 days ago | Moderate   | Low            | Fault Tolerance      |
+          | Uvw12345 | 10 days ago | Low        | Very low       | Security             |
       And 3 issues are detected for cluster 11111111-0000-0000-0000-000000000000
-          | Title    | Modified    | Total risk |
-          | Bug12345 | 10 days ago | Critical   |
-          | Abc12345 | 10 days ago | Important  |
-          | Xyz12345 | 10 days ago | Moderate   |
+          | Title    | Modified    | Total risk | Risk of change | Category             |
+          | Bug12345 | 10 days ago | Critical   | High           | Service Availability |
+          | Abc12345 | 10 days ago | Important  | Moderate       | Performance          |
+          | Xyz12345 | 10 days ago | Moderate   | Low            | Fault Tolerance      |
       And 2 issues are detected for cluster 22222222-0000-0000-0000-000000000000
-          | Title    | Modified    | Total risk |
-          | Bug12345 | 10 days ago | Critical   |
-          | Abc12345 | 10 days ago | Important  |
+          | Title    | Modified    | Total risk | Risk of change | Category             |
+          | Bug12345 | 10 days ago | Critical   | High           | Service Availability |
+          | Abc12345 | 10 days ago | Important  | Moderate       | Performance          |
       And 1 issue is detected for cluster 33333333-0000-0000-0000-000000000000
-          | Title    | Modified    | Total risk |
-          | Bug12345 | 10 days ago | Critical   |
+          | Title    | Modified    | Total risk | Risk of change | Category             |
+          | Bug12345 | 10 days ago | Critical   | High           | Service Availability |
       And 1 another issue without cluster hit exists
-          | Title    | Modified    | Total risk |
-          | Nohit    | 10 days ago | Critical   |
+          | Title    | Modified    | Total risk | Risk of change | Category             |
+          | Nohit    | 10 days ago | Critical   | High           | Service Availability |
       And the user USER1 is already logged in into Hybrid Cloud Console
      When user looks at Hybrid Cloud Console main page
      Then menu on the left side should be displayed
@@ -129,20 +130,21 @@ Feature: Sorting on Advisor affected clusters page behaviour on Hybrid Cloud Con
      When user select "Recommendations" menu item from this sub-menu
      Then an "Advisor recommendations" page should be displayed right of the left menu bar
       And that table should contain following four rows in that order
-          | Name        | Modified    | Total risk | Clusters |
-          | Bug12345    | 10 days ago | Critical   | 4        |
-          | Abc12345    | 10 days ago | Important  | 3        |
-          | Xyz12345    | 10 days ago | Moderate   | 2        |
-          | Uvw12345    | 10 days ago | Low        | 1        |
+          | Name        | Modified    | Category             | Total risk | Risk of change | Clusters |
+          | Bug12345    | 10 days ago | Service Availability | Critical   | High           | 4        |
+          | Abc12345    | 10 days ago | Performance          | Important  | Moderate       | 3        |
+          | Xyz12345    | 10 days ago | Fault Tolerance      | Moderate   | Low            | 2        |
+          | Uvw12345    | 10 days ago | Security             | Low        | Very Low       | 1        |
      When user clicks on an "Bug12345" link
      Then new page with additional information about selected recommendation should be displayed
       And the following values needs to be displayed
-          | Value type  | Content             | Displayed as              | Optional |
-          | Description | Textual description | Text                      | no       |
-          | KB article  | Link to KB article  | Link                      | yes      |
-          | Total risk  | Important           | Widget (icon+label)       | no       |
-          | Likelihood  | High                | Widget (thermometer-like) | no       |
-          | Impact      | High                | Widget (thermometer-like) | no       |
+          | Value type     | Content             | Displayed as              | Optional |
+          | Description    | Textual description | Text                      | no       |
+          | KB article     | Link to KB article  | Link                      | yes      |
+          | Total risk     | Important           | Widget (icon+label)       | no       |
+          | Likelihood     | High                | Widget (thermometer-like) | no       |
+          | Impact         | High                | Widget (thermometer-like) | no       |
+          | Risk of change | High                | Widget (icon+label)       | no       |
       And "Affected clusters" table needs to be displayed below additional info
           | Name                                 | Clickable (link) |
           | 33333333-0000-0000-0000-000000000000 | yes              |
@@ -171,26 +173,26 @@ Feature: Sorting on Advisor affected clusters page behaviour on Hybrid Cloud Con
           | 22222222-0000-0000-0000-000000000000 |
           | 33333333-0000-0000-0000-000000000000 |
       And 4 issues are detected for cluster 00000000-0000-0000-0000-000000000000
-          | Title    | Modified    | Total risk |
-          | Bug12345 | 10 days ago | Critical   |
-          | Abc12345 | 10 days ago | Important  |
-          | Xyz12345 | 10 days ago | Moderate   |
-          | Uvw12345 | 10 days ago | Low        |
+          | Title    | Modified    | Total risk | Risk of change | Category             |
+          | Bug12345 | 10 days ago | Critical   | High           | Service Availability |
+          | Abc12345 | 10 days ago | Important  | Moderate       | Performance          |
+          | Xyz12345 | 10 days ago | Moderate   | Low            | Fault Tolerance      |
+          | Uvw12345 | 10 days ago | Low        | Very low       | Security             |
       And 3 issues are detected for cluster 11111111-0000-0000-0000-000000000000
-          | Title    | Modified    | Total risk |
-          | Bug12345 | 10 days ago | Critical   |
-          | Abc12345 | 10 days ago | Important  |
-          | Xyz12345 | 10 days ago | Moderate   |
+          | Title    | Modified    | Total risk | Risk of change | Category             |
+          | Bug12345 | 10 days ago | Critical   | High           | Service Availability |
+          | Abc12345 | 10 days ago | Important  | Moderate       | Performance          |
+          | Xyz12345 | 10 days ago | Moderate   | Low            | Fault Tolerance      |
       And 2 issues are detected for cluster 22222222-0000-0000-0000-000000000000
-          | Title    | Modified    | Total risk |
-          | Bug12345 | 10 days ago | Critical   |
-          | Abc12345 | 10 days ago | Important  |
+          | Title    | Modified    | Total risk | Risk of change | Category             |
+          | Bug12345 | 10 days ago | Critical   | High           | Service Availability |
+          | Abc12345 | 10 days ago | Important  | Moderate       | Performance          |
       And 1 issue is detected for cluster 33333333-0000-0000-0000-000000000000
-          | Title    | Modified    | Total risk |
-          | Bug12345 | 10 days ago | Critical   |
+          | Title    | Modified    | Total risk | Risk of change | Category             |
+          | Bug12345 | 10 days ago | Critical   | High           | Service Availability |
       And 1 another issue without cluster hit exists
-          | Title    | Modified    | Total risk |
-          | Nohit    | 10 days ago | Critical   |
+          | Title    | Modified    | Total risk | Risk of change | Category             |
+          | Nohit    | 10 days ago | Critical   | High           | Service Availability |
       And the user USER1 is already logged in into Hybrid Cloud Console
      When user looks at Hybrid Cloud Console main page
      Then menu on the left side should be displayed
@@ -214,20 +216,21 @@ Feature: Sorting on Advisor affected clusters page behaviour on Hybrid Cloud Con
      When user select "Recommendations" menu item from this sub-menu
      Then an "Advisor recommendations" page should be displayed right of the left menu bar
       And that table should contain following four rows in that order
-          | Name        | Modified    | Total risk | Clusters |
-          | Bug12345    | 10 days ago | Critical   | 4        |
-          | Abc12345    | 10 days ago | Important  | 3        |
-          | Xyz12345    | 10 days ago | Moderate   | 2        |
-          | Uvw12345    | 10 days ago | Low        | 1        |
+          | Name        | Modified    | Category             | Total risk | Risk of change | Clusters |
+          | Bug12345    | 10 days ago | Service Availability | Critical   | High           | 4        |
+          | Abc12345    | 10 days ago | Performance          | Important  | Moderate       | 3        |
+          | Xyz12345    | 10 days ago | Fault Tolerance      | Moderate   | Low            | 2        |
+          | Uvw12345    | 10 days ago | Security             | Low        | Very Low       | 1        |
      When user clicks on an "Bug12345" link
      Then new page with additional information about selected recommendation should be displayed
       And the following values needs to be displayed
-          | Value type  | Content             | Displayed as              | Optional |
-          | Description | Textual description | Text                      | no       |
-          | KB article  | Link to KB article  | Link                      | yes      |
-          | Total risk  | Important           | Widget (icon+label)       | no       |
-          | Likelihood  | High                | Widget (thermometer-like) | no       |
-          | Impact      | High                | Widget (thermometer-like) | no       |
+          | Value type     | Content             | Displayed as              | Optional |
+          | Description    | Textual description | Text                      | no       |
+          | KB article     | Link to KB article  | Link                      | yes      |
+          | Total risk     | Important           | Widget (icon+label)       | no       |
+          | Likelihood     | High                | Widget (thermometer-like) | no       |
+          | Impact         | High                | Widget (thermometer-like) | no       |
+          | Risk of change | High                | Widget (icon+label)       | no       |
       And "Affected clusters" table needs to be displayed below additional info
           | Name                                 | Clickable (link) |
           | 33333333-0000-0000-0000-000000000000 | yes              |

--- a/features/Insights_Advisor/affected_clusters_sorting.feature
+++ b/features/Insights_Advisor/affected_clusters_sorting.feature
@@ -34,13 +34,25 @@ Feature: Sorting on Advisor affected clusters page behaviour on Hybrid Cloud Con
      When user looks at Hybrid Cloud Console main page
      Then menu on the left side should be displayed
       And the left menu might contain these top level items
+          | Left menu item                | Required for this test |
+          | Application and Data Services | no                     |
+          | OpenShift                     | yes                    |
+          | Red Hat Enterprise Linux      | no                     |
+          | Ansible Automation Platform   | no                     |
+     When user selects "OpenShift" from the left side menu
+     Then menu on the left side should be changed
+      And the left menu might contain these top level items
           | Left menu item           | Required for this test |
+          | Clusters                 | no                     |
           | Overview                 | no                     |
           | Releases                 | no                     |
+          | Developer Sandbox        | no                     |
           | Downloads                | no                     |
           | Advisor                  | yes                    |
+          | Vulnerability            | no                     |
           | Subscriptions            | no                     |
           | Cost Management          | no                     |
+          | Support Cases            | no                     |
           | Cluster Manager Feedback | no                     |
           | Red Hat Marketplace      | no                     |
           | Documentation            | no                     |
@@ -111,13 +123,25 @@ Feature: Sorting on Advisor affected clusters page behaviour on Hybrid Cloud Con
      When user looks at Hybrid Cloud Console main page
      Then menu on the left side should be displayed
       And the left menu might contain these top level items
+          | Left menu item                | Required for this test |
+          | Application and Data Services | no                     |
+          | OpenShift                     | yes                    |
+          | Red Hat Enterprise Linux      | no                     |
+          | Ansible Automation Platform   | no                     |
+     When user selects "OpenShift" from the left side menu
+     Then menu on the left side should be changed
+      And the left menu might contain these top level items
           | Left menu item           | Required for this test |
+          | Clusters                 | no                     |
           | Overview                 | no                     |
           | Releases                 | no                     |
+          | Developer Sandbox        | no                     |
           | Downloads                | no                     |
           | Advisor                  | yes                    |
+          | Vulnerability            | no                     |
           | Subscriptions            | no                     |
           | Cost Management          | no                     |
+          | Support Cases            | no                     |
           | Cluster Manager Feedback | no                     |
           | Red Hat Marketplace      | no                     |
           | Documentation            | no                     |
@@ -197,13 +221,25 @@ Feature: Sorting on Advisor affected clusters page behaviour on Hybrid Cloud Con
      When user looks at Hybrid Cloud Console main page
      Then menu on the left side should be displayed
       And the left menu might contain these top level items
+          | Left menu item                | Required for this test |
+          | Application and Data Services | no                     |
+          | OpenShift                     | yes                    |
+          | Red Hat Enterprise Linux      | no                     |
+          | Ansible Automation Platform   | no                     |
+     When user selects "OpenShift" from the left side menu
+     Then menu on the left side should be changed
+      And the left menu might contain these top level items
           | Left menu item           | Required for this test |
+          | Clusters                 | no                     |
           | Overview                 | no                     |
           | Releases                 | no                     |
+          | Developer Sandbox        | no                     |
           | Downloads                | no                     |
           | Advisor                  | yes                    |
+          | Vulnerability            | no                     |
           | Subscriptions            | no                     |
           | Cost Management          | no                     |
+          | Support Cases            | no                     |
           | Cluster Manager Feedback | no                     |
           | Red Hat Marketplace      | no                     |
           | Documentation            | no                     |

--- a/features/Insights_Advisor/affected_clusters_version.feature
+++ b/features/Insights_Advisor/affected_clusters_version.feature
@@ -42,13 +42,13 @@ Feature: Recommendations view page with recommendations behaviour on Hybrid Clou
             | Clusters       |
         And that table should contain at least one row
             | Column name    | Value       |
-            | Name           | Bug1234     |
+            | Name           | Bug12345     |
             | Modified       | 10 days ago |
             | Category       | Security    |
             | Total risk     | Important   |
             | Risk of change | Moderate    |
             | Clusters       | 1           |
-        When user clicks on an "Bug1234" link
+        When user clicks on an "Bug12345" link
         Then new page with additional information about selected recommendation should be displayed
         And the following values needs to be displayed
           | Value type     | Content             | Displayed as              | Optional |
@@ -109,13 +109,13 @@ Feature: Recommendations view page with recommendations behaviour on Hybrid Clou
             | Clusters       |
         And that table should contain at least one row
             | Column name    | Value       |
-            | Name           | Bug1234     |
+            | Name           | Bug12345     |
             | Modified       | 10 days ago |
             | Category       | Security    |
             | Total risk     | Important   |
             | Risk of change | Moderate    |
             | Clusters       | 2           |
-        When user clicks on an "Bug1234" link
+        When user clicks on an "Bug12345" link
         Then new page with additional information about selected recommendation should be displayed
         And the following values needs to be displayed
           | Value type     | Content             | Displayed as              | Optional |
@@ -184,13 +184,13 @@ Feature: Recommendations view page with recommendations behaviour on Hybrid Clou
             | Clusters       |
         And that table should contain at least one row
             | Column name    | Value       |
-            | Name           | Bug1234     |
+            | Name           | Bug12345     |
             | Modified       | 10 days ago |
             | Category       | Security    |
             | Total risk     | Important   |
             | Risk of change | Moderate    |
             | Clusters       | 12          |
-        When user clicks on an "Bug1234" link
+        When user clicks on an "Bug12345" link
         Then new page with additional information about selected recommendation should be displayed
         And the following values needs to be displayed
           | Value type     | Content             | Displayed as              | Optional |

--- a/features/Insights_Advisor/affected_clusters_version.feature
+++ b/features/Insights_Advisor/affected_clusters_version.feature
@@ -7,8 +7,8 @@ Feature: Recommendations view page with recommendations behaviour on Hybrid Clou
             | Cluster name                         | Version |
             | 00000000-0000-0000-0000-000000000000 | 0.0     |
         And 1 issue is detected for cluster 00000000-0000-0000-0000-000000000000
-            | Title    | Modified    | Total risk | Likelihood | Impact |
-            | Bug12345 | 10 days ago | Important  | high       | high   |
+            | Title    | Modified    | Category | Total risk | Likelihood | Impact | Risk of change |
+            | Bug12345 | 10 days ago | Security | Important  | high       | high   | Moderate       |
         And the user USER1 is already logged in into Hybrid Cloud Console
         When user looks at Hybrid Cloud Console main page
         Then menu on the left side should be displayed
@@ -33,26 +33,31 @@ Feature: Recommendations view page with recommendations behaviour on Hybrid Clou
         Then an "Advisor recommendations" page should be displayed right of the left menu bar
         And widget with filter settings should be displayed
         And table with several columns should be displayed
-            | Column name |
-            | Name        |
-            | Modified    |
-            | Total risk  |
-            | Clusters    |
+            | Column name    |
+            | Name           |
+            | Modified       |
+            | Category       |
+            | Total risk     |
+            | Risk of change |
+            | Clusters       |
         And that table should contain at least one row
-            | Column name | Value       |
-            | Name        | Bug1234     |
-            | Modified    | 10 days ago |
-            | Total risk  | Important   |
-            | Clusters    | 1           |
+            | Column name    | Value       |
+            | Name           | Bug1234     |
+            | Modified       | 10 days ago |
+            | Category       | Security    |
+            | Total risk     | Important   |
+            | Risk of change | Moderate    |
+            | Clusters       | 1           |
         When user clicks on an "Bug1234" link
         Then new page with additional information about selected recommendation should be displayed
         And the following values needs to be displayed
-            | Value type  | Content             | Displayed as              | Optional |
-            | Description | Textual description | Text                      | no       |
-            | KB article  | Link to KB article  | Link                      | yes      |
-            | Total risk  | Important           | Widget (icon+label)       | no       |
-            | Likelihood  | High                | Widget (thermometer-like) | no       |
-            | Impact      | High                | Widget (thermometer-like) | no       |
+          | Value type     | Content             | Displayed as              | Optional |
+          | Description    | Textual description | Text                      | no       |
+          | KB article     | Link to KB article  | Link                      | yes      |
+          | Total risk     | Important           | Widget (icon+label)       | no       |
+          | Likelihood     | High                | Widget (thermometer-like) | no       |
+          | Impact         | High                | Widget (thermometer-like) | no       |
+          | Risk of change | Moderate            | Widget (icon+label)       | no       |
         And "Affected clusters" table needs to be displayed below additional info
             | Name                                 | Clickable (link) | Version |
             | 00000000-0000-0000-0000-000000000000 | yes              | 0.0     |
@@ -66,11 +71,11 @@ Feature: Recommendations view page with recommendations behaviour on Hybrid Clou
             | 00000000-0000-0000-0000-000000000000 | 0.0     |
             | 11111111-0000-0000-0000-000000000000 |         |
         And 1 issue is detected for cluster 00000000-0000-0000-0000-000000000000
-            | Title    | Modified    | Total risk | Likelihood | Impact |
-            | Bug12345 | 10 days ago | Important  | high       | high   |
+            | Title    | Modified    | Category | Total risk | Likelihood | Impact | Risk of change |
+            | Bug12345 | 10 days ago | Security | Important  | high       | high   | Moderate       |
         And 1 issue is detected for cluster 11111111-0000-0000-0000-000000000000
-            | Title    | Modified    | Total risk | Likelihood | Impact |
-            | Bug12345 | 10 days ago | Important  | high       | high   |
+            | Title    | Modified    | Category | Total risk | Likelihood | Impact | Risk of change |
+            | Bug12345 | 10 days ago | Security | Important  | high       | high   | Moderate       |
         And the user USER1 is already logged in into Hybrid Cloud Console
         When user looks at Hybrid Cloud Console main page
         Then menu on the left side should be displayed
@@ -95,26 +100,31 @@ Feature: Recommendations view page with recommendations behaviour on Hybrid Clou
         Then an "Advisor recommendations" page should be displayed right of the left menu bar
         And widget with filter settings should be displayed
         And table with several columns should be displayed
-            | Column name |
-            | Name        |
-            | Modified    |
-            | Total risk  |
-            | Clusters    |
+            | Column name    |
+            | Name           |
+            | Modified       |
+            | Category       |
+            | Total risk     |
+            | Risk of change |
+            | Clusters       |
         And that table should contain at least one row
-            | Column name | Value       |
-            | Name        | Bug1234     |
-            | Modified    | 10 days ago |
-            | Total risk  | Important   |
-            | Clusters    | 2           |
+            | Column name    | Value       |
+            | Name           | Bug1234     |
+            | Modified       | 10 days ago |
+            | Category       | Security    |
+            | Total risk     | Important   |
+            | Risk of change | Moderate    |
+            | Clusters       | 2           |
         When user clicks on an "Bug1234" link
         Then new page with additional information about selected recommendation should be displayed
         And the following values needs to be displayed
-            | Value type  | Content             | Displayed as              | Optional |
-            | Description | Textual description | Text                      | no       |
-            | KB article  | Link to KB article  | Link                      | yes      |
-            | Total risk  | Important           | Widget (icon+label)       | no       |
-            | Likelihood  | High                | Widget (thermometer-like) | no       |
-            | Impact      | High                | Widget (thermometer-like) | no       |
+          | Value type     | Content             | Displayed as              | Optional |
+          | Description    | Textual description | Text                      | no       |
+          | KB article     | Link to KB article  | Link                      | yes      |
+          | Total risk     | Important           | Widget (icon+label)       | no       |
+          | Likelihood     | High                | Widget (thermometer-like) | no       |
+          | Impact         | High                | Widget (thermometer-like) | no       |
+          | Risk of change | Moderate            | Widget (icon+label)       | no       |
         And "Affected clusters" table needs to be displayed below additional info
             | Name                                 | Clickable (link) | Version |
             | 00000000-0000-0000-0000-000000000000 | yes              | 0.0     |
@@ -124,7 +134,7 @@ Feature: Recommendations view page with recommendations behaviour on Hybrid Clou
 
     Scenario: Pagination on "Affected clusters" page on Hybrid Cloud Console with more than 10 clusters should show the cluster version
         Given user USER1 is part of account (organization) ACCOUNT1
-        And account (organization) ACCOUNT1 owns 2 clusters
+        And account (organization) ACCOUNT1 owns 12 clusters
             | Cluster name                         | Version |
             | 00000000-0000-0000-0000-000000000000 | 0.0     |
             | 11111111-0000-0000-0000-000000000000 | 1.0     |
@@ -139,6 +149,8 @@ Feature: Recommendations view page with recommendations behaviour on Hybrid Clou
             | aaaaaaaa-0000-0000-0000-000000000000 | a.0     |
             | bbbbbbbb-0000-0000-0000-000000000000 | b.0     |
         And 1 issue is detected for all clusters
+            | Title    | Modified    | Category | Total risk | Likelihood | Impact | Risk of change |
+            | Bug12345 | 10 days ago | Security | Important  | high       | high   | Moderate       |
         And the user USER1 is already logged in into Hybrid Cloud Console
         When user looks at Hybrid Cloud Console main page
         Then menu on the left side should be displayed
@@ -163,26 +175,31 @@ Feature: Recommendations view page with recommendations behaviour on Hybrid Clou
         Then an "Advisor recommendations" page should be displayed right of the left menu bar
         And widget with filter settings should be displayed
         And table with several columns should be displayed
-            | Column name |
-            | Name        |
-            | Modified    |
-            | Total risk  |
-            | Clusters    |
+            | Column name    |
+            | Name           |
+            | Modified       |
+            | Category       |
+            | Total risk     |
+            | Risk of change |
+            | Clusters       |
         And that table should contain at least one row
-            | Column name | Value       |
-            | Name        | Bug1234     |
-            | Modified    | 10 days ago |
-            | Total risk  | Important   |
-            | Clusters    | 12          |
+            | Column name    | Value       |
+            | Name           | Bug1234     |
+            | Modified       | 10 days ago |
+            | Category       | Security    |
+            | Total risk     | Important   |
+            | Risk of change | Moderate    |
+            | Clusters       | 12          |
         When user clicks on an "Bug1234" link
         Then new page with additional information about selected recommendation should be displayed
         And the following values needs to be displayed
-            | Value type  | Content             | Displayed as              | Optional |
-            | Description | Textual description | Text                      | no       |
-            | KB article  | Link to KB article  | Link                      | yes      |
-            | Total risk  | Important           | Widget (icon+label)       | no       |
-            | Likelihood  | High                | Widget (thermometer-like) | no       |
-            | Impact      | High                | Widget (thermometer-like) | no       |
+          | Value type     | Content             | Displayed as              | Optional |
+          | Description    | Textual description | Text                      | no       |
+          | KB article     | Link to KB article  | Link                      | yes      |
+          | Total risk     | Important           | Widget (icon+label)       | no       |
+          | Likelihood     | High                | Widget (thermometer-like) | no       |
+          | Impact         | High                | Widget (thermometer-like) | no       |
+          | Risk of change | Moderate            | Widget (icon+label)       | no       |
         And "Affected clusters" table needs to be displayed below additional info
             | Name                                 | Clickable (link) | Version |
             | 00000000-0000-0000-0000-000000000000 | yes              | 0.0     |

--- a/features/Insights_Advisor/cluster_page.feature
+++ b/features/Insights_Advisor/cluster_page.feature
@@ -6,14 +6,14 @@ Feature: Cluster view page with recommendations behaviour on Hybrid Cloud Consol
           | Cluster name                         |
           | 00000000-0000-0000-0000-000000000000 |
       And 4 issues are detected for cluster 00000000-0000-0000-0000-000000000000
-          | Title    | Modified    | Total risk |
-          | Bug12345 | 10 days ago | Critical   |
-          | Abc12345 | 10 days ago | Important  |
-          | Xyz12345 | 10 days ago | Moderate   |
-          | Uvw12345 | 10 days ago | Low        |
+          | Title    | Modified    | Total risk | Risk of change | Category             |
+          | Bug12345 | 10 days ago | Critical   | High           | Service Availability |
+          | Abc12345 | 10 days ago | Important  | Moderate       | Performance          |
+          | Xyz12345 | 10 days ago | Moderate   | Low            | Fault Tolerance      |
+          | Uvw12345 | 10 days ago | Low        | Very low       | Security             |
       And 1 another issue without cluster hit exists
-          | Title    | Modified    | Total risk |
-          | Nohit    | 10 days ago | Critical   |
+          | Title    | Modified    | Total risk | Risk of change | Category             |
+          | Nohit    | 10 days ago | Critical   | High           | Service Availability |
       And the user USER1 is already logged in into Hybrid Cloud Console
      When user looks at Hybrid Cloud Console main page
      Then menu on the left side should be displayed
@@ -37,20 +37,21 @@ Feature: Cluster view page with recommendations behaviour on Hybrid Cloud Consol
      When user select "Recommendations" menu item from this sub-menu
      Then an "Advisor recommendations" page should be displayed right of the left menu bar
       And that table should contain following four rows in that order
-          | Name        | Modified    | Total risk | Clusters |
-          | Bug12345    | 10 days ago | Critical   | 1        |
-          | Abc12345    | 10 days ago | Important  | 1        |
-          | Xyz12345    | 10 days ago | Moderate   | 1        |
-          | Uvw12345    | 10 days ago | Low        | 1        |
+          | Name        | Modified    | Category             | Total risk | Risk of change | Clusters |
+          | Bug12345    | 10 days ago | Service Availability | Critical   | High           | 1        |
+          | Abc12345    | 10 days ago | Performance          | Important  | Moderate       | 1        |
+          | Xyz12345    | 10 days ago | Fault Tolerance      | Moderate   | Low            | 1        |
+          | Uvw12345    | 10 days ago | Security             | Low        | Very low       | 1        |
      When user clicks on an "Bug12345" link
      Then new page with additional information about selected recommendation should be displayed
       And the following values needs to be displayed
-          | Value type  | Content             | Displayed as              | Optional |
-          | Description | Textual description | Text                      | no       |
-          | KB article  | Link to KB article  | Link                      | yes      |
-          | Total risk  | Important           | Widget (icon+label)       | no       |
-          | Likelihood  | High                | Widget (thermometer-like) | no       |
-          | Impact      | High                | Widget (thermometer-like) | no       |
+          | Value type     | Content             | Displayed as              | Optional |
+          | Description    | Textual description | Text                      | no       |
+          | KB article     | Link to KB article  | Link                      | yes      |
+          | Total risk     | Important           | Widget (icon+label)       | no       |
+          | Likelihood     | High                | Widget (thermometer-like) | no       |
+          | Impact         | High                | Widget (thermometer-like) | no       |
+          | Risk of change | Moderate            | Widget (icon+label)       | no       |
       And "Affected clusters" table needs to be displayed below additional info
           | Name                                 | Clickable (link) |
           | 00000000-0000-0000-0000-000000000000 | yes              |
@@ -73,14 +74,14 @@ Feature: Cluster view page with recommendations behaviour on Hybrid Cloud Consol
           | Cluster name                         |
           | 00000000-0000-0000-0000-000000000000 |
       And 4 issues are detected for cluster 00000000-0000-0000-0000-000000000000
-          | Title    | Modified    | Total risk |
-          | Bug12345 | 10 days ago | Critical   |
-          | Abc12345 | 10 days ago | Important  |
-          | Xyz12345 | 10 days ago | Moderate   |
-          | Uvw12345 | 10 days ago | Low        |
+          | Title    | Modified    | Total risk | Risk of change | Category             |
+          | Bug12345 | 10 days ago | Critical   | High           | Service Availability |
+          | Abc12345 | 10 days ago | Important  | Moderate       | Performance          |
+          | Xyz12345 | 10 days ago | Moderate   | Low            | Fault Tolerance      |
+          | Uvw12345 | 10 days ago | Low        | Very low       | Security             |
       And 1 another issue without cluster hit exists
-          | Title    | Modified    | Total risk |
-          | Nohit    | 10 days ago | Critical   |
+          | Title    | Modified    | Total risk | Risk of change | Category             |
+          | Nohit    | 10 days ago | Critical   | High           | Service Availability |
       And the user USER1 is already logged in into Hybrid Cloud Console
      When user looks at Hybrid Cloud Console main page
      Then menu on the left side should be displayed
@@ -104,20 +105,21 @@ Feature: Cluster view page with recommendations behaviour on Hybrid Cloud Consol
      When user select "Recommendations" menu item from this sub-menu
      Then an "Advisor recommendations" page should be displayed right of the left menu bar
       And that table should contain following four rows in that order
-          | Name        | Modified    | Total risk | Clusters |
-          | Bug12345    | 10 days ago | Critical   | 1        |
-          | Abc12345    | 10 days ago | Important  | 1        |
-          | Xyz12345    | 10 days ago | Moderate   | 1        |
-          | Uvw12345    | 10 days ago | Low        | 1        |
+          | Name        | Modified    | Category             | Total risk | Risk of change | Clusters |
+          | Bug12345    | 10 days ago | Service Availability | Critical   | High           | 1        |
+          | Abc12345    | 10 days ago | Performance          | Important  | Moderate       | 1        |
+          | Xyz12345    | 10 days ago | Fault Tolerance      | Moderate   | Low            | 1        |
+          | Uvw12345    | 10 days ago | Security             | Low        | Very low       | 1        |
      When user clicks on an "Bug12345" link
      Then new page with additional information about selected recommendation should be displayed
       And the following values needs to be displayed
-          | Value type  | Content             | Displayed as              | Optional |
-          | Description | Textual description | Text                      | no       |
-          | KB article  | Link to KB article  | Link                      | yes      |
-          | Total risk  | Important           | Widget (icon+label)       | no       |
-          | Likelihood  | High                | Widget (thermometer-like) | no       |
-          | Impact      | High                | Widget (thermometer-like) | no       |
+          | Value type     | Content             | Displayed as              | Optional |
+          | Description    | Textual description | Text                      | no       |
+          | KB article     | Link to KB article  | Link                      | yes      |
+          | Total risk     | Important           | Widget (icon+label)       | no       |
+          | Likelihood     | High                | Widget (thermometer-like) | no       |
+          | Impact         | High                | Widget (thermometer-like) | no       |
+          | Risk of change | Moderate            | Widget (icon+label)       | no       |
       And "Affected clusters" table needs to be displayed below additional info
           | Name                                 | Clickable (link) |
           | 00000000-0000-0000-0000-000000000000 | yes              |
@@ -152,14 +154,14 @@ Feature: Cluster view page with recommendations behaviour on Hybrid Cloud Consol
           | Cluster name                         |
           | 00000000-0000-0000-0000-000000000000 |
       And 4 issues are detected for cluster 00000000-0000-0000-0000-000000000000
-          | Title    | Modified    | Total risk |
-          | Bug12345 | 10 days ago | Critical   |
-          | Abc12345 | 10 days ago | Important  |
-          | Xyz12345 | 10 days ago | Moderate   |
-          | Uvw12345 | 10 days ago | Low        |
+          | Title    | Modified    | Total risk | Risk of change | Category             |
+          | Bug12345 | 10 days ago | Critical   | High           | Service Availability |
+          | Abc12345 | 10 days ago | Important  | Moderate       | Performance          |
+          | Xyz12345 | 10 days ago | Moderate   | Low            | Fault Tolerance      |
+          | Uvw12345 | 10 days ago | Low        | Very low       | Security             |
       And 1 another issue without cluster hit exists
-          | Title    | Modified    | Total risk |
-          | Nohit    | 10 days ago | Critical   |
+          | Title    | Modified    | Total risk | Risk of change | Category             |
+          | Nohit    | 10 days ago | Critical   | High           | Service Availability |
       And the user USER1 is already logged in into Hybrid Cloud Console
      When user looks at Hybrid Cloud Console main page
      Then menu on the left side should be displayed
@@ -183,20 +185,21 @@ Feature: Cluster view page with recommendations behaviour on Hybrid Cloud Consol
      When user select "Recommendations" menu item from this sub-menu
      Then an "Advisor recommendations" page should be displayed right of the left menu bar
       And that table should contain following four rows in that order
-          | Name        | Modified    | Total risk | Clusters |
-          | Bug12345    | 10 days ago | Critical   | 1        |
-          | Abc12345    | 10 days ago | Important  | 1        |
-          | Xyz12345    | 10 days ago | Moderate   | 1        |
-          | Uvw12345    | 10 days ago | Low        | 1        |
+          | Name        | Modified    | Category             | Total risk | Risk of change | Clusters |
+          | Bug12345    | 10 days ago | Service Availability | Critical   | High           | 1        |
+          | Abc12345    | 10 days ago | Performance          | Important  | Moderate       | 1        |
+          | Xyz12345    | 10 days ago | Fault Tolerance      | Moderate   | Low            | 1        |
+          | Uvw12345    | 10 days ago | Security             | Low        | Very low       | 1        |
      When user clicks on an "Bug12345" link
      Then new page with additional information about selected recommendation should be displayed
       And the following values needs to be displayed
-          | Value type  | Content             | Displayed as              | Optional |
-          | Description | Textual description | Text                      | no       |
-          | KB article  | Link to KB article  | Link                      | yes      |
-          | Total risk  | Important           | Widget (icon+label)       | no       |
-          | Likelihood  | High                | Widget (thermometer-like) | no       |
-          | Impact      | High                | Widget (thermometer-like) | no       |
+          | Value type     | Content             | Displayed as              | Optional |
+          | Description    | Textual description | Text                      | no       |
+          | KB article     | Link to KB article  | Link                      | yes      |
+          | Total risk     | Important           | Widget (icon+label)       | no       |
+          | Likelihood     | High                | Widget (thermometer-like) | no       |
+          | Impact         | High                | Widget (thermometer-like) | no       |
+          | Risk of change | Moderate            | Widget (icon+label)       | no       |
       And "Affected clusters" table needs to be displayed below additional info
           | Name                                 | Clickable (link) |
           | 00000000-0000-0000-0000-000000000000 | yes              |
@@ -237,14 +240,14 @@ Feature: Cluster view page with recommendations behaviour on Hybrid Cloud Consol
           | Cluster name                         |
           | 00000000-0000-0000-0000-000000000000 |
       And 4 issues are detected for cluster 00000000-0000-0000-0000-000000000000
-          | Title    | Modified    | Total risk |
-          | Bug12345 | 10 days ago | Critical   |
-          | Abc12345 | 10 days ago | Important  |
-          | Xyz12345 | 10 days ago | Moderate   |
-          | Uvw12345 | 10 days ago | Low        |
+          | Title    | Modified    | Total risk | Risk of change | Category             |
+          | Bug12345 | 10 days ago | Critical   | High           | Service Availability |
+          | Abc12345 | 10 days ago | Important  | Moderate       | Performance          |
+          | Xyz12345 | 10 days ago | Moderate   | Low            | Fault Tolerance      |
+          | Uvw12345 | 10 days ago | Low        | Very low       | Security             |
       And 1 another issue without cluster hit exists
-          | Title    | Modified    | Total risk |
-          | Nohit    | 10 days ago | Critical   |
+          | Title    | Modified    | Total risk | Risk of change | Category             |
+          | Nohit    | 10 days ago | Critical   | High           | Service Availability |
       And the user USER1 is already logged in into Hybrid Cloud Console
      When user looks at Hybrid Cloud Console main page
      Then menu on the left side should be displayed
@@ -268,20 +271,21 @@ Feature: Cluster view page with recommendations behaviour on Hybrid Cloud Consol
      When user select "Recommendations" menu item from this sub-menu
      Then an "Advisor recommendations" page should be displayed right of the left menu bar
       And that table should contain following four rows in that order
-          | Name        | Modified    | Total risk | Clusters |
-          | Bug12345    | 10 days ago | Critical   | 1        |
-          | Abc12345    | 10 days ago | Important  | 1        |
-          | Xyz12345    | 10 days ago | Moderate   | 1        |
-          | Uvw12345    | 10 days ago | Low        | 1        |
+          | Name        | Modified    | Category             | Total risk | Risk of change | Clusters |
+          | Bug12345    | 10 days ago | Service Availability | Critical   | High           | 1        |
+          | Abc12345    | 10 days ago | Performance          | Important  | Moderate       | 1        |
+          | Xyz12345    | 10 days ago | Fault Tolerance      | Moderate   | Low            | 1        |
+          | Uvw12345    | 10 days ago | Security             | Low        | Very low       | 1        |
      When user clicks on an "Bug12345" link
      Then new page with additional information about selected recommendation should be displayed
       And the following values needs to be displayed
-          | Value type  | Content             | Displayed as              | Optional |
-          | Description | Textual description | Text                      | no       |
-          | KB article  | Link to KB article  | Link                      | yes      |
-          | Total risk  | Important           | Widget (icon+label)       | no       |
-          | Likelihood  | High                | Widget (thermometer-like) | no       |
-          | Impact      | High                | Widget (thermometer-like) | no       |
+          | Value type     | Content             | Displayed as              | Optional |
+          | Description    | Textual description | Text                      | no       |
+          | KB article     | Link to KB article  | Link                      | yes      |
+          | Total risk     | Important           | Widget (icon+label)       | no       |
+          | Likelihood     | High                | Widget (thermometer-like) | no       |
+          | Impact         | High                | Widget (thermometer-like) | no       |
+          | Risk of change | Moderate            | Widget (icon+label)       | no       |
       And "Affected clusters" table needs to be displayed below additional info
           | Name                                 | Clickable (link) |
           | 00000000-0000-0000-0000-000000000000 | yes              |
@@ -324,14 +328,14 @@ Feature: Cluster view page with recommendations behaviour on Hybrid Cloud Consol
           | Cluster name                         |
           | 00000000-0000-0000-0000-000000000000 |
       And 4 issues are detected for cluster 00000000-0000-0000-0000-000000000000
-          | Title    | Modified    | Total risk |
-          | Bug12345 | 10 days ago | Critical   |
-          | Abc12345 | 10 days ago | Important  |
-          | Xyz12345 | 10 days ago | Moderate   |
-          | Uvw12345 | 10 days ago | Low        |
+          | Title    | Modified    | Total risk | Risk of change | Category             |
+          | Bug12345 | 10 days ago | Critical   | High           | Service Availability |
+          | Abc12345 | 10 days ago | Important  | Moderate       | Performance          |
+          | Xyz12345 | 10 days ago | Moderate   | Low            | Fault Tolerance      |
+          | Uvw12345 | 10 days ago | Low        | Very low       | Security             |
       And 1 another issue without cluster hit exists
-          | Title    | Modified    | Total risk |
-          | Nohit    | 10 days ago | Critical   |
+          | Title    | Modified    | Total risk | Risk of change | Category             |
+          | Nohit    | 10 days ago | Critical   | High           | Service Availability |
       And the user USER1 is already logged in into Hybrid Cloud Console
      When user looks at Hybrid Cloud Console main page
      Then menu on the left side should be displayed
@@ -355,20 +359,21 @@ Feature: Cluster view page with recommendations behaviour on Hybrid Cloud Consol
      When user select "Recommendations" menu item from this sub-menu
      Then an "Advisor recommendations" page should be displayed right of the left menu bar
       And that table should contain following four rows in that order
-          | Name        | Modified    | Total risk | Clusters |
-          | Bug12345    | 10 days ago | Critical   | 1        |
-          | Abc12345    | 10 days ago | Important  | 1        |
-          | Xyz12345    | 10 days ago | Moderate   | 1        |
-          | Uvw12345    | 10 days ago | Low        | 1        |
+          | Name        | Modified    | Category             | Total risk | Risk of change | Clusters |
+          | Bug12345    | 10 days ago | Service Availability | Critical   | High           | 1        |
+          | Abc12345    | 10 days ago | Performance          | Important  | Moderate       | 1        |
+          | Xyz12345    | 10 days ago | Fault Tolerance      | Moderate   | Low            | 1        |
+          | Uvw12345    | 10 days ago | Security             | Low        | Very low       | 1        |
      When user clicks on an "Bug12345" link
      Then new page with additional information about selected recommendation should be displayed
       And the following values needs to be displayed
-          | Value type  | Content             | Displayed as              | Optional |
-          | Description | Textual description | Text                      | no       |
-          | KB article  | Link to KB article  | Link                      | yes      |
-          | Total risk  | Important           | Widget (icon+label)       | no       |
-          | Likelihood  | High                | Widget (thermometer-like) | no       |
-          | Impact      | High                | Widget (thermometer-like) | no       |
+          | Value type     | Content             | Displayed as              | Optional |
+          | Description    | Textual description | Text                      | no       |
+          | KB article     | Link to KB article  | Link                      | yes      |
+          | Total risk     | Important           | Widget (icon+label)       | no       |
+          | Likelihood     | High                | Widget (thermometer-like) | no       |
+          | Impact         | High                | Widget (thermometer-like) | no       |
+          | Risk of change | Moderate            | Widget (icon+label)       | no       |
       And "Affected clusters" table needs to be displayed below additional info
           | Name                                 | Clickable (link) |
           | 00000000-0000-0000-0000-000000000000 | yes              |
@@ -411,14 +416,14 @@ Feature: Cluster view page with recommendations behaviour on Hybrid Cloud Consol
           | Cluster name                         |
           | 00000000-0000-0000-0000-000000000000 |
       And 4 issues are detected for cluster 00000000-0000-0000-0000-000000000000
-          | Title    | Modified    | Total risk |
-          | Bug12345 | 10 days ago | Critical   |
-          | Abc12345 | 10 days ago | Important  |
-          | Xyz12345 | 10 days ago | Moderate   |
-          | Uvw12345 | 10 days ago | Low        |
+          | Title    | Modified    | Total risk | Risk of change | Category             |
+          | Bug12345 | 10 days ago | Critical   | High           | Service Availability |
+          | Abc12345 | 10 days ago | Important  | Moderate       | Performance          |
+          | Xyz12345 | 10 days ago | Moderate   | Low            | Fault Tolerance      |
+          | Uvw12345 | 10 days ago | Low        | Very low       | Security             |
       And 1 another issue without cluster hit exists
-          | Title    | Modified    | Total risk |
-          | Nohit    | 10 days ago | Critical   |
+          | Title    | Modified    | Total risk | Risk of change | Category             |
+          | Nohit    | 10 days ago | Critical   | High           | Service Availability |
       And the user USER1 is already logged in into Hybrid Cloud Console
      When user looks at Hybrid Cloud Console main page
      Then menu on the left side should be displayed
@@ -442,20 +447,21 @@ Feature: Cluster view page with recommendations behaviour on Hybrid Cloud Consol
      When user select "Recommendations" menu item from this sub-menu
      Then an "Advisor recommendations" page should be displayed right of the left menu bar
       And that table should contain following four rows in that order
-          | Name        | Modified    | Total risk | Clusters |
-          | Bug12345    | 10 days ago | Critical   | 1        |
-          | Abc12345    | 10 days ago | Important  | 1        |
-          | Xyz12345    | 10 days ago | Moderate   | 1        |
-          | Uvw12345    | 10 days ago | Low        | 1        |
+          | Name        | Modified    | Category             | Total risk | Risk of change | Clusters |
+          | Bug12345    | 10 days ago | Service Availability | Critical   | High           | 1        |
+          | Abc12345    | 10 days ago | Performance          | Important  | Moderate       | 1        |
+          | Xyz12345    | 10 days ago | Fault Tolerance      | Moderate   | Low            | 1        |
+          | Uvw12345    | 10 days ago | Security             | Low        | Very low       | 1        |
      When user clicks on an "Bug12345" link
      Then new page with additional information about selected recommendation should be displayed
       And the following values needs to be displayed
-          | Value type  | Content             | Displayed as              | Optional |
-          | Description | Textual description | Text                      | no       |
-          | KB article  | Link to KB article  | Link                      | yes      |
-          | Total risk  | Important           | Widget (icon+label)       | no       |
-          | Likelihood  | High                | Widget (thermometer-like) | no       |
-          | Impact      | High                | Widget (thermometer-like) | no       |
+          | Value type     | Content             | Displayed as              | Optional |
+          | Description    | Textual description | Text                      | no       |
+          | KB article     | Link to KB article  | Link                      | yes      |
+          | Total risk     | Important           | Widget (icon+label)       | no       |
+          | Likelihood     | High                | Widget (thermometer-like) | no       |
+          | Impact         | High                | Widget (thermometer-like) | no       |
+          | Risk of change | Moderate            | Widget (icon+label)       | no       |
       And "Affected clusters" table needs to be displayed below additional info
           | Name                                 | Clickable (link) |
           | 00000000-0000-0000-0000-000000000000 | yes              |
@@ -499,14 +505,14 @@ Feature: Cluster view page with recommendations behaviour on Hybrid Cloud Consol
           | Cluster name                         |
           | 00000000-0000-0000-0000-000000000000 |
       And 4 issues are detected for cluster 00000000-0000-0000-0000-000000000000
-          | Title    | Modified    | Total risk |
-          | Bug12345 | 10 days ago | Critical   |
-          | Abc12345 | 10 days ago | Important  |
-          | Xyz12345 | 10 days ago | Moderate   |
-          | Uvw12345 | 10 days ago | Low        |
+          | Title    | Modified    | Total risk | Risk of change | Category             |
+          | Bug12345 | 10 days ago | Critical   | High           | Service Availability |
+          | Abc12345 | 10 days ago | Important  | Moderate       | Performance          |
+          | Xyz12345 | 10 days ago | Moderate   | Low            | Fault Tolerance      |
+          | Uvw12345 | 10 days ago | Low        | Very low       | Security             |
       And 1 another issue without cluster hit exists
-          | Title    | Modified    | Total risk |
-          | Nohit    | 10 days ago | Critical   |
+          | Title    | Modified    | Total risk | Risk of change | Category             |
+          | Nohit    | 10 days ago | Critical   | High           | Service Availability |
       And the user USER1 is already logged in into Hybrid Cloud Console
      When user looks at Hybrid Cloud Console main page
      Then menu on the left side should be displayed
@@ -530,20 +536,21 @@ Feature: Cluster view page with recommendations behaviour on Hybrid Cloud Consol
      When user select "Recommendations" menu item from this sub-menu
      Then an "Advisor recommendations" page should be displayed right of the left menu bar
       And that table should contain following four rows in that order
-          | Name        | Modified    | Total risk | Clusters |
-          | Bug12345    | 10 days ago | Critical   | 1        |
-          | Abc12345    | 10 days ago | Important  | 1        |
-          | Xyz12345    | 10 days ago | Moderate   | 1        |
-          | Uvw12345    | 10 days ago | Low        | 1        |
+          | Name        | Modified    | Category             | Total risk | Risk of change | Clusters |
+          | Bug12345    | 10 days ago | Service Availability | Critical   | High           | 1        |
+          | Abc12345    | 10 days ago | Performance          | Important  | Moderate       | 1        |
+          | Xyz12345    | 10 days ago | Fault Tolerance      | Moderate   | Low            | 1        |
+          | Uvw12345    | 10 days ago | Security             | Low        | Very low       | 1        |
      When user clicks on an "Bug12345" link
      Then new page with additional information about selected recommendation should be displayed
       And the following values needs to be displayed
-          | Value type  | Content             | Displayed as              | Optional |
-          | Description | Textual description | Text                      | no       |
-          | KB article  | Link to KB article  | Link                      | yes      |
-          | Total risk  | Important           | Widget (icon+label)       | no       |
-          | Likelihood  | High                | Widget (thermometer-like) | no       |
-          | Impact      | High                | Widget (thermometer-like) | no       |
+          | Value type     | Content             | Displayed as              | Optional |
+          | Description    | Textual description | Text                      | no       |
+          | KB article     | Link to KB article  | Link                      | yes      |
+          | Total risk     | Important           | Widget (icon+label)       | no       |
+          | Likelihood     | High                | Widget (thermometer-like) | no       |
+          | Impact         | High                | Widget (thermometer-like) | no       |
+          | Risk of change | Moderate            | Widget (icon+label)       | no       |
       And "Affected clusters" table needs to be displayed below additional info
           | Name                                 | Clickable (link) |
           | 00000000-0000-0000-0000-000000000000 | yes              |

--- a/features/Insights_Advisor/cluster_page.feature
+++ b/features/Insights_Advisor/cluster_page.feature
@@ -2,7 +2,7 @@ Feature: Cluster view page with recommendations behaviour on Hybrid Cloud Consol
 
   Scenario: Cluster view page on Hybrid Cloud Console with five recommendations and one cluster
     Given user USER1 is part of account (organization) ACCOUNT1
-      And account (organization) ACCOUNT1 owns 4 clusters
+      And account (organization) ACCOUNT1 owns 1 cluster
           | Cluster name                         |
           | 00000000-0000-0000-0000-000000000000 |
       And 4 issues are detected for cluster 00000000-0000-0000-0000-000000000000
@@ -70,7 +70,7 @@ Feature: Cluster view page with recommendations behaviour on Hybrid Cloud Consol
 
   Scenario: Recommendations table on cluster view page on Hybrid Cloud Console with five recommendations and one cluster
     Given user USER1 is part of account (organization) ACCOUNT1
-      And account (organization) ACCOUNT1 owns 4 clusters
+      And account (organization) ACCOUNT1 owns 1 cluster
           | Cluster name                         |
           | 00000000-0000-0000-0000-000000000000 |
       And 4 issues are detected for cluster 00000000-0000-0000-0000-000000000000
@@ -150,7 +150,7 @@ Feature: Cluster view page with recommendations behaviour on Hybrid Cloud Consol
 
   Scenario: Expanded recommendation on cluster view page on Hybrid Cloud Console with five recommendations and one cluster
     Given user USER1 is part of account (organization) ACCOUNT1
-      And account (organization) ACCOUNT1 owns 4 clusters
+      And account (organization) ACCOUNT1 owns 1 cluster
           | Cluster name                         |
           | 00000000-0000-0000-0000-000000000000 |
       And 4 issues are detected for cluster 00000000-0000-0000-0000-000000000000
@@ -236,7 +236,7 @@ Feature: Cluster view page with recommendations behaviour on Hybrid Cloud Consol
 
   Scenario: Folding recommendation on cluster view page on Hybrid Cloud Console with five recommendations and one cluster
     Given user USER1 is part of account (organization) ACCOUNT1
-      And account (organization) ACCOUNT1 owns 4 clusters
+      And account (organization) ACCOUNT1 owns 1 cluster
           | Cluster name                         |
           | 00000000-0000-0000-0000-000000000000 |
       And 4 issues are detected for cluster 00000000-0000-0000-0000-000000000000
@@ -324,7 +324,7 @@ Feature: Cluster view page with recommendations behaviour on Hybrid Cloud Consol
 
   Scenario: Expanding recommendation on cluster view page on Hybrid Cloud Console with five recommendations and one cluster
     Given user USER1 is part of account (organization) ACCOUNT1
-      And account (organization) ACCOUNT1 owns 4 clusters
+      And account (organization) ACCOUNT1 owns 1 cluster
           | Cluster name                         |
           | 00000000-0000-0000-0000-000000000000 |
       And 4 issues are detected for cluster 00000000-0000-0000-0000-000000000000
@@ -412,7 +412,7 @@ Feature: Cluster view page with recommendations behaviour on Hybrid Cloud Consol
 
   Scenario: Expanding all recommendations on cluster view page on Hybrid Cloud Console with five recommendations and one cluster
     Given user USER1 is part of account (organization) ACCOUNT1
-      And account (organization) ACCOUNT1 owns 4 clusters
+      And account (organization) ACCOUNT1 owns 1 cluster
           | Cluster name                         |
           | 00000000-0000-0000-0000-000000000000 |
       And 4 issues are detected for cluster 00000000-0000-0000-0000-000000000000
@@ -501,7 +501,7 @@ Feature: Cluster view page with recommendations behaviour on Hybrid Cloud Consol
 
   Scenario: Collapsing all recommendations on cluster view page on Hybrid Cloud Console with five recommendations and one cluster
     Given user USER1 is part of account (organization) ACCOUNT1
-      And account (organization) ACCOUNT1 owns 4 clusters
+      And account (organization) ACCOUNT1 owns 1 cluster
           | Cluster name                         |
           | 00000000-0000-0000-0000-000000000000 |
       And 4 issues are detected for cluster 00000000-0000-0000-0000-000000000000

--- a/features/Insights_Advisor/cluster_page.feature
+++ b/features/Insights_Advisor/cluster_page.feature
@@ -18,13 +18,25 @@ Feature: Cluster view page with recommendations behaviour on Hybrid Cloud Consol
      When user looks at Hybrid Cloud Console main page
      Then menu on the left side should be displayed
       And the left menu might contain these top level items
+          | Left menu item                | Required for this test |
+          | Application and Data Services | no                     |
+          | OpenShift                     | yes                    |
+          | Red Hat Enterprise Linux      | no                     |
+          | Ansible Automation Platform   | no                     |
+     When user selects "OpenShift" from the left side menu
+     Then menu on the left side should be changed
+      And the left menu might contain these top level items
           | Left menu item           | Required for this test |
+          | Clusters                 | no                     |
           | Overview                 | no                     |
           | Releases                 | no                     |
+          | Developer Sandbox        | no                     |
           | Downloads                | no                     |
           | Advisor                  | yes                    |
+          | Vulnerability            | no                     |
           | Subscriptions            | no                     |
           | Cost Management          | no                     |
+          | Support Cases            | no                     |
           | Cluster Manager Feedback | no                     |
           | Red Hat Marketplace      | no                     |
           | Documentation            | no                     |
@@ -86,13 +98,25 @@ Feature: Cluster view page with recommendations behaviour on Hybrid Cloud Consol
      When user looks at Hybrid Cloud Console main page
      Then menu on the left side should be displayed
       And the left menu might contain these top level items
+          | Left menu item                | Required for this test |
+          | Application and Data Services | no                     |
+          | OpenShift                     | yes                    |
+          | Red Hat Enterprise Linux      | no                     |
+          | Ansible Automation Platform   | no                     |
+     When user selects "OpenShift" from the left side menu
+     Then menu on the left side should be changed
+      And the left menu might contain these top level items
           | Left menu item           | Required for this test |
+          | Clusters                 | no                     |
           | Overview                 | no                     |
           | Releases                 | no                     |
+          | Developer Sandbox        | no                     |
           | Downloads                | no                     |
           | Advisor                  | yes                    |
+          | Vulnerability            | no                     |
           | Subscriptions            | no                     |
           | Cost Management          | no                     |
+          | Support Cases            | no                     |
           | Cluster Manager Feedback | no                     |
           | Red Hat Marketplace      | no                     |
           | Documentation            | no                     |
@@ -166,13 +190,25 @@ Feature: Cluster view page with recommendations behaviour on Hybrid Cloud Consol
      When user looks at Hybrid Cloud Console main page
      Then menu on the left side should be displayed
       And the left menu might contain these top level items
+          | Left menu item                | Required for this test |
+          | Application and Data Services | no                     |
+          | OpenShift                     | yes                    |
+          | Red Hat Enterprise Linux      | no                     |
+          | Ansible Automation Platform   | no                     |
+     When user selects "OpenShift" from the left side menu
+     Then menu on the left side should be changed
+      And the left menu might contain these top level items
           | Left menu item           | Required for this test |
+          | Clusters                 | no                     |
           | Overview                 | no                     |
           | Releases                 | no                     |
+          | Developer Sandbox        | no                     |
           | Downloads                | no                     |
           | Advisor                  | yes                    |
+          | Vulnerability            | no                     |
           | Subscriptions            | no                     |
           | Cost Management          | no                     |
+          | Support Cases            | no                     |
           | Cluster Manager Feedback | no                     |
           | Red Hat Marketplace      | no                     |
           | Documentation            | no                     |
@@ -252,13 +288,25 @@ Feature: Cluster view page with recommendations behaviour on Hybrid Cloud Consol
      When user looks at Hybrid Cloud Console main page
      Then menu on the left side should be displayed
       And the left menu might contain these top level items
+          | Left menu item                | Required for this test |
+          | Application and Data Services | no                     |
+          | OpenShift                     | yes                    |
+          | Red Hat Enterprise Linux      | no                     |
+          | Ansible Automation Platform   | no                     |
+     When user selects "OpenShift" from the left side menu
+     Then menu on the left side should be changed
+      And the left menu might contain these top level items
           | Left menu item           | Required for this test |
+          | Clusters                 | no                     |
           | Overview                 | no                     |
           | Releases                 | no                     |
+          | Developer Sandbox        | no                     |
           | Downloads                | no                     |
           | Advisor                  | yes                    |
+          | Vulnerability            | no                     |
           | Subscriptions            | no                     |
           | Cost Management          | no                     |
+          | Support Cases            | no                     |
           | Cluster Manager Feedback | no                     |
           | Red Hat Marketplace      | no                     |
           | Documentation            | no                     |
@@ -340,13 +388,25 @@ Feature: Cluster view page with recommendations behaviour on Hybrid Cloud Consol
      When user looks at Hybrid Cloud Console main page
      Then menu on the left side should be displayed
       And the left menu might contain these top level items
+          | Left menu item                | Required for this test |
+          | Application and Data Services | no                     |
+          | OpenShift                     | yes                    |
+          | Red Hat Enterprise Linux      | no                     |
+          | Ansible Automation Platform   | no                     |
+     When user selects "OpenShift" from the left side menu
+     Then menu on the left side should be changed
+      And the left menu might contain these top level items
           | Left menu item           | Required for this test |
+          | Clusters                 | no                     |
           | Overview                 | no                     |
           | Releases                 | no                     |
+          | Developer Sandbox        | no                     |
           | Downloads                | no                     |
           | Advisor                  | yes                    |
+          | Vulnerability            | no                     |
           | Subscriptions            | no                     |
           | Cost Management          | no                     |
+          | Support Cases            | no                     |
           | Cluster Manager Feedback | no                     |
           | Red Hat Marketplace      | no                     |
           | Documentation            | no                     |
@@ -428,13 +488,25 @@ Feature: Cluster view page with recommendations behaviour on Hybrid Cloud Consol
      When user looks at Hybrid Cloud Console main page
      Then menu on the left side should be displayed
       And the left menu might contain these top level items
+          | Left menu item                | Required for this test |
+          | Application and Data Services | no                     |
+          | OpenShift                     | yes                    |
+          | Red Hat Enterprise Linux      | no                     |
+          | Ansible Automation Platform   | no                     |
+     When user selects "OpenShift" from the left side menu
+     Then menu on the left side should be changed
+      And the left menu might contain these top level items
           | Left menu item           | Required for this test |
+          | Clusters                 | no                     |
           | Overview                 | no                     |
           | Releases                 | no                     |
+          | Developer Sandbox        | no                     |
           | Downloads                | no                     |
           | Advisor                  | yes                    |
+          | Vulnerability            | no                     |
           | Subscriptions            | no                     |
           | Cost Management          | no                     |
+          | Support Cases            | no                     |
           | Cluster Manager Feedback | no                     |
           | Red Hat Marketplace      | no                     |
           | Documentation            | no                     |
@@ -517,13 +589,25 @@ Feature: Cluster view page with recommendations behaviour on Hybrid Cloud Consol
      When user looks at Hybrid Cloud Console main page
      Then menu on the left side should be displayed
       And the left menu might contain these top level items
+          | Left menu item                | Required for this test |
+          | Application and Data Services | no                     |
+          | OpenShift                     | yes                    |
+          | Red Hat Enterprise Linux      | no                     |
+          | Ansible Automation Platform   | no                     |
+     When user selects "OpenShift" from the left side menu
+     Then menu on the left side should be changed
+      And the left menu might contain these top level items
           | Left menu item           | Required for this test |
+          | Clusters                 | no                     |
           | Overview                 | no                     |
           | Releases                 | no                     |
+          | Developer Sandbox        | no                     |
           | Downloads                | no                     |
           | Advisor                  | yes                    |
+          | Vulnerability            | no                     |
           | Subscriptions            | no                     |
           | Cost Management          | no                     |
+          | Support Cases            | no                     |
           | Cluster Manager Feedback | no                     |
           | Red Hat Marketplace      | no                     |
           | Documentation            | no                     |

--- a/features/Insights_Advisor/cluster_page_filtering.feature
+++ b/features/Insights_Advisor/cluster_page_filtering.feature
@@ -19,13 +19,25 @@ Feature: Filtering on cluster view page with recommendations behaviour on Hybrid
      When user looks at Hybrid Cloud Console main page
      Then menu on the left side should be displayed
       And the left menu might contain these top level items
+          | Left menu item                | Required for this test |
+          | Application and Data Services | no                     |
+          | OpenShift                     | yes                    |
+          | Red Hat Enterprise Linux      | no                     |
+          | Ansible Automation Platform   | no                     |
+     When user selects "OpenShift" from the left side menu
+     Then menu on the left side should be changed
+      And the left menu might contain these top level items
           | Left menu item           | Required for this test |
+          | Clusters                 | no                     |
           | Overview                 | no                     |
           | Releases                 | no                     |
+          | Developer Sandbox        | no                     |
           | Downloads                | no                     |
           | Advisor                  | yes                    |
+          | Vulnerability            | no                     |
           | Subscriptions            | no                     |
           | Cost Management          | no                     |
+          | Support Cases            | no                     |
           | Cluster Manager Feedback | no                     |
           | Red Hat Marketplace      | no                     |
           | Documentation            | no                     |
@@ -105,13 +117,25 @@ Feature: Filtering on cluster view page with recommendations behaviour on Hybrid
      When user looks at Hybrid Cloud Console main page
      Then menu on the left side should be displayed
       And the left menu might contain these top level items
+          | Left menu item                | Required for this test |
+          | Application and Data Services | no                     |
+          | OpenShift                     | yes                    |
+          | Red Hat Enterprise Linux      | no                     |
+          | Ansible Automation Platform   | no                     |
+     When user selects "OpenShift" from the left side menu
+     Then menu on the left side should be changed
+      And the left menu might contain these top level items
           | Left menu item           | Required for this test |
+          | Clusters                 | no                     |
           | Overview                 | no                     |
           | Releases                 | no                     |
+          | Developer Sandbox        | no                     |
           | Downloads                | no                     |
           | Advisor                  | yes                    |
+          | Vulnerability            | no                     |
           | Subscriptions            | no                     |
           | Cost Management          | no                     |
+          | Support Cases            | no                     |
           | Cluster Manager Feedback | no                     |
           | Red Hat Marketplace      | no                     |
           | Documentation            | no                     |
@@ -208,13 +232,25 @@ Feature: Filtering on cluster view page with recommendations behaviour on Hybrid
      When user looks at Hybrid Cloud Console main page
      Then menu on the left side should be displayed
       And the left menu might contain these top level items
+          | Left menu item                | Required for this test |
+          | Application and Data Services | no                     |
+          | OpenShift                     | yes                    |
+          | Red Hat Enterprise Linux      | no                     |
+          | Ansible Automation Platform   | no                     |
+     When user selects "OpenShift" from the left side menu
+     Then menu on the left side should be changed
+      And the left menu might contain these top level items
           | Left menu item           | Required for this test |
+          | Clusters                 | no                     |
           | Overview                 | no                     |
           | Releases                 | no                     |
+          | Developer Sandbox        | no                     |
           | Downloads                | no                     |
           | Advisor                  | yes                    |
+          | Vulnerability            | no                     |
           | Subscriptions            | no                     |
           | Cost Management          | no                     |
+          | Support Cases            | no                     |
           | Cluster Manager Feedback | no                     |
           | Red Hat Marketplace      | no                     |
           | Documentation            | no                     |
@@ -314,13 +350,25 @@ Feature: Filtering on cluster view page with recommendations behaviour on Hybrid
      When user looks at Hybrid Cloud Console main page
      Then menu on the left side should be displayed
       And the left menu might contain these top level items
+          | Left menu item                | Required for this test |
+          | Application and Data Services | no                     |
+          | OpenShift                     | yes                    |
+          | Red Hat Enterprise Linux      | no                     |
+          | Ansible Automation Platform   | no                     |
+     When user selects "OpenShift" from the left side menu
+     Then menu on the left side should be changed
+      And the left menu might contain these top level items
           | Left menu item           | Required for this test |
+          | Clusters                 | no                     |
           | Overview                 | no                     |
           | Releases                 | no                     |
+          | Developer Sandbox        | no                     |
           | Downloads                | no                     |
           | Advisor                  | yes                    |
+          | Vulnerability            | no                     |
           | Subscriptions            | no                     |
           | Cost Management          | no                     |
+          | Support Cases            | no                     |
           | Cluster Manager Feedback | no                     |
           | Red Hat Marketplace      | no                     |
           | Documentation            | no                     |
@@ -430,13 +478,25 @@ Feature: Filtering on cluster view page with recommendations behaviour on Hybrid
      When user looks at Hybrid Cloud Console main page
      Then menu on the left side should be displayed
       And the left menu might contain these top level items
+          | Left menu item                | Required for this test |
+          | Application and Data Services | no                     |
+          | OpenShift                     | yes                    |
+          | Red Hat Enterprise Linux      | no                     |
+          | Ansible Automation Platform   | no                     |
+     When user selects "OpenShift" from the left side menu
+     Then menu on the left side should be changed
+      And the left menu might contain these top level items
           | Left menu item           | Required for this test |
+          | Clusters                 | no                     |
           | Overview                 | no                     |
           | Releases                 | no                     |
+          | Developer Sandbox        | no                     |
           | Downloads                | no                     |
           | Advisor                  | yes                    |
+          | Vulnerability            | no                     |
           | Subscriptions            | no                     |
           | Cost Management          | no                     |
+          | Support Cases            | no                     |
           | Cluster Manager Feedback | no                     |
           | Red Hat Marketplace      | no                     |
           | Documentation            | no                     |
@@ -536,13 +596,25 @@ Feature: Filtering on cluster view page with recommendations behaviour on Hybrid
      When user looks at Hybrid Cloud Console main page
      Then menu on the left side should be displayed
       And the left menu might contain these top level items
+          | Left menu item                | Required for this test |
+          | Application and Data Services | no                     |
+          | OpenShift                     | yes                    |
+          | Red Hat Enterprise Linux      | no                     |
+          | Ansible Automation Platform   | no                     |
+     When user selects "OpenShift" from the left side menu
+     Then menu on the left side should be changed
+      And the left menu might contain these top level items
           | Left menu item           | Required for this test |
+          | Clusters                 | no                     |
           | Overview                 | no                     |
           | Releases                 | no                     |
+          | Developer Sandbox        | no                     |
           | Downloads                | no                     |
           | Advisor                  | yes                    |
+          | Vulnerability            | no                     |
           | Subscriptions            | no                     |
           | Cost Management          | no                     |
+          | Support Cases            | no                     |
           | Cluster Manager Feedback | no                     |
           | Red Hat Marketplace      | no                     |
           | Documentation            | no                     |
@@ -653,13 +725,25 @@ Feature: Filtering on cluster view page with recommendations behaviour on Hybrid
      When user looks at Hybrid Cloud Console main page
      Then menu on the left side should be displayed
       And the left menu might contain these top level items
+          | Left menu item                | Required for this test |
+          | Application and Data Services | no                     |
+          | OpenShift                     | yes                    |
+          | Red Hat Enterprise Linux      | no                     |
+          | Ansible Automation Platform   | no                     |
+     When user selects "OpenShift" from the left side menu
+     Then menu on the left side should be changed
+      And the left menu might contain these top level items
           | Left menu item           | Required for this test |
+          | Clusters                 | no                     |
           | Overview                 | no                     |
           | Releases                 | no                     |
+          | Developer Sandbox        | no                     |
           | Downloads                | no                     |
           | Advisor                  | yes                    |
+          | Vulnerability            | no                     |
           | Subscriptions            | no                     |
           | Cost Management          | no                     |
+          | Support Cases            | no                     |
           | Cluster Manager Feedback | no                     |
           | Red Hat Marketplace      | no                     |
           | Documentation            | no                     |
@@ -774,13 +858,25 @@ Feature: Filtering on cluster view page with recommendations behaviour on Hybrid
      When user looks at Hybrid Cloud Console main page
      Then menu on the left side should be displayed
       And the left menu might contain these top level items
+          | Left menu item                | Required for this test |
+          | Application and Data Services | no                     |
+          | OpenShift                     | yes                    |
+          | Red Hat Enterprise Linux      | no                     |
+          | Ansible Automation Platform   | no                     |
+     When user selects "OpenShift" from the left side menu
+     Then menu on the left side should be changed
+      And the left menu might contain these top level items
           | Left menu item           | Required for this test |
+          | Clusters                 | no                     |
           | Overview                 | no                     |
           | Releases                 | no                     |
+          | Developer Sandbox        | no                     |
           | Downloads                | no                     |
           | Advisor                  | yes                    |
+          | Vulnerability            | no                     |
           | Subscriptions            | no                     |
           | Cost Management          | no                     |
+          | Support Cases            | no                     |
           | Cluster Manager Feedback | no                     |
           | Red Hat Marketplace      | no                     |
           | Documentation            | no                     |

--- a/features/Insights_Advisor/cluster_page_filtering.feature
+++ b/features/Insights_Advisor/cluster_page_filtering.feature
@@ -3,18 +3,18 @@ Feature: Filtering on cluster view page with recommendations behaviour on Hybrid
 
   Scenario: Default filtering in recommendations table on cluster view page on Hybrid Cloud Console with five recommendations and one cluster
     Given user USER1 is part of account (organization) ACCOUNT1
-      And account (organization) ACCOUNT1 owns 4 clusters
+      And account (organization) ACCOUNT1 owns 1 cluster
           | Cluster name                         |
           | 00000000-0000-0000-0000-000000000000 |
       And 4 issues are detected for cluster 00000000-0000-0000-0000-000000000000
-          | Title    | Modified    | Total risk | Category             | Status   |
-          | Bug12345 | 10 days ago | Critical   | Service Availability | enabled  |
-          | Abc12345 | 10 days ago | Important  | Performance          | enabled  |
-          | Xyz12345 | 10 days ago | Moderate   | Fault Tolerance      | disabled |
-          | Uvw12345 | 10 days ago | Low        | Security             | disabled |
+          | Title    | Modified    | Total risk | Risk of change | Category             | Status   |
+          | Bug12345 | 10 days ago | Critical   | High           | Service Availability | enabled  |
+          | Abc12345 | 10 days ago | Important  | Moderate       | Performance          | enabled  |
+          | Xyz12345 | 10 days ago | Moderate   | Low            | Fault Tolerance      | disabled |
+          | Uvw12345 | 10 days ago | Low        | Very low       | Security             | disabled |
       And 1 another issue without cluster hit exists
-          | Title    | Modified    | Total risk |
-          | Nohit    | 10 days ago | Critical   |
+          | Title    | Modified    | Total risk | Risk of change | Category             |
+          | Nohit    | 10 days ago | Critical   | High           | Service Availability |
       And the user USER1 is already logged in into Hybrid Cloud Console
      When user looks at Hybrid Cloud Console main page
      Then menu on the left side should be displayed
@@ -38,20 +38,21 @@ Feature: Filtering on cluster view page with recommendations behaviour on Hybrid
      When user select "Recommendations" menu item from this sub-menu
      Then an "Advisor recommendations" page should be displayed right of the left menu bar
       And that table should contain following four rows in that order
-          | Name        | Modified    | Total risk | Clusters |
-          | Bug12345    | 10 days ago | Critical   | 1        |
-          | Abc12345    | 10 days ago | Important  | 1        |
-          | Xyz12345    | 10 days ago | Moderate   | 1        |
-          | Uvw12345    | 10 days ago | Low        | 1        |
+          | Name        | Modified    | Category             | Total risk | Risk of change | Clusters |
+          | Bug12345    | 10 days ago | Service Availability | Critical   | High           | 1        |
+          | Abc12345    | 10 days ago | Performance          | Important  | Moderate       | 1        |
+          | Xyz12345    | 10 days ago | Fault Tolerance      | Moderate   | Low            | 1        |
+          | Uvw12345    | 10 days ago | Security             | Low        | Very low       | 1        |
      When user clicks on an "Bug12345" link
      Then new page with additional information about selected recommendation should be displayed
       And the following values needs to be displayed
-          | Value type  | Content             | Displayed as              | Optional |
-          | Description | Textual description | Text                      | no       |
-          | KB article  | Link to KB article  | Link                      | yes      |
-          | Total risk  | Important           | Widget (icon+label)       | no       |
-          | Likelihood  | High                | Widget (thermometer-like) | no       |
-          | Impact      | High                | Widget (thermometer-like) | no       |
+          | Value type     | Content             | Displayed as              | Optional |
+          | Description    | Textual description | Text                      | no       |
+          | KB article     | Link to KB article  | Link                      | yes      |
+          | Total risk     | Important           | Widget (icon+label)       | no       |
+          | Likelihood     | High                | Widget (thermometer-like) | no       |
+          | Impact         | High                | Widget (thermometer-like) | no       |
+          | Risk of change | Moderate            | Widget (icon+label)       | no       |
       And "Affected clusters" table needs to be displayed below additional info
           | Name                                 | Clickable (link) |
           | 00000000-0000-0000-0000-000000000000 | yes              |
@@ -88,18 +89,18 @@ Feature: Filtering on cluster view page with recommendations behaviour on Hybrid
 
   Scenario: Filtering by description in recommendations table on cluster view page on Hybrid Cloud Console with five recommendations and one cluster
     Given user USER1 is part of account (organization) ACCOUNT1
-      And account (organization) ACCOUNT1 owns 4 clusters
+      And account (organization) ACCOUNT1 owns 1 cluster
           | Cluster name                         |
           | 00000000-0000-0000-0000-000000000000 |
       And 4 issues are detected for cluster 00000000-0000-0000-0000-000000000000
-          | Title    | Modified    | Total risk | Category             | Status   |
-          | Bug12345 | 10 days ago | Critical   | Service Availability | enabled  |
-          | Abc12345 | 10 days ago | Important  | Performance          | enabled  |
-          | Xyz12345 | 10 days ago | Moderate   | Fault Tolerance      | disabled |
-          | Uvw12345 | 10 days ago | Low        | Security             | disabled |
+          | Title    | Modified    | Total risk | Risk of change | Category             | Status   |
+          | Bug12345 | 10 days ago | Critical   | High           | Service Availability | enabled  |
+          | Abc12345 | 10 days ago | Important  | Moderate       | Performance          | enabled  |
+          | Xyz12345 | 10 days ago | Moderate   | Low            | Fault Tolerance      | disabled |
+          | Uvw12345 | 10 days ago | Low        | Very low       | Security             | disabled |
       And 1 another issue without cluster hit exists
-          | Title    | Modified    | Total risk |
-          | Nohit    | 10 days ago | Critical   |
+          | Title    | Modified    | Total risk | Risk of change | Category             |
+          | Nohit    | 10 days ago | Critical   | High           | Service Availability |
       And the user USER1 is already logged in into Hybrid Cloud Console
      When user looks at Hybrid Cloud Console main page
      Then menu on the left side should be displayed
@@ -123,20 +124,21 @@ Feature: Filtering on cluster view page with recommendations behaviour on Hybrid
      When user select "Recommendations" menu item from this sub-menu
      Then an "Advisor recommendations" page should be displayed right of the left menu bar
       And that table should contain following four rows in that order
-          | Name        | Modified    | Total risk | Clusters |
-          | Bug12345    | 10 days ago | Critical   | 1        |
-          | Abc12345    | 10 days ago | Important  | 1        |
-          | Xyz12345    | 10 days ago | Moderate   | 1        |
-          | Uvw12345    | 10 days ago | Low        | 1        |
+          | Name        | Modified    | Category             | Total risk | Risk of change | Clusters |
+          | Bug12345    | 10 days ago | Service Availability | Critical   | High           | 1        |
+          | Abc12345    | 10 days ago | Performance          | Important  | Moderate       | 1        |
+          | Xyz12345    | 10 days ago | Fault Tolerance      | Moderate   | Low            | 1        |
+          | Uvw12345    | 10 days ago | Security             | Low        | Very low       | 1        |
      When user clicks on an "Bug12345" link
      Then new page with additional information about selected recommendation should be displayed
       And the following values needs to be displayed
-          | Value type  | Content             | Displayed as              | Optional |
-          | Description | Textual description | Text                      | no       |
-          | KB article  | Link to KB article  | Link                      | yes      |
-          | Total risk  | Important           | Widget (icon+label)       | no       |
-          | Likelihood  | High                | Widget (thermometer-like) | no       |
-          | Impact      | High                | Widget (thermometer-like) | no       |
+          | Value type     | Content             | Displayed as              | Optional |
+          | Description    | Textual description | Text                      | no       |
+          | KB article     | Link to KB article  | Link                      | yes      |
+          | Total risk     | Important           | Widget (icon+label)       | no       |
+          | Likelihood     | High                | Widget (thermometer-like) | no       |
+          | Impact         | High                | Widget (thermometer-like) | no       |
+          | Risk of change | Moderate            | Widget (icon+label)       | no       |
       And "Affected clusters" table needs to be displayed below additional info
           | Name                                 | Clickable (link) |
           | 00000000-0000-0000-0000-000000000000 | yes              |
@@ -190,18 +192,18 @@ Feature: Filtering on cluster view page with recommendations behaviour on Hybrid
 
   Scenario: Filtering by total risk in recommendations table on cluster view page on Hybrid Cloud Console with five recommendations and one cluster
     Given user USER1 is part of account (organization) ACCOUNT1
-      And account (organization) ACCOUNT1 owns 4 clusters
+      And account (organization) ACCOUNT1 owns 1 cluster
           | Cluster name                         |
           | 00000000-0000-0000-0000-000000000000 |
       And 4 issues are detected for cluster 00000000-0000-0000-0000-000000000000
-          | Title    | Modified    | Total risk | Category             | Status   |
-          | Bug12345 | 10 days ago | Critical   | Service Availability | enabled  |
-          | Abc12345 | 10 days ago | Important  | Performance          | enabled  |
-          | Xyz12345 | 10 days ago | Moderate   | Fault Tolerance      | disabled |
-          | Uvw12345 | 10 days ago | Low        | Security             | disabled |
+          | Title    | Modified    | Total risk | Risk of change | Category             | Status   |
+          | Bug12345 | 10 days ago | Critical   | High           | Service Availability | enabled  |
+          | Abc12345 | 10 days ago | Important  | Moderate       | Performance          | enabled  |
+          | Xyz12345 | 10 days ago | Moderate   | Low            | Fault Tolerance      | disabled |
+          | Uvw12345 | 10 days ago | Low        | Very low       | Security             | disabled |
       And 1 another issue without cluster hit exists
-          | Title    | Modified    | Total risk |
-          | Nohit    | 10 days ago | Critical   |
+          | Title    | Modified    | Total risk | Risk of change | Category             |
+          | Nohit    | 10 days ago | Critical   | High           | Service Availability |
       And the user USER1 is already logged in into Hybrid Cloud Console
      When user looks at Hybrid Cloud Console main page
      Then menu on the left side should be displayed
@@ -225,20 +227,21 @@ Feature: Filtering on cluster view page with recommendations behaviour on Hybrid
      When user select "Recommendations" menu item from this sub-menu
      Then an "Advisor recommendations" page should be displayed right of the left menu bar
       And that table should contain following four rows in that order
-          | Name        | Modified    | Total risk | Clusters |
-          | Bug12345    | 10 days ago | Critical   | 1        |
-          | Abc12345    | 10 days ago | Important  | 1        |
-          | Xyz12345    | 10 days ago | Moderate   | 1        |
-          | Uvw12345    | 10 days ago | Low        | 1        |
+          | Name        | Modified    | Category             | Total risk | Risk of change | Clusters |
+          | Bug12345    | 10 days ago | Service Availability | Critical   | High           | 1        |
+          | Abc12345    | 10 days ago | Performance          | Important  | Moderate       | 1        |
+          | Xyz12345    | 10 days ago | Fault Tolerance      | Moderate   | Low            | 1        |
+          | Uvw12345    | 10 days ago | Security             | Low        | Very low       | 1        |
      When user clicks on an "Bug12345" link
      Then new page with additional information about selected recommendation should be displayed
       And the following values needs to be displayed
-          | Value type  | Content             | Displayed as              | Optional |
-          | Description | Textual description | Text                      | no       |
-          | KB article  | Link to KB article  | Link                      | yes      |
-          | Total risk  | Important           | Widget (icon+label)       | no       |
-          | Likelihood  | High                | Widget (thermometer-like) | no       |
-          | Impact      | High                | Widget (thermometer-like) | no       |
+          | Value type     | Content             | Displayed as              | Optional |
+          | Description    | Textual description | Text                      | no       |
+          | KB article     | Link to KB article  | Link                      | yes      |
+          | Total risk     | Important           | Widget (icon+label)       | no       |
+          | Likelihood     | High                | Widget (thermometer-like) | no       |
+          | Impact         | High                | Widget (thermometer-like) | no       |
+          | Risk of change | Moderate            | Widget (icon+label)       | no       |
       And "Affected clusters" table needs to be displayed below additional info
           | Name                                 | Clickable (link) |
           | 00000000-0000-0000-0000-000000000000 | yes              |
@@ -295,18 +298,18 @@ Feature: Filtering on cluster view page with recommendations behaviour on Hybrid
 
   Scenario: Filtering by multiple total risk values in recommendations table on cluster view page on Hybrid Cloud Console with five recommendations and one cluster
     Given user USER1 is part of account (organization) ACCOUNT1
-      And account (organization) ACCOUNT1 owns 4 clusters
+      And account (organization) ACCOUNT1 owns 1 cluster
           | Cluster name                         |
           | 00000000-0000-0000-0000-000000000000 |
       And 4 issues are detected for cluster 00000000-0000-0000-0000-000000000000
-          | Title    | Modified    | Total risk | Category             | Status   |
-          | Bug12345 | 10 days ago | Critical   | Service Availability | enabled  |
-          | Abc12345 | 10 days ago | Important  | Performance          | enabled  |
-          | Xyz12345 | 10 days ago | Moderate   | Fault Tolerance      | disabled |
-          | Uvw12345 | 10 days ago | Low        | Security             | disabled |
+          | Title    | Modified    | Total risk | Risk of change | Category             | Status   |
+          | Bug12345 | 10 days ago | Critical   | High           | Service Availability | enabled  |
+          | Abc12345 | 10 days ago | Important  | Moderate       | Performance          | enabled  |
+          | Xyz12345 | 10 days ago | Moderate   | Low            | Fault Tolerance      | disabled |
+          | Uvw12345 | 10 days ago | Low        | Very low       | Security             | disabled |
       And 1 another issue without cluster hit exists
-          | Title    | Modified    | Total risk |
-          | Nohit    | 10 days ago | Critical   |
+          | Title    | Modified    | Total risk | Risk of change | Category             |
+          | Nohit    | 10 days ago | Critical   | High           | Service Availability |
       And the user USER1 is already logged in into Hybrid Cloud Console
      When user looks at Hybrid Cloud Console main page
      Then menu on the left side should be displayed
@@ -330,20 +333,21 @@ Feature: Filtering on cluster view page with recommendations behaviour on Hybrid
      When user select "Recommendations" menu item from this sub-menu
      Then an "Advisor recommendations" page should be displayed right of the left menu bar
       And that table should contain following four rows in that order
-          | Name        | Modified    | Total risk | Clusters |
-          | Bug12345    | 10 days ago | Critical   | 1        |
-          | Abc12345    | 10 days ago | Important  | 1        |
-          | Xyz12345    | 10 days ago | Moderate   | 1        |
-          | Uvw12345    | 10 days ago | Low        | 1        |
+          | Name        | Modified    | Category             | Total risk | Risk of change | Clusters |
+          | Bug12345    | 10 days ago | Service Availability | Critical   | High           | 1        |
+          | Abc12345    | 10 days ago | Performance          | Important  | Moderate       | 1        |
+          | Xyz12345    | 10 days ago | Fault Tolerance      | Moderate   | Low            | 1        |
+          | Uvw12345    | 10 days ago | Security             | Low        | Very low       | 1        |
      When user clicks on an "Bug12345" link
      Then new page with additional information about selected recommendation should be displayed
       And the following values needs to be displayed
-          | Value type  | Content             | Displayed as              | Optional |
-          | Description | Textual description | Text                      | no       |
-          | KB article  | Link to KB article  | Link                      | yes      |
-          | Total risk  | Important           | Widget (icon+label)       | no       |
-          | Likelihood  | High                | Widget (thermometer-like) | no       |
-          | Impact      | High                | Widget (thermometer-like) | no       |
+          | Value type     | Content             | Displayed as              | Optional |
+          | Description    | Textual description | Text                      | no       |
+          | KB article     | Link to KB article  | Link                      | yes      |
+          | Total risk     | Important           | Widget (icon+label)       | no       |
+          | Likelihood     | High                | Widget (thermometer-like) | no       |
+          | Impact         | High                | Widget (thermometer-like) | no       |
+          | Risk of change | Moderate            | Widget (icon+label)       | no       |
       And "Affected clusters" table needs to be displayed below additional info
           | Name                                 | Clickable (link) |
           | 00000000-0000-0000-0000-000000000000 | yes              |
@@ -410,18 +414,18 @@ Feature: Filtering on cluster view page with recommendations behaviour on Hybrid
 
   Scenario: Filtering by category in recommendations table on cluster view page on Hybrid Cloud Console with five recommendations and one cluster
     Given user USER1 is part of account (organization) ACCOUNT1
-      And account (organization) ACCOUNT1 owns 4 clusters
+      And account (organization) ACCOUNT1 owns 1 cluster
           | Cluster name                         |
           | 00000000-0000-0000-0000-000000000000 |
       And 4 issues are detected for cluster 00000000-0000-0000-0000-000000000000
-          | Title    | Modified    | Total risk | Category             | Status   |
-          | Bug12345 | 10 days ago | Critical   | Service Availability | enabled  |
-          | Abc12345 | 10 days ago | Important  | Performance          | enabled  |
-          | Xyz12345 | 10 days ago | Moderate   | Fault Tolerance      | disabled |
-          | Uvw12345 | 10 days ago | Low        | Security             | disabled |
+          | Title    | Modified    | Total risk | Risk of change | Category             | Status   |
+          | Bug12345 | 10 days ago | Critical   | High           | Service Availability | enabled  |
+          | Abc12345 | 10 days ago | Important  | Moderate       | Performance          | enabled  |
+          | Xyz12345 | 10 days ago | Moderate   | Low            | Fault Tolerance      | disabled |
+          | Uvw12345 | 10 days ago | Low        | Very low       | Security             | disabled |
       And 1 another issue without cluster hit exists
-          | Title    | Modified    | Total risk |
-          | Nohit    | 10 days ago | Critical   |
+          | Title    | Modified    | Total risk | Risk of change | Category             |
+          | Nohit    | 10 days ago | Critical   | High           | Service Availability |
       And the user USER1 is already logged in into Hybrid Cloud Console
      When user looks at Hybrid Cloud Console main page
      Then menu on the left side should be displayed
@@ -445,20 +449,21 @@ Feature: Filtering on cluster view page with recommendations behaviour on Hybrid
      When user select "Recommendations" menu item from this sub-menu
      Then an "Advisor recommendations" page should be displayed right of the left menu bar
       And that table should contain following four rows in that order
-          | Name        | Modified    | Total risk | Clusters |
-          | Bug12345    | 10 days ago | Critical   | 1        |
-          | Abc12345    | 10 days ago | Important  | 1        |
-          | Xyz12345    | 10 days ago | Moderate   | 1        |
-          | Uvw12345    | 10 days ago | Low        | 1        |
+          | Name        | Modified    | Category             | Total risk | Risk of change | Clusters |
+          | Bug12345    | 10 days ago | Service Availability | Critical   | High           | 1        |
+          | Abc12345    | 10 days ago | Performance          | Important  | Moderate       | 1        |
+          | Xyz12345    | 10 days ago | Fault Tolerance      | Moderate   | Low            | 1        |
+          | Uvw12345    | 10 days ago | Security             | Low        | Very low       | 1        |
      When user clicks on an "Bug12345" link
      Then new page with additional information about selected recommendation should be displayed
       And the following values needs to be displayed
-          | Value type  | Content             | Displayed as              | Optional |
-          | Description | Textual description | Text                      | no       |
-          | KB article  | Link to KB article  | Link                      | yes      |
-          | Total risk  | Important           | Widget (icon+label)       | no       |
-          | Likelihood  | High                | Widget (thermometer-like) | no       |
-          | Impact      | High                | Widget (thermometer-like) | no       |
+          | Value type     | Content             | Displayed as              | Optional |
+          | Description    | Textual description | Text                      | no       |
+          | KB article     | Link to KB article  | Link                      | yes      |
+          | Total risk     | Important           | Widget (icon+label)       | no       |
+          | Likelihood     | High                | Widget (thermometer-like) | no       |
+          | Impact         | High                | Widget (thermometer-like) | no       |
+          | Risk of change | Moderate            | Widget (icon+label)       | no       |
       And "Affected clusters" table needs to be displayed below additional info
           | Name                                 | Clickable (link) |
           | 00000000-0000-0000-0000-000000000000 | yes              |
@@ -515,18 +520,18 @@ Feature: Filtering on cluster view page with recommendations behaviour on Hybrid
 
   Scenario: Filtering by multiple categories in recommendations table on cluster view page on Hybrid Cloud Console with five recommendations and one cluster
     Given user USER1 is part of account (organization) ACCOUNT1
-      And account (organization) ACCOUNT1 owns 4 clusters
+      And account (organization) ACCOUNT1 owns 1 cluster
           | Cluster name                         |
           | 00000000-0000-0000-0000-000000000000 |
       And 4 issues are detected for cluster 00000000-0000-0000-0000-000000000000
-          | Title    | Modified    | Total risk | Category             | Status   |
-          | Bug12345 | 10 days ago | Critical   | Service Availability | enabled  |
-          | Abc12345 | 10 days ago | Important  | Performance          | enabled  |
-          | Xyz12345 | 10 days ago | Moderate   | Fault Tolerance      | disabled |
-          | Uvw12345 | 10 days ago | Low        | Security             | disabled |
+          | Title    | Modified    | Total risk | Risk of change | Category             | Status   |
+          | Bug12345 | 10 days ago | Critical   | High           | Service Availability | enabled  |
+          | Abc12345 | 10 days ago | Important  | Moderate       | Performance          | enabled  |
+          | Xyz12345 | 10 days ago | Moderate   | Low            | Fault Tolerance      | disabled |
+          | Uvw12345 | 10 days ago | Low        | Very low       | Security             | disabled |
       And 1 another issue without cluster hit exists
-          | Title    | Modified    | Total risk |
-          | Nohit    | 10 days ago | Critical   |
+          | Title    | Modified    | Total risk | Risk of change | Category             |
+          | Nohit    | 10 days ago | Critical   | High           | Service Availability |
       And the user USER1 is already logged in into Hybrid Cloud Console
      When user looks at Hybrid Cloud Console main page
      Then menu on the left side should be displayed
@@ -550,20 +555,21 @@ Feature: Filtering on cluster view page with recommendations behaviour on Hybrid
      When user select "Recommendations" menu item from this sub-menu
      Then an "Advisor recommendations" page should be displayed right of the left menu bar
       And that table should contain following four rows in that order
-          | Name        | Modified    | Total risk | Clusters |
-          | Bug12345    | 10 days ago | Critical   | 1        |
-          | Abc12345    | 10 days ago | Important  | 1        |
-          | Xyz12345    | 10 days ago | Moderate   | 1        |
-          | Uvw12345    | 10 days ago | Low        | 1        |
+          | Name        | Modified    | Category             | Total risk | Risk of change | Clusters |
+          | Bug12345    | 10 days ago | Service Availability | Critical   | High           | 1        |
+          | Abc12345    | 10 days ago | Performance          | Important  | Moderate       | 1        |
+          | Xyz12345    | 10 days ago | Fault Tolerance      | Moderate   | Low            | 1        |
+          | Uvw12345    | 10 days ago | Security             | Low        | Very low       | 1        |
      When user clicks on an "Bug12345" link
      Then new page with additional information about selected recommendation should be displayed
       And the following values needs to be displayed
-          | Value type  | Content             | Displayed as              | Optional |
-          | Description | Textual description | Text                      | no       |
-          | KB article  | Link to KB article  | Link                      | yes      |
-          | Total risk  | Important           | Widget (icon+label)       | no       |
-          | Likelihood  | High                | Widget (thermometer-like) | no       |
-          | Impact      | High                | Widget (thermometer-like) | no       |
+          | Value type     | Content             | Displayed as              | Optional |
+          | Description    | Textual description | Text                      | no       |
+          | KB article     | Link to KB article  | Link                      | yes      |
+          | Total risk     | Important           | Widget (icon+label)       | no       |
+          | Likelihood     | High                | Widget (thermometer-like) | no       |
+          | Impact         | High                | Widget (thermometer-like) | no       |
+          | Risk of change | Moderate            | Widget (icon+label)       | no       |
       And "Affected clusters" table needs to be displayed below additional info
           | Name                                 | Clickable (link) |
           | 00000000-0000-0000-0000-000000000000 | yes              |
@@ -631,18 +637,18 @@ Feature: Filtering on cluster view page with recommendations behaviour on Hybrid
 
   Scenario: Filtering by status in recommendations table on cluster view page on Hybrid Cloud Console with five recommendations and one cluster
     Given user USER1 is part of account (organization) ACCOUNT1
-      And account (organization) ACCOUNT1 owns 4 clusters
+      And account (organization) ACCOUNT1 owns 1 cluster
           | Cluster name                         |
           | 00000000-0000-0000-0000-000000000000 |
       And 4 issues are detected for cluster 00000000-0000-0000-0000-000000000000
-          | Title    | Modified    | Total risk | Category             | Status   |
-          | Bug12345 | 10 days ago | Critical   | Service Availability | enabled  |
-          | Abc12345 | 10 days ago | Important  | Performance          | enabled  |
-          | Xyz12345 | 10 days ago | Moderate   | Fault Tolerance      | disabled |
-          | Uvw12345 | 10 days ago | Low        | Security             | disabled |
+          | Title    | Modified    | Total risk | Risk of change | Category             | Status   |
+          | Bug12345 | 10 days ago | Critical   | High           | Service Availability | enabled  |
+          | Abc12345 | 10 days ago | Important  | Moderate       | Performance          | enabled  |
+          | Xyz12345 | 10 days ago | Moderate   | Low            | Fault Tolerance      | disabled |
+          | Uvw12345 | 10 days ago | Low        | Very low       | Security             | disabled |
       And 1 another issue without cluster hit exists
-          | Title    | Modified    | Total risk |
-          | Nohit    | 10 days ago | Critical   |
+          | Title    | Modified    | Total risk | Risk of change | Category             |
+          | Nohit    | 10 days ago | Critical   | High           | Service Availability |
       And the user USER1 is already logged in into Hybrid Cloud Console
      When user looks at Hybrid Cloud Console main page
      Then menu on the left side should be displayed
@@ -666,20 +672,21 @@ Feature: Filtering on cluster view page with recommendations behaviour on Hybrid
      When user select "Recommendations" menu item from this sub-menu
      Then an "Advisor recommendations" page should be displayed right of the left menu bar
       And that table should contain following four rows in that order
-          | Name        | Modified    | Total risk | Clusters |
-          | Bug12345    | 10 days ago | Critical   | 1        |
-          | Abc12345    | 10 days ago | Important  | 1        |
-          | Xyz12345    | 10 days ago | Moderate   | 1        |
-          | Uvw12345    | 10 days ago | Low        | 1        |
+          | Name        | Modified    | Category             | Total risk | Risk of change | Clusters |
+          | Bug12345    | 10 days ago | Service Availability | Critical   | High           | 1        |
+          | Abc12345    | 10 days ago | Performance          | Important  | Moderate       | 1        |
+          | Xyz12345    | 10 days ago | Fault Tolerance      | Moderate   | Low            | 1        |
+          | Uvw12345    | 10 days ago | Security             | Low        | Very low       | 1        |
      When user clicks on an "Bug12345" link
      Then new page with additional information about selected recommendation should be displayed
       And the following values needs to be displayed
-          | Value type  | Content             | Displayed as              | Optional |
-          | Description | Textual description | Text                      | no       |
-          | KB article  | Link to KB article  | Link                      | yes      |
-          | Total risk  | Important           | Widget (icon+label)       | no       |
-          | Likelihood  | High                | Widget (thermometer-like) | no       |
-          | Impact      | High                | Widget (thermometer-like) | no       |
+          | Value type     | Content             | Displayed as              | Optional |
+          | Description    | Textual description | Text                      | no       |
+          | KB article     | Link to KB article  | Link                      | yes      |
+          | Total risk     | Important           | Widget (icon+label)       | no       |
+          | Likelihood     | High                | Widget (thermometer-like) | no       |
+          | Impact         | High                | Widget (thermometer-like) | no       |
+          | Risk of change | Moderate            | Widget (icon+label)       | no       |
       And "Affected clusters" table needs to be displayed below additional info
           | Name                                 | Clickable (link) |
           | 00000000-0000-0000-0000-000000000000 | yes              |
@@ -751,18 +758,18 @@ Feature: Filtering on cluster view page with recommendations behaviour on Hybrid
 
   Scenario: Filtering by status all in recommendations table on cluster view page on Hybrid Cloud Console with five recommendations and one cluster
     Given user USER1 is part of account (organization) ACCOUNT1
-      And account (organization) ACCOUNT1 owns 4 clusters
+      And account (organization) ACCOUNT1 owns 1 cluster
           | Cluster name                         |
           | 00000000-0000-0000-0000-000000000000 |
       And 4 issues are detected for cluster 00000000-0000-0000-0000-000000000000
-          | Title    | Modified    | Total risk | Category             | Status   |
-          | Bug12345 | 10 days ago | Critical   | Service Availability | enabled  |
-          | Abc12345 | 10 days ago | Important  | Performance          | enabled  |
-          | Xyz12345 | 10 days ago | Moderate   | Fault Tolerance      | disabled |
-          | Uvw12345 | 10 days ago | Low        | Security             | disabled |
+          | Title    | Modified    | Total risk | Risk of change | Category             | Status   |
+          | Bug12345 | 10 days ago | Critical   | High           | Service Availability | enabled  |
+          | Abc12345 | 10 days ago | Important  | Moderate       | Performance          | enabled  |
+          | Xyz12345 | 10 days ago | Moderate   | Low            | Fault Tolerance      | disabled |
+          | Uvw12345 | 10 days ago | Low        | Very low       | Security             | disabled |
       And 1 another issue without cluster hit exists
-          | Title    | Modified    | Total risk |
-          | Nohit    | 10 days ago | Critical   |
+          | Title    | Modified    | Total risk | Risk of change | Category             |
+          | Nohit    | 10 days ago | Critical   | High           | Service Availability |
       And the user USER1 is already logged in into Hybrid Cloud Console
      When user looks at Hybrid Cloud Console main page
      Then menu on the left side should be displayed
@@ -786,20 +793,21 @@ Feature: Filtering on cluster view page with recommendations behaviour on Hybrid
      When user select "Recommendations" menu item from this sub-menu
      Then an "Advisor recommendations" page should be displayed right of the left menu bar
       And that table should contain following four rows in that order
-          | Name        | Modified    | Total risk | Clusters |
-          | Bug12345    | 10 days ago | Critical   | 1        |
-          | Abc12345    | 10 days ago | Important  | 1        |
-          | Xyz12345    | 10 days ago | Moderate   | 1        |
-          | Uvw12345    | 10 days ago | Low        | 1        |
+          | Name        | Modified    | Category             | Total risk | Risk of change | Clusters |
+          | Bug12345    | 10 days ago | Service Availability | Critical   | High           | 1        |
+          | Abc12345    | 10 days ago | Performance          | Important  | Moderate       | 1        |
+          | Xyz12345    | 10 days ago | Fault Tolerance      | Moderate   | Low            | 1        |
+          | Uvw12345    | 10 days ago | Security             | Low        | Very low       | 1        |
      When user clicks on an "Bug12345" link
      Then new page with additional information about selected recommendation should be displayed
       And the following values needs to be displayed
-          | Value type  | Content             | Displayed as              | Optional |
-          | Description | Textual description | Text                      | no       |
-          | KB article  | Link to KB article  | Link                      | yes      |
-          | Total risk  | Important           | Widget (icon+label)       | no       |
-          | Likelihood  | High                | Widget (thermometer-like) | no       |
-          | Impact      | High                | Widget (thermometer-like) | no       |
+          | Value type     | Content             | Displayed as              | Optional |
+          | Description    | Textual description | Text                      | no       |
+          | KB article     | Link to KB article  | Link                      | yes      |
+          | Total risk     | Important           | Widget (icon+label)       | no       |
+          | Likelihood     | High                | Widget (thermometer-like) | no       |
+          | Impact         | High                | Widget (thermometer-like) | no       |
+          | Risk of change | Moderate            | Widget (icon+label)       | no       |
       And "Affected clusters" table needs to be displayed below additional info
           | Name                                 | Clickable (link) |
           | 00000000-0000-0000-0000-000000000000 | yes              |

--- a/features/Insights_Advisor/cluster_page_sorting.feature
+++ b/features/Insights_Advisor/cluster_page_sorting.feature
@@ -19,13 +19,25 @@ Feature: Sorting on cluster view page with recommendations behaviour on Hybrid C
      When user looks at Hybrid Cloud Console main page
      Then menu on the left side should be displayed
       And the left menu might contain these top level items
+          | Left menu item                | Required for this test |
+          | Application and Data Services | no                     |
+          | OpenShift                     | yes                    |
+          | Red Hat Enterprise Linux      | no                     |
+          | Ansible Automation Platform   | no                     |
+     When user selects "OpenShift" from the left side menu
+     Then menu on the left side should be changed
+      And the left menu might contain these top level items
           | Left menu item           | Required for this test |
+          | Clusters                 | no                     |
           | Overview                 | no                     |
           | Releases                 | no                     |
+          | Developer Sandbox        | no                     |
           | Downloads                | no                     |
           | Advisor                  | yes                    |
+          | Vulnerability            | no                     |
           | Subscriptions            | no                     |
           | Cost Management          | no                     |
+          | Support Cases            | no                     |
           | Cluster Manager Feedback | no                     |
           | Red Hat Marketplace      | no                     |
           | Documentation            | no                     |
@@ -99,13 +111,25 @@ Feature: Sorting on cluster view page with recommendations behaviour on Hybrid C
      When user looks at Hybrid Cloud Console main page
      Then menu on the left side should be displayed
       And the left menu might contain these top level items
+          | Left menu item                | Required for this test |
+          | Application and Data Services | no                     |
+          | OpenShift                     | yes                    |
+          | Red Hat Enterprise Linux      | no                     |
+          | Ansible Automation Platform   | no                     |
+     When user selects "OpenShift" from the left side menu
+     Then menu on the left side should be changed
+      And the left menu might contain these top level items
           | Left menu item           | Required for this test |
+          | Clusters                 | no                     |
           | Overview                 | no                     |
           | Releases                 | no                     |
+          | Developer Sandbox        | no                     |
           | Downloads                | no                     |
           | Advisor                  | yes                    |
+          | Vulnerability            | no                     |
           | Subscriptions            | no                     |
           | Cost Management          | no                     |
+          | Support Cases            | no                     |
           | Cluster Manager Feedback | no                     |
           | Red Hat Marketplace      | no                     |
           | Documentation            | no                     |
@@ -203,13 +227,25 @@ Feature: Sorting on cluster view page with recommendations behaviour on Hybrid C
      When user looks at Hybrid Cloud Console main page
      Then menu on the left side should be displayed
       And the left menu might contain these top level items
+          | Left menu item                | Required for this test |
+          | Application and Data Services | no                     |
+          | OpenShift                     | yes                    |
+          | Red Hat Enterprise Linux      | no                     |
+          | Ansible Automation Platform   | no                     |
+     When user selects "OpenShift" from the left side menu
+     Then menu on the left side should be changed
+      And the left menu might contain these top level items
           | Left menu item           | Required for this test |
+          | Clusters                 | no                     |
           | Overview                 | no                     |
           | Releases                 | no                     |
+          | Developer Sandbox        | no                     |
           | Downloads                | no                     |
           | Advisor                  | yes                    |
+          | Vulnerability            | no                     |
           | Subscriptions            | no                     |
           | Cost Management          | no                     |
+          | Support Cases            | no                     |
           | Cluster Manager Feedback | no                     |
           | Red Hat Marketplace      | no                     |
           | Documentation            | no                     |
@@ -307,13 +343,25 @@ Feature: Sorting on cluster view page with recommendations behaviour on Hybrid C
      When user looks at Hybrid Cloud Console main page
      Then menu on the left side should be displayed
       And the left menu might contain these top level items
+          | Left menu item                | Required for this test |
+          | Application and Data Services | no                     |
+          | OpenShift                     | yes                    |
+          | Red Hat Enterprise Linux      | no                     |
+          | Ansible Automation Platform   | no                     |
+     When user selects "OpenShift" from the left side menu
+     Then menu on the left side should be changed
+      And the left menu might contain these top level items
           | Left menu item           | Required for this test |
+          | Clusters                 | no                     |
           | Overview                 | no                     |
           | Releases                 | no                     |
+          | Developer Sandbox        | no                     |
           | Downloads                | no                     |
           | Advisor                  | yes                    |
+          | Vulnerability            | no                     |
           | Subscriptions            | no                     |
           | Cost Management          | no                     |
+          | Support Cases            | no                     |
           | Cluster Manager Feedback | no                     |
           | Red Hat Marketplace      | no                     |
           | Documentation            | no                     |

--- a/features/Insights_Advisor/cluster_page_sorting.feature
+++ b/features/Insights_Advisor/cluster_page_sorting.feature
@@ -7,14 +7,14 @@ Feature: Sorting on cluster view page with recommendations behaviour on Hybrid C
           | Cluster name                         |
           | 00000000-0000-0000-0000-000000000000 |
       And 4 issues are detected for cluster 00000000-0000-0000-0000-000000000000
-          | Title    | Modified    | Total risk |
-          | Bug12345 | 10 days ago | Critical   |
-          | Abc12345 | 10 days ago | Important  |
-          | Xyz12345 | 10 days ago | Moderate   |
-          | Uvw12345 | 10 days ago | Low        |
+          | Title    | Modified    | Total risk | Risk of change | Category             |
+          | Bug12345 | 10 days ago | Critical   | High           | Service Availability |
+          | Abc12345 | 10 days ago | Important  | Moderate       | Performance          |
+          | Xyz12345 | 10 days ago | Moderate   | Low            | Fault Tolerance      |
+          | Uvw12345 | 10 days ago | Low        | Very low       | Security             |
       And 1 another issue without cluster hit exists
-          | Title    | Modified    | Total risk |
-          | Nohit    | 10 days ago | Critical   |
+          | Title    | Modified    | Total risk | Risk of change | Category             |
+          | Nohit    | 10 days ago | Critical   | High           | Service Availability |
       And the user USER1 is already logged in into Hybrid Cloud Console
      When user looks at Hybrid Cloud Console main page
      Then menu on the left side should be displayed
@@ -38,20 +38,21 @@ Feature: Sorting on cluster view page with recommendations behaviour on Hybrid C
      When user select "Recommendations" menu item from this sub-menu
      Then an "Advisor recommendations" page should be displayed right of the left menu bar
       And that table should contain following four rows in that order
-          | Name        | Modified    | Total risk | Clusters |
-          | Bug12345    | 10 days ago | Critical   | 1        |
-          | Abc12345    | 10 days ago | Important  | 1        |
-          | Xyz12345    | 10 days ago | Moderate   | 1        |
-          | Uvw12345    | 10 days ago | Low        | 1        |
+          | Name        | Modified    | Category             | Total risk | Risk of change | Clusters |
+          | Bug12345    | 10 days ago | Service Availability | Critical   | High           | 1        |
+          | Abc12345    | 10 days ago | Performance          | Important  | Moderate       | 1        |
+          | Xyz12345    | 10 days ago | Fault Tolerance      | Moderate   | Low            | 1        |
+          | Uvw12345    | 10 days ago | Security             | Low        | Very low       | 1        |
      When user clicks on an "Bug12345" link
      Then new page with additional information about selected recommendation should be displayed
       And the following values needs to be displayed
-          | Value type  | Content             | Displayed as              | Optional |
-          | Description | Textual description | Text                      | no       |
-          | KB article  | Link to KB article  | Link                      | yes      |
-          | Total risk  | Important           | Widget (icon+label)       | no       |
-          | Likelihood  | High                | Widget (thermometer-like) | no       |
-          | Impact      | High                | Widget (thermometer-like) | no       |
+          | Value type     | Content             | Displayed as              | Optional |
+          | Description    | Textual description | Text                      | no       |
+          | KB article     | Link to KB article  | Link                      | yes      |
+          | Total risk     | Important           | Widget (icon+label)       | no       |
+          | Likelihood     | High                | Widget (thermometer-like) | no       |
+          | Impact         | High                | Widget (thermometer-like) | no       |
+          | Risk of change | Moderate            | Widget (icon+label)       | no       |
       And "Affected clusters" table needs to be displayed below additional info
           | Name                                 | Clickable (link) |
           | 00000000-0000-0000-0000-000000000000 | yes              |
@@ -86,14 +87,14 @@ Feature: Sorting on cluster view page with recommendations behaviour on Hybrid C
           | Cluster name                         |
           | 00000000-0000-0000-0000-000000000000 |
       And 4 issues are detected for cluster 00000000-0000-0000-0000-000000000000
-          | Title    | Modified    | Total risk |
-          | Bug12345 | 10 days ago | Critical   |
-          | Abc12345 | 10 days ago | Important  |
-          | Xyz12345 | 10 days ago | Moderate   |
-          | Uvw12345 | 10 days ago | Low        |
+          | Title    | Modified    | Total risk | Risk of change | Category             |
+          | Bug12345 | 10 days ago | Critical   | High           | Service Availability |
+          | Abc12345 | 10 days ago | Important  | Moderate       | Performance          |
+          | Xyz12345 | 10 days ago | Moderate   | Low            | Fault Tolerance      |
+          | Uvw12345 | 10 days ago | Low        | Very low       | Security             |
       And 1 another issue without cluster hit exists
-          | Title    | Modified    | Total risk |
-          | Nohit    | 10 days ago | Critical   |
+          | Title    | Modified    | Total risk | Risk of change | Category             |
+          | Nohit    | 10 days ago | Critical   | High           | Service Availability |
       And the user USER1 is already logged in into Hybrid Cloud Console
      When user looks at Hybrid Cloud Console main page
      Then menu on the left side should be displayed
@@ -117,20 +118,21 @@ Feature: Sorting on cluster view page with recommendations behaviour on Hybrid C
      When user select "Recommendations" menu item from this sub-menu
      Then an "Advisor recommendations" page should be displayed right of the left menu bar
       And that table should contain following four rows in that order
-          | Name        | Modified    | Total risk | Clusters |
-          | Bug12345    | 10 days ago | Critical   | 1        |
-          | Abc12345    | 10 days ago | Important  | 1        |
-          | Xyz12345    | 10 days ago | Moderate   | 1        |
-          | Uvw12345    | 10 days ago | Low        | 1        |
+          | Name        | Modified    | Category             | Total risk | Risk of change | Clusters |
+          | Bug12345    | 10 days ago | Service Availability | Critical   | High           | 1        |
+          | Abc12345    | 10 days ago | Performance          | Important  | Moderate       | 1        |
+          | Xyz12345    | 10 days ago | Fault Tolerance      | Moderate   | Low            | 1        |
+          | Uvw12345    | 10 days ago | Security             | Low        | Very low       | 1        |
      When user clicks on an "Bug12345" link
      Then new page with additional information about selected recommendation should be displayed
       And the following values needs to be displayed
-          | Value type  | Content             | Displayed as              | Optional |
-          | Description | Textual description | Text                      | no       |
-          | KB article  | Link to KB article  | Link                      | yes      |
-          | Total risk  | Important           | Widget (icon+label)       | no       |
-          | Likelihood  | High                | Widget (thermometer-like) | no       |
-          | Impact      | High                | Widget (thermometer-like) | no       |
+          | Value type     | Content             | Displayed as              | Optional |
+          | Description    | Textual description | Text                      | no       |
+          | KB article     | Link to KB article  | Link                      | yes      |
+          | Total risk     | Important           | Widget (icon+label)       | no       |
+          | Likelihood     | High                | Widget (thermometer-like) | no       |
+          | Impact         | High                | Widget (thermometer-like) | no       |
+          | Risk of change | Moderate            | Widget (icon+label)       | no       |
       And "Affected clusters" table needs to be displayed below additional info
           | Name                                 | Clickable (link) |
           | 00000000-0000-0000-0000-000000000000 | yes              |
@@ -189,14 +191,14 @@ Feature: Sorting on cluster view page with recommendations behaviour on Hybrid C
           | Cluster name                         |
           | 00000000-0000-0000-0000-000000000000 |
       And 4 issues are detected for cluster 00000000-0000-0000-0000-000000000000
-          | Title    | Modified    | Total risk |
-          | Bug12345 | 10 days ago | Critical   |
-          | Abc12345 | 20 days ago | Important  |
-          | Xyz12345 | 30 days ago | Moderate   |
-          | Uvw12345 | 40 days ago | Low        |
+          | Title    | Modified    | Total risk | Risk of change | Category             |
+          | Bug12345 | 10 days ago | Critical   | High           | Service Availability |
+          | Abc12345 | 20 days ago | Important  | Moderate       | Performance          |
+          | Xyz12345 | 30 days ago | Moderate   | Low            | Fault Tolerance      |
+          | Uvw12345 | 40 days ago | Low        | Very low       | Security             |
       And 1 another issue without cluster hit exists
-          | Title    | Modified    | Total risk |
-          | Nohit    | 10 days ago | Critical   |
+          | Title    | Modified    | Total risk | Risk of change | Category             |
+          | Nohit    | 10 days ago | Critical   | High           | Service Availability |
       And the user USER1 is already logged in into Hybrid Cloud Console
      When user looks at Hybrid Cloud Console main page
      Then menu on the left side should be displayed
@@ -220,20 +222,21 @@ Feature: Sorting on cluster view page with recommendations behaviour on Hybrid C
      When user select "Recommendations" menu item from this sub-menu
      Then an "Advisor recommendations" page should be displayed right of the left menu bar
       And that table should contain following four rows in that order
-          | Name        | Modified    | Total risk | Clusters |
-          | Bug12345    | 10 days ago | Critical   | 1        |
-          | Abc12345    | 20 days ago | Important  | 1        |
-          | Xyz12345    | 30 days ago | Moderate   | 1        |
-          | Uvw12345    | 40 days ago | Low        | 1        |
+          | Name        | Modified    | Category             | Total risk | Risk of change | Clusters |
+          | Bug12345    | 10 days ago | Service Availability | Critical   | High           | 1        |
+          | Abc12345    | 20 days ago | Performance          | Important  | Moderate       | 1        |
+          | Xyz12345    | 30 days ago | Fault Tolerance      | Moderate   | Low            | 1        |
+          | Uvw12345    | 40 days ago | Security             | Low        | Very low       | 1        |
      When user clicks on an "Bug12345" link
      Then new page with additional information about selected recommendation should be displayed
       And the following values needs to be displayed
-          | Value type  | Content             | Displayed as              | Optional |
-          | Description | Textual description | Text                      | no       |
-          | KB article  | Link to KB article  | Link                      | yes      |
-          | Total risk  | Important           | Widget (icon+label)       | no       |
-          | Likelihood  | High                | Widget (thermometer-like) | no       |
-          | Impact      | High                | Widget (thermometer-like) | no       |
+          | Value type     | Content             | Displayed as              | Optional |
+          | Description    | Textual description | Text                      | no       |
+          | KB article     | Link to KB article  | Link                      | yes      |
+          | Total risk     | Important           | Widget (icon+label)       | no       |
+          | Likelihood     | High                | Widget (thermometer-like) | no       |
+          | Impact         | High                | Widget (thermometer-like) | no       |
+          | Risk of change | Moderate            | Widget (icon+label)       | no       |
       And "Affected clusters" table needs to be displayed below additional info
           | Name                                 | Clickable (link) |
           | 00000000-0000-0000-0000-000000000000 | yes              |
@@ -292,14 +295,14 @@ Feature: Sorting on cluster view page with recommendations behaviour on Hybrid C
           | Cluster name                         |
           | 00000000-0000-0000-0000-000000000000 |
       And 4 issues are detected for cluster 00000000-0000-0000-0000-000000000000
-          | Title    | Modified    | Total risk |
-          | Bug12345 | 10 days ago | Critical   |
-          | Abc12345 | 20 days ago | Important  |
-          | Xyz12345 | 30 days ago | Moderate   |
-          | Uvw12345 | 40 days ago | Low        |
+          | Name        | Modified    | Category             | Total risk | Risk of change | Clusters |
+          | Bug12345    | 10 days ago | Service Availability | Critical   | High           | 1        |
+          | Abc12345    | 20 days ago | Performance          | Important  | Moderate       | 1        |
+          | Xyz12345    | 30 days ago | Fault Tolerance      | Moderate   | Low            | 1        |
+          | Uvw12345    | 40 days ago | Security             | Low        | Very low       | 1        |
       And 1 another issue without cluster hit exists
-          | Title    | Modified    | Total risk |
-          | Nohit    | 10 days ago | Critical   |
+          | Title    | Modified    | Total risk | Risk of change | Category             |
+          | Nohit    | 10 days ago | Critical   | High           | Service Availability |
       And the user USER1 is already logged in into Hybrid Cloud Console
      When user looks at Hybrid Cloud Console main page
      Then menu on the left side should be displayed
@@ -323,20 +326,21 @@ Feature: Sorting on cluster view page with recommendations behaviour on Hybrid C
      When user select "Recommendations" menu item from this sub-menu
      Then an "Advisor recommendations" page should be displayed right of the left menu bar
       And that table should contain following four rows in that order
-          | Name        | Modified    | Total risk | Clusters |
-          | Bug12345    | 10 days ago | Critical   | 1        |
-          | Abc12345    | 20 days ago | Important  | 1        |
-          | Xyz12345    | 30 days ago | Moderate   | 1        |
-          | Uvw12345    | 40 days ago | Low        | 1        |
+          | Name        | Modified    | Category             | Total risk | Risk of change | Clusters |
+          | Bug12345    | 10 days ago | Service Availability | Critical   | High           | 1        |
+          | Abc12345    | 20 days ago | Performance          | Important  | Moderate       | 1        |
+          | Xyz12345    | 30 days ago | Fault Tolerance      | Moderate   | Low            | 1        |
+          | Uvw12345    | 40 days ago | Security             | Low        | Very low       | 1        |
      When user clicks on an "Bug12345" link
      Then new page with additional information about selected recommendation should be displayed
       And the following values needs to be displayed
-          | Value type  | Content             | Displayed as              | Optional |
-          | Description | Textual description | Text                      | no       |
-          | KB article  | Link to KB article  | Link                      | yes      |
-          | Total risk  | Important           | Widget (icon+label)       | no       |
-          | Likelihood  | High                | Widget (thermometer-like) | no       |
-          | Impact      | High                | Widget (thermometer-like) | no       |
+          | Value type     | Content             | Displayed as              | Optional |
+          | Description    | Textual description | Text                      | no       |
+          | KB article     | Link to KB article  | Link                      | yes      |
+          | Total risk     | Important           | Widget (icon+label)       | no       |
+          | Likelihood     | High                | Widget (thermometer-like) | no       |
+          | Impact         | High                | Widget (thermometer-like) | no       |
+          | Risk of change | Moderate            | Widget (icon+label)       | no       |
       And "Affected clusters" table needs to be displayed below additional info
           | Name                                 | Clickable (link) |
           | 00000000-0000-0000-0000-000000000000 | yes              |

--- a/features/Insights_Advisor/cluster_page_sorting.feature
+++ b/features/Insights_Advisor/cluster_page_sorting.feature
@@ -3,7 +3,7 @@ Feature: Sorting on cluster view page with recommendations behaviour on Hybrid C
 
   Scenario: Default sort order in recommendations table on cluster view page on Hybrid Cloud Console with five recommendations and one cluster
     Given user USER1 is part of account (organization) ACCOUNT1
-      And account (organization) ACCOUNT1 owns 4 clusters
+      And account (organization) ACCOUNT1 owns 1 cluster
           | Cluster name                         |
           | 00000000-0000-0000-0000-000000000000 |
       And 4 issues are detected for cluster 00000000-0000-0000-0000-000000000000
@@ -83,7 +83,7 @@ Feature: Sorting on cluster view page with recommendations behaviour on Hybrid C
 
   Scenario: Sorting by description in recommendations table on cluster view page on Hybrid Cloud Console with five recommendations and one cluster
     Given user USER1 is part of account (organization) ACCOUNT1
-      And account (organization) ACCOUNT1 owns 4 clusters
+      And account (organization) ACCOUNT1 owns 1 cluster
           | Cluster name                         |
           | 00000000-0000-0000-0000-000000000000 |
       And 4 issues are detected for cluster 00000000-0000-0000-0000-000000000000
@@ -187,7 +187,7 @@ Feature: Sorting on cluster view page with recommendations behaviour on Hybrid C
 
   Scenario: Sorting by added at in recommendations table on cluster view page on Hybrid Cloud Console with five recommendations and one cluster
     Given user USER1 is part of account (organization) ACCOUNT1
-      And account (organization) ACCOUNT1 owns 4 clusters
+      And account (organization) ACCOUNT1 owns 1 cluster
           | Cluster name                         |
           | 00000000-0000-0000-0000-000000000000 |
       And 4 issues are detected for cluster 00000000-0000-0000-0000-000000000000
@@ -291,7 +291,7 @@ Feature: Sorting on cluster view page with recommendations behaviour on Hybrid C
 
   Scenario: Sorting by total risk at in recommendations table on cluster view page on Hybrid Cloud Console with five recommendations and one cluster
     Given user USER1 is part of account (organization) ACCOUNT1
-      And account (organization) ACCOUNT1 owns 4 clusters
+      And account (organization) ACCOUNT1 owns 1 cluster
           | Cluster name                         |
           | 00000000-0000-0000-0000-000000000000 |
       And 4 issues are detected for cluster 00000000-0000-0000-0000-000000000000

--- a/features/Insights_Advisor/clusters_version.feature
+++ b/features/Insights_Advisor/clusters_version.feature
@@ -3,7 +3,7 @@ Feature: Clusters view page with recommendations behaviour on Hybrid Cloud Conso
 
     Scenario: Displaying Advisor's "Affected clusters" page on Hybrid Cloud Console should show the cluster version
         Given user USER1 is part of account (organization) ACCOUNT1
-        And account (organization) ACCOUNT1 owns 1 cluster
+        And account (organization) ACCOUNT1 owns 2 clusters
             | Cluster name                         | Version |
             | 00000000-0000-0000-0000-000000000000 | 0.0     |
             | 11111111-0000-0000-0000-000000000000 |         |

--- a/features/Insights_Advisor/recommendations_page.feature
+++ b/features/Insights_Advisor/recommendations_page.feature
@@ -9,13 +9,25 @@ Feature: Advisor recommendations page behaviour on Hybrid Cloud Console
      When user looks at Hybrid Cloud Console main page
      Then menu on the left side should be displayed
       And the left menu might contain these top level items
+          | Left menu item                | Required for this test |
+          | Application and Data Services | no                     |
+          | OpenShift                     | yes                    |
+          | Red Hat Enterprise Linux      | no                     |
+          | Ansible Automation Platform   | no                     |
+     When user selects "OpenShift" from the left side menu
+     Then menu on the left side should be changed
+      And the left menu might contain these top level items
           | Left menu item           | Required for this test |
+          | Clusters                 | no                     |
           | Overview                 | no                     |
           | Releases                 | no                     |
+          | Developer Sandbox        | no                     |
           | Downloads                | no                     |
           | Advisor                  | yes                    |
+          | Vulnerability            | no                     |
           | Subscriptions            | no                     |
           | Cost Management          | no                     |
+          | Support Cases            | no                     |
           | Cluster Manager Feedback | no                     |
           | Red Hat Marketplace      | no                     |
           | Documentation            | no                     |
@@ -49,13 +61,25 @@ Feature: Advisor recommendations page behaviour on Hybrid Cloud Console
      When user looks at Hybrid Cloud Console main page
      Then menu on the left side should be displayed
       And the left menu might contain these top level items
+          | Left menu item                | Required for this test |
+          | Application and Data Services | no                     |
+          | OpenShift                     | yes                    |
+          | Red Hat Enterprise Linux      | no                     |
+          | Ansible Automation Platform   | no                     |
+     When user selects "OpenShift" from the left side menu
+     Then menu on the left side should be changed
+      And the left menu might contain these top level items
           | Left menu item           | Required for this test |
+          | Clusters                 | no                     |
           | Overview                 | no                     |
           | Releases                 | no                     |
+          | Developer Sandbox        | no                     |
           | Downloads                | no                     |
           | Advisor                  | yes                    |
+          | Vulnerability            | no                     |
           | Subscriptions            | no                     |
           | Cost Management          | no                     |
+          | Support Cases            | no                     |
           | Cluster Manager Feedback | no                     |
           | Red Hat Marketplace      | no                     |
           | Documentation            | no                     |
@@ -99,13 +123,25 @@ Feature: Advisor recommendations page behaviour on Hybrid Cloud Console
      When user looks at Hybrid Cloud Console main page
      Then menu on the left side should be displayed
       And the left menu might contain these top level items
+          | Left menu item                | Required for this test |
+          | Application and Data Services | no                     |
+          | OpenShift                     | yes                    |
+          | Red Hat Enterprise Linux      | no                     |
+          | Ansible Automation Platform   | no                     |
+     When user selects "OpenShift" from the left side menu
+     Then menu on the left side should be changed
+      And the left menu might contain these top level items
           | Left menu item           | Required for this test |
+          | Clusters                 | no                     |
           | Overview                 | no                     |
           | Releases                 | no                     |
+          | Developer Sandbox        | no                     |
           | Downloads                | no                     |
           | Advisor                  | yes                    |
+          | Vulnerability            | no                     |
           | Subscriptions            | no                     |
           | Cost Management          | no                     |
+          | Support Cases            | no                     |
           | Cluster Manager Feedback | no                     |
           | Red Hat Marketplace      | no                     |
           | Documentation            | no                     |

--- a/features/Insights_Advisor/recommendations_page.feature
+++ b/features/Insights_Advisor/recommendations_page.feature
@@ -78,7 +78,7 @@ Feature: Advisor recommendations page behaviour on Hybrid Cloud Console
           | Clusters       |
       And that table should contain at least one row
           | Column name    | Value                |
-          | Name           | Bug1234              |
+          | Name           | Bug12345              |
           | Modified       | 10 days ago          |
           | Category       | Service Availability |
           | Total risk     | Critical             |
@@ -128,7 +128,7 @@ Feature: Advisor recommendations page behaviour on Hybrid Cloud Console
           | Clusters       |
       And that table should contain at least one row
           | Column name    | Value                |
-          | Name           | Bug1234              |
+          | Name           | Bug12345              |
           | Modified       | 10 days ago          |
           | Category       | Service Availability |
           | Total risk     | Critical             |

--- a/features/Insights_Advisor/recommendations_page.feature
+++ b/features/Insights_Advisor/recommendations_page.feature
@@ -29,11 +29,13 @@ Feature: Advisor recommendations page behaviour on Hybrid Cloud Console
      Then an "Advisor recommendations" page should be displayed right of the left menu bar
       And widget with filter settings should be displayed
       And table with several columns should be displayed
-          | Column name |
-          | Name        |
-          | Modified    |
-          | Total risk  |
-          | Clusters    |
+          | Column name    |
+          | Name           |
+          | Modified       |
+          | Category       |
+          | Total risk     |
+          | Risk of change |
+          | Clusters       |
       And that table might contains only rows saying Clusters: 0
 
 
@@ -41,8 +43,8 @@ Feature: Advisor recommendations page behaviour on Hybrid Cloud Console
     Given user USER1 is part of account (organization) ACCOUNT1
       And account (organization) ACCOUNT1 owns one cluster
       And 1 issue is detected for this cluster
-          | Title    | Modified    | Total risk |
-          | Bug12345 | 10 days ago | Important  |
+          | Title    | Modified    | Total risk | Risk of change | Category             |
+          | Bug12345 | 10 days ago | Critical   | High           | Service Availability |
       And the user USER1 is already logged in into Hybrid Cloud Console
      When user looks at Hybrid Cloud Console main page
      Then menu on the left side should be displayed
@@ -67,17 +69,21 @@ Feature: Advisor recommendations page behaviour on Hybrid Cloud Console
      Then an "Advisor recommendations" page should be displayed right of the left menu bar
       And widget with filter settings should be displayed
       And table with several columns should be displayed
-          | Column name |
-          | Name        |
-          | Modified    |
-          | Total risk  |
-          | Clusters    |
+          | Column name    |
+          | Name           |
+          | Modified       |
+          | Category       |
+          | Total risk     |
+          | Risk of change |
+          | Clusters       |
       And that table should contain at least one row
-          | Column name | Value       |
-          | Name        | Bug1234     |
-          | Modified    | 10 days ago |
-          | Total risk  | Important   |
-          | Clusters    | 1           |
+          | Column name    | Value                |
+          | Name           | Bug1234              |
+          | Modified       | 10 days ago          |
+          | Category       | Service Availability |
+          | Total risk     | Critical             |
+          | Risk of change | High                 |
+          | Clusters       | 1                    |
 
 
   Scenario: Displaying Advisor's "Recommendations" page on Hybrid Cloud Console with at least one recommendation and two clusters
@@ -87,8 +93,8 @@ Feature: Advisor recommendations page behaviour on Hybrid Cloud Console
           | 00000000-0000-0000-0000-000000000000 |
           | 11111111-0000-0000-0000-000000000000 |
       And 1 issue is detected for cluster 00000000-0000-0000-0000-000000000000
-          | Title    | Modified    | Total risk |
-          | Bug12345 | 10 days ago | Important  |
+          | Title    | Modified    | Total risk | Risk of change | Category             |
+          | Bug12345 | 10 days ago | Critical   | High           | Service Availability |
       And the user USER1 is already logged in into Hybrid Cloud Console
      When user looks at Hybrid Cloud Console main page
      Then menu on the left side should be displayed
@@ -113,14 +119,18 @@ Feature: Advisor recommendations page behaviour on Hybrid Cloud Console
      Then an "Advisor recommendations" page should be displayed right of the left menu bar
       And widget with filter settings should be displayed
       And table with several columns should be displayed
-          | Column name |
-          | Name        |
-          | Modified    |
-          | Total risk  |
-          | Clusters    |
+          | Column name    |
+          | Name           |
+          | Modified       |
+          | Category       |
+          | Total risk     |
+          | Risk of change |
+          | Clusters       |
       And that table should contain at least one row
-          | Column name | Value       |
-          | Name        | Bug1234     |
-          | Modified    | 10 days ago |
-          | Total risk  | Important   |
-          | Clusters    | 1           |
+          | Column name    | Value                |
+          | Name           | Bug1234              |
+          | Modified       | 10 days ago          |
+          | Category       | Service Availability |
+          | Total risk     | Critical             |
+          | Risk of change | High                 |
+          | Clusters       | 1                    |

--- a/features/Insights_Advisor/recommendations_page.feature
+++ b/features/Insights_Advisor/recommendations_page.feature
@@ -3,7 +3,7 @@ Feature: Advisor recommendations page behaviour on Hybrid Cloud Console
 
   Scenario: Displaying Advisor's "Recommendations" page on Hybrid Cloud Console without any recommendations
     Given user USER1 is part of account (organization) ACCOUNT1
-      And account (organization) ACCOUNT1 owns one cluster
+      And account (organization) ACCOUNT1 owns 1 cluster
       And 0 issues are detected for this cluster
       And the user USER1 is already logged in into Hybrid Cloud Console
      When user looks at Hybrid Cloud Console main page
@@ -41,7 +41,7 @@ Feature: Advisor recommendations page behaviour on Hybrid Cloud Console
 
   Scenario: Displaying Advisor's "Recommendations" page on Hybrid Cloud Console with at least one recommendation and one cluster
     Given user USER1 is part of account (organization) ACCOUNT1
-      And account (organization) ACCOUNT1 owns one cluster
+      And account (organization) ACCOUNT1 owns 1 cluster
       And 1 issue is detected for this cluster
           | Title    | Modified    | Total risk | Risk of change | Category             |
           | Bug12345 | 10 days ago | Critical   | High           | Service Availability |

--- a/features/Insights_Advisor/recommendations_page_expanded_info.feature
+++ b/features/Insights_Advisor/recommendations_page_expanded_info.feature
@@ -5,8 +5,8 @@ Feature: Advisor recommendations page behaviour on Hybrid Cloud Console - expand
     Given user USER1 is part of account (organization) ACCOUNT1
       And account (organization) ACCOUNT1 owns one cluster
       And 1 issue is detected for this cluster
-          | Title    | Modified    | Total risk | Likelihood | Impact |
-          | Bug12345 | 10 days ago | Important  | high       | high   |
+          | Title    | Modified    | Category | Total risk | Likelihood | Impact | Risk of change |
+          | Bug12345 | 10 days ago | Security | Important  | high       | high   | Moderate       |
       And the user USER1 is already logged in into Hybrid Cloud Console
      When user looks at Hybrid Cloud Console main page
      Then menu on the left side should be displayed
@@ -31,17 +31,21 @@ Feature: Advisor recommendations page behaviour on Hybrid Cloud Console - expand
      Then an "Advisor recommendations" page should be displayed right of the left menu bar
       And widget with filter settings should be displayed
       And table with several columns should be displayed
-          | Column name |
-          | Name        |
-          | Modified    |
-          | Total risk  |
-          | Clusters    |
+          | Column name    |
+          | Name           |
+          | Modified       |
+          | Category       |
+          | Total risk     |
+          | Risk of change |
+          | Clusters       |
       And that table should contain at least one row
-          | Column name | Value       |
-          | Name        | Bug1234     |
-          | Modified    | 10 days ago |
-          | Total risk  | Important   |
-          | Clusters    | 1           |
+          | Column name    | Value       |
+          | Name           | Bug1234     |
+          | Modified       | 10 days ago |
+          | Category       | Security    |
+          | Total risk     | Important   |
+          | Risk of change | Moderate    |
+          | Clusters       | 1           |
       And an "expand" arrow should be displayed before recommendation name
       And the "expand" arrow should point to east
      When user clicks on an "expand" arrow
@@ -49,12 +53,13 @@ Feature: Advisor recommendations page behaviour on Hybrid Cloud Console - expand
       And the "expand" arrow should point to south
      When user looks at expanded information
      Then the following values needs to be displayed
-          | Value type  | Content             | Displayed as              | Optional |
-          | Description | Textual description | Text                      | no       |
-          | KB article  | Link to KB article  | Link                      | yes      |
-          | Total risk  | Important           | Widget (icon+label)       | no       |
-          | Likelihood  | High                | Widget (thermometer-like) | no       |
-          | Impact      | High                | Widget (thermometer-like) | no       |
+          | Value type     | Content             | Displayed as              | Optional |
+          | Description    | Textual description | Text                      | no       |
+          | KB article     | Link to KB article  | Link                      | yes      |
+          | Total risk     | Important           | Widget (icon+label)       | no       |
+          | Likelihood     | High                | Widget (thermometer-like) | no       |
+          | Impact         | High                | Widget (thermometer-like) | no       |
+          | Risk of change | Moderate            | Widget (icon+label)       | no       |
      When user clicks on an "expand" arrow
      Then additional information about selected recommendation should be hidden
       And the "expand" arrow should point to east
@@ -64,8 +69,8 @@ Feature: Advisor recommendations page behaviour on Hybrid Cloud Console - expand
     Given user USER1 is part of account (organization) ACCOUNT1
       And account (organization) ACCOUNT1 owns one cluster
       And 1 issue is detected for this cluster
-          | Title    | Modified    | Total risk | Likelihood | Impact |
-          | Bug12345 | 10 days ago | Low        | medium     | low    |
+          | Title    | Modified    | Category | Total risk | Likelihood | Impact | Risk of change |
+          | Bug12345 | 10 days ago | Security | Low        | medium     | low    | Very Low       |
       And the user USER1 is already logged in into Hybrid Cloud Console
      When user looks at Hybrid Cloud Console main page
      Then menu on the left side should be displayed
@@ -90,17 +95,21 @@ Feature: Advisor recommendations page behaviour on Hybrid Cloud Console - expand
      Then an "Advisor recommendations" page should be displayed right of the left menu bar
       And widget with filter settings should be displayed
       And table with several columns should be displayed
-          | Column name |
-          | Name        |
-          | Modified    |
-          | Total risk  |
-          | Clusters    |
+          | Column name    |
+          | Name           |
+          | Modified       |
+          | Category       |
+          | Total risk     |
+          | Risk of change |
+          | Clusters       |
       And that table should contain at least one row
-          | Column name | Value       |
-          | Name        | Bug1234     |
-          | Modified    | 10 days ago |
-          | Total risk  | Low         |
-          | Clusters    | 1           |
+          | Column name    | Value       |
+          | Name           | Bug1234     |
+          | Modified       | 10 days ago |
+          | Category       | Security    |
+          | Total risk     | Low         |
+          | Risk of change | Very Low    |
+          | Clusters       | 1           |
       And an "expand" arrow should be displayed before recommendation name
       And the "expand" arrow should point to east
      When user clicks on an "expand" arrow
@@ -108,12 +117,13 @@ Feature: Advisor recommendations page behaviour on Hybrid Cloud Console - expand
       And the "expand" arrow should point to south
      When user looks at expanded information
      Then the following values needs to be displayed
-          | Value type  | Content             | Displayed as              | Optional |
-          | Description | Textual description | Text                      | no       |
-          | KB article  | Link to KB article  | Link                      | yes      |
-          | Total risk  | Low                 | Widget (icon+label)       |
-          | Likelihood  | Medium              | Widget (thermometer-like) |
-          | Impact      | Low                 | Widget (thermometer-like) |
+          | Value type     | Content             | Displayed as              | Optional |
+          | Description    | Textual description | Text                      | no       |
+          | KB article     | Link to KB article  | Link                      | yes      |
+          | Total risk     | Low                 | Widget (icon+label)       | no       |
+          | Likelihood     | Medium              | Widget (thermometer-like) | no       |
+          | Impact         | Low                 | Widget (thermometer-like) | no       |
+          | Risk of change | Very Low            | Widget (icon+label)       | no       |
      When user clicks on an "expand" arrow
      Then additional information about selected recommendation should be hidden
       And the "expand" arrow should point to east
@@ -123,8 +133,8 @@ Feature: Advisor recommendations page behaviour on Hybrid Cloud Console - expand
     Given user USER1 is part of account (organization) ACCOUNT1
       And account (organization) ACCOUNT1 owns one cluster
       And 1 issue is detected for this cluster
-          | Title    | Modified    | Total risk | Likelihood | Impact |
-          | Bug12345 | 10 days ago | Moderate   | medium     | low    |
+          | Title    | Modified    | Category    | Total risk | Likelihood | Impact | Risk of change |
+          | Bug12345 | 10 days ago | Performance | Moderate   | medium     | low    | Low            |
       And the user USER1 is already logged in into Hybrid Cloud Console
      When user looks at Hybrid Cloud Console main page
      Then menu on the left side should be displayed
@@ -149,17 +159,21 @@ Feature: Advisor recommendations page behaviour on Hybrid Cloud Console - expand
      Then an "Advisor recommendations" page should be displayed right of the left menu bar
       And widget with filter settings should be displayed
       And table with several columns should be displayed
-          | Column name |
-          | Name        |
-          | Modified    |
-          | Total risk  |
-          | Clusters    |
+          | Column name    |
+          | Name           |
+          | Modified       |
+          | Category       |
+          | Total risk     |
+          | Risk of change |
+          | Clusters       |
       And that table should contain at least one row
-          | Column name | Value       |
-          | Name        | Bug1234     |
-          | Modified    | 10 days ago |
-          | Total risk  | Low         |
-          | Clusters    | 1           |
+          | Column name    | Value       |
+          | Name           | Bug1234     |
+          | Modified       | 10 days ago |
+          | Category       | Performance |
+          | Total risk     | Moderate    |
+          | Risk of change | Low         |
+          | Clusters       | 1           |
       And an "expand" arrow should be displayed before recommendation name
       And the "expand" arrow should point to east
      When user clicks on an "expand" arrow
@@ -167,12 +181,13 @@ Feature: Advisor recommendations page behaviour on Hybrid Cloud Console - expand
      When user looks at expanded information
       And the "expand" arrow should point to south
      Then the following values needs to be displayed
-          | Value type  | Content             | Displayed as              | Optional |
-          | Description | Textual description | Text                      | no       |
-          | KB article  | Link to KB article  | Link                      | yes      |
-          | Total risk  | Moderate            | Widget (icon+label)       |
-          | Likelihood  | Critical            | Widget (thermometer-like) |
-          | Impact      | Low                 | Widget (thermometer-like) |
+          | Value type     | Content             | Displayed as              | Optional |
+          | Description    | Textual description | Text                      | no       |
+          | KB article     | Link to KB article  | Link                      | yes      |
+          | Total risk     | Moderate            | Widget (icon+label)       | no       |
+          | Likelihood     | Medium              | Widget (thermometer-like) | no       |
+          | Impact         | Low                 | Widget (thermometer-like) | no       |
+          | Risk of change | Low                 | Widget (icon+label)       | no       |
      When user clicks on an "expand" arrow
      Then additional information about selected recommendation should be hidden
       And the "expand" arrow should point to east

--- a/features/Insights_Advisor/recommendations_page_expanded_info.feature
+++ b/features/Insights_Advisor/recommendations_page_expanded_info.feature
@@ -11,13 +11,25 @@ Feature: Advisor recommendations page behaviour on Hybrid Cloud Console - expand
      When user looks at Hybrid Cloud Console main page
      Then menu on the left side should be displayed
       And the left menu might contain these top level items
+          | Left menu item                | Required for this test |
+          | Application and Data Services | no                     |
+          | OpenShift                     | yes                    |
+          | Red Hat Enterprise Linux      | no                     |
+          | Ansible Automation Platform   | no                     |
+     When user selects "OpenShift" from the left side menu
+     Then menu on the left side should be changed
+      And the left menu might contain these top level items
           | Left menu item           | Required for this test |
+          | Clusters                 | no                     |
           | Overview                 | no                     |
           | Releases                 | no                     |
+          | Developer Sandbox        | no                     |
           | Downloads                | no                     |
           | Advisor                  | yes                    |
+          | Vulnerability            | no                     |
           | Subscriptions            | no                     |
           | Cost Management          | no                     |
+          | Support Cases            | no                     |
           | Cluster Manager Feedback | no                     |
           | Red Hat Marketplace      | no                     |
           | Documentation            | no                     |
@@ -75,13 +87,25 @@ Feature: Advisor recommendations page behaviour on Hybrid Cloud Console - expand
      When user looks at Hybrid Cloud Console main page
      Then menu on the left side should be displayed
       And the left menu might contain these top level items
+          | Left menu item                | Required for this test |
+          | Application and Data Services | no                     |
+          | OpenShift                     | yes                    |
+          | Red Hat Enterprise Linux      | no                     |
+          | Ansible Automation Platform   | no                     |
+     When user selects "OpenShift" from the left side menu
+     Then menu on the left side should be changed
+      And the left menu might contain these top level items
           | Left menu item           | Required for this test |
+          | Clusters                 | no                     |
           | Overview                 | no                     |
           | Releases                 | no                     |
+          | Developer Sandbox        | no                     |
           | Downloads                | no                     |
           | Advisor                  | yes                    |
+          | Vulnerability            | no                     |
           | Subscriptions            | no                     |
           | Cost Management          | no                     |
+          | Support Cases            | no                     |
           | Cluster Manager Feedback | no                     |
           | Red Hat Marketplace      | no                     |
           | Documentation            | no                     |
@@ -139,13 +163,25 @@ Feature: Advisor recommendations page behaviour on Hybrid Cloud Console - expand
      When user looks at Hybrid Cloud Console main page
      Then menu on the left side should be displayed
       And the left menu might contain these top level items
+          | Left menu item                | Required for this test |
+          | Application and Data Services | no                     |
+          | OpenShift                     | yes                    |
+          | Red Hat Enterprise Linux      | no                     |
+          | Ansible Automation Platform   | no                     |
+     When user selects "OpenShift" from the left side menu
+     Then menu on the left side should be changed
+      And the left menu might contain these top level items
           | Left menu item           | Required for this test |
+          | Clusters                 | no                     |
           | Overview                 | no                     |
           | Releases                 | no                     |
+          | Developer Sandbox        | no                     |
           | Downloads                | no                     |
           | Advisor                  | yes                    |
+          | Vulnerability            | no                     |
           | Subscriptions            | no                     |
           | Cost Management          | no                     |
+          | Support Cases            | no                     |
           | Cluster Manager Feedback | no                     |
           | Red Hat Marketplace      | no                     |
           | Documentation            | no                     |

--- a/features/Insights_Advisor/recommendations_page_expanded_info.feature
+++ b/features/Insights_Advisor/recommendations_page_expanded_info.feature
@@ -3,7 +3,7 @@ Feature: Advisor recommendations page behaviour on Hybrid Cloud Console - expand
 
   Scenario: Displaying expanded information about selected recommendation with high likelihood and high impact
     Given user USER1 is part of account (organization) ACCOUNT1
-      And account (organization) ACCOUNT1 owns one cluster
+      And account (organization) ACCOUNT1 owns 1 cluster
       And 1 issue is detected for this cluster
           | Title    | Modified    | Category | Total risk | Likelihood | Impact | Risk of change |
           | Bug12345 | 10 days ago | Security | Important  | high       | high   | Moderate       |
@@ -67,7 +67,7 @@ Feature: Advisor recommendations page behaviour on Hybrid Cloud Console - expand
 
   Scenario: Displaying expanded information about selected recommendation with medium likelihood and low impact
     Given user USER1 is part of account (organization) ACCOUNT1
-      And account (organization) ACCOUNT1 owns one cluster
+      And account (organization) ACCOUNT1 owns 1 cluster
       And 1 issue is detected for this cluster
           | Title    | Modified    | Category | Total risk | Likelihood | Impact | Risk of change |
           | Bug12345 | 10 days ago | Security | Low        | medium     | low    | Very Low       |
@@ -131,7 +131,7 @@ Feature: Advisor recommendations page behaviour on Hybrid Cloud Console - expand
 
   Scenario: Displaying expanded information about selected recommendation with critical likelihood and low impact
     Given user USER1 is part of account (organization) ACCOUNT1
-      And account (organization) ACCOUNT1 owns one cluster
+      And account (organization) ACCOUNT1 owns 1 cluster
       And 1 issue is detected for this cluster
           | Title    | Modified    | Category    | Total risk | Likelihood | Impact | Risk of change |
           | Bug12345 | 10 days ago | Performance | Moderate   | medium     | low    | Low            |

--- a/features/Insights_Advisor/recommendations_page_expanded_info.feature
+++ b/features/Insights_Advisor/recommendations_page_expanded_info.feature
@@ -40,7 +40,7 @@ Feature: Advisor recommendations page behaviour on Hybrid Cloud Console - expand
           | Clusters       |
       And that table should contain at least one row
           | Column name    | Value       |
-          | Name           | Bug1234     |
+          | Name           | Bug12345     |
           | Modified       | 10 days ago |
           | Category       | Security    |
           | Total risk     | Important   |
@@ -104,7 +104,7 @@ Feature: Advisor recommendations page behaviour on Hybrid Cloud Console - expand
           | Clusters       |
       And that table should contain at least one row
           | Column name    | Value       |
-          | Name           | Bug1234     |
+          | Name           | Bug12345     |
           | Modified       | 10 days ago |
           | Category       | Security    |
           | Total risk     | Low         |
@@ -168,7 +168,7 @@ Feature: Advisor recommendations page behaviour on Hybrid Cloud Console - expand
           | Clusters       |
       And that table should contain at least one row
           | Column name    | Value       |
-          | Name           | Bug1234     |
+          | Name           | Bug12345     |
           | Modified       | 10 days ago |
           | Category       | Performance |
           | Total risk     | Moderate    |

--- a/features/Insights_Advisor/recommendations_page_filtering.feature
+++ b/features/Insights_Advisor/recommendations_page_filtering.feature
@@ -44,9 +44,10 @@ Feature: Filtering on Advisor recommendations page behaviour on Hybrid Cloud Con
       And that table should contain exactly 1 row
           | Name        | Modified    | Category             | Total risk | Risk of change | Clusters |
           | Bug12345    | 10 days ago | Service Availability | Important  | High           | 1        |
-      And one filter needs to be preselected
+      And 2 filters need to be preselected
           | Filter name       | Tag         |
           | Clusters impacted | 1 or more   |
+          | Status            | Enabled     |
 
 
   Scenario: Reset filter on Advisor's "Recommendations" page on Hybrid Cloud Console with at least one recommendation and two clusters
@@ -96,9 +97,10 @@ Feature: Filtering on Advisor recommendations page behaviour on Hybrid Cloud Con
       And that table should contain exactly 1 row
           | Name        | Modified    | Category             | Total risk | Risk of change | Clusters |
           | Bug12345    | 10 days ago | Service Availability | Important  | High           | 1        |
-      And one filter needs to be preselected
+      And 2 filters need to be preselected
           | Filter name       | Tag         |
           | Clusters impacted | 1 or more   |
+          | Status            | Enabled     |
      When user clicks on "x" icon displayed on "1 or more" filter tag
      Then table with advisor recommendation should contain recommendations names with 0 clusters
       And that table should contain 3 rows
@@ -155,9 +157,10 @@ Feature: Filtering on Advisor recommendations page behaviour on Hybrid Cloud Con
       And that table should contain exactly 1 row
           | Name        | Modified    | Category             | Total risk | Risk of change | Clusters |
           | Bug12345    | 10 days ago | Service Availability | Important  | High           | 1        |
-      And one filter needs to be preselected
+      And 2 filters need to be preselected
           | Filter name       | Tag         |
           | Clusters impacted | 1 or more   |
+          | Status            | Enabled     |
      When user clicks on "x" icon displayed on "1 or more" filter tag
      Then table with advisor recommendation should contain recommendations names with 0 clusters
           | Name        | Modified    | Category             | Total risk | Risk of change | Clusters |
@@ -178,9 +181,10 @@ Feature: Filtering on Advisor recommendations page behaviour on Hybrid Cloud Con
       And that table should contain exactly 1 row
           | Name        | Modified    | Category             | Total risk | Risk of change | Clusters |
           | Abc12345    | 10 days ago | Service Availability | Important  | High           | 0        |
-      And one filter needs to be preselected
+      And 2 filters need to be preselected
           | Filter name | Tag     |
           | Name        | "Abc"   |
+          | Status      | Enabled |
      When user clicks on "x" icon displayed on "Abc" filter tag
      Then table with several columns should be displayed
           | Column name    |
@@ -244,9 +248,10 @@ Feature: Filtering on Advisor recommendations page behaviour on Hybrid Cloud Con
       And that table should contain exactly 1 row
           | Name        | Modified    | Category             | Total risk | Risk of change | Clusters |
           | Bug12345    | 10 days ago | Service Availability | Important  | High           | 1        |
-      And one filter needs to be preselected
+      And 2 filters need to be preselected
           | Filter name       | Tag         |
           | Clusters impacted | 1 or more   |
+          | Status            | Enabled     |
      When user clicks on "x" icon displayed on "1 or more" filter tag
      Then table with advisor recommendation should contain recommendations names with 0 clusters
           | Name        | Modified    | Category             | Total risk | Risk of change | Clusters |
@@ -273,9 +278,10 @@ Feature: Filtering on Advisor recommendations page behaviour on Hybrid Cloud Con
       And that table should contain exactly 1 row
           | Name        | Modified    | Category             | Total risk | Risk of change | Clusters |
           | Xyz12345    | 10 days ago | Performance          | Moderate   | Low            | 0        |
-      And one filter needs to be preselected
+      And 2 filters need to be preselected
           | Filter name | Tag        |
           | Total risk  | "Moderate" |
+          | Status      | Enabled    |
      When user clicks on "x" icon displayed on "Moderate" filter tag
      Then table with several columns should be displayed
           | Column name    |
@@ -339,9 +345,10 @@ Feature: Filtering on Advisor recommendations page behaviour on Hybrid Cloud Con
       And that table should contain exactly 1 row
           | Name        | Modified    | Category             | Total risk | Risk of change | Clusters |
           | Bug12345    | 10 days ago | Service Availability | Important  | High           | 1        |
-      And one filter needs to be preselected
+      And 2 filters need to be preselected
           | Filter name       | Tag         |
           | Clusters impacted | 1 or more   |
+          | Status            | Enabled     |
      When user clicks on "x" icon displayed on "1 or more" filter tag
      Then table with advisor recommendation should contain recommendations names with 0 clusters
           | Name        | Modified    | Category             | Total risk | Risk of change | Clusters |
@@ -362,9 +369,10 @@ Feature: Filtering on Advisor recommendations page behaviour on Hybrid Cloud Con
       And that table should contain exactly 1 row
           | Name        | Modified    | Category             | Total risk | Risk of change | Clusters |
           | Bug12345    | 10 days ago | Service Availability | Important  | High           | 1        |
-      And one filter needs to be preselected
+      And 2 filters need to be preselected
           | Filter name       | Tag       |
           | Clusters impacted | 1 or more |
+          | Status            | Enabled   |
      When user clicks on "x" icon displayed on "1 or more" filter tag
      Then table with several columns should be displayed
           | Column name    |
@@ -428,9 +436,10 @@ Feature: Filtering on Advisor recommendations page behaviour on Hybrid Cloud Con
       And that table should contain exactly 1 row
           | Name        | Modified    | Category             | Total risk | Risk of change | Clusters |
           | Bug12345    | 10 days ago | Service Availability | Important  | High           | 1        |
-      And one filter needs to be preselected
+      And 2 filters need to be preselected
           | Filter name       | Tag         |
           | Clusters impacted | 1 or more   |
+          | Status            | Enabled     |
      When user clicks on "x" icon displayed on "1 or more" filter tag
      Then table with advisor recommendation should contain recommendations names with 0 clusters
           | Name        | Modified    | Category             | Total risk | Risk of change | Clusters |
@@ -457,9 +466,10 @@ Feature: Filtering on Advisor recommendations page behaviour on Hybrid Cloud Con
       And that table should contain exactly 1 row
           | Name        | Modified    | Category             | Total risk | Risk of change | Clusters |
           | Xyz12345    | 10 days ago | Performance          | Moderate   | Low            | 0        |
-      And one filter needs to be preselected
+      And 2 filters need to be preselected
           | Filter name | Tag        |
           | Total risk  | "Moderate" |
+          | Status      | Enabled    |
      When user clicks on "Reset filters" link
      Then table with several columns should be displayed
           | Column name    |
@@ -474,9 +484,10 @@ Feature: Filtering on Advisor recommendations page behaviour on Hybrid Cloud Con
           | Abc12345    | 10 days ago | Service Availability | Important  | High           | 0        |
           | Bug12345    | 10 days ago | Service Availability | Important  | High           | 1        |
           | Xyz12345    | 10 days ago | Performance          | Moderate   | Low            | 0        |
-      And one filter needs to be preselected
+      And 2 filters need to be preselected
           | Filter name       | Tag         |
           | Clusters impacted | 1 or more   |
+          | Status            | Enabled     |
 
 
   Scenario: Set filter "Category" on Advisor's "Recommendations" page on Hybrid Cloud Console with at least one recommendation and two clusters
@@ -526,9 +537,10 @@ Feature: Filtering on Advisor recommendations page behaviour on Hybrid Cloud Con
           | PerfBug  | 10 days ago | Performance     | Important  | Moderate       | 1        |
           | FaultBug | 10 days ago | Fault tolerance | Important  | Low            | 1        |
           | Security | 10 days ago | Security        | Important  | High           | 1        |
-      And one filter needs to be preselected
+      And 2 filters need to be preselected
           | Filter name       | Tag         |
           | Clusters impacted | 1 or more   |
+          | Status            | Enabled     |
      When user clicks on "x" icon displayed on "1 or more" filter tag
      Then table with advisor recommendation should contain recommendations names with 0 clusters
           | Name     | Modified    | Category        | Total risk | Risk of change | Clusters |
@@ -555,9 +567,10 @@ Feature: Filtering on Advisor recommendations page behaviour on Hybrid Cloud Con
       And that table should contain exactly 1 row
           | Name     | Modified    | Category        | Total risk | Risk of change | Clusters |
           | PerfBug  | 10 days ago | Performance     | Important  | Moderate       | 1        |
-      And one filter needs to be preselected
+      And 2 filters need to be preselected
           | Filter name       | Tag         |
           | Category          | Performance |
+          | Status            | Enabled     |
      When user selects "Category" in filter names pull-down menu
      Then search input field becomes a pull-down menu with several options
           | Option |
@@ -578,10 +591,11 @@ Feature: Filtering on Advisor recommendations page behaviour on Hybrid Cloud Con
           | Name     | Modified    | Category        | Total risk | Risk of change | Clusters |
           | PerfBug  | 10 days ago | Performance     | Important  | Moderate       | 1        |
           | FaultBug | 10 days ago | Fault tolerance | Important  | Low            | 1        |
-      And two filters needs to be preselected
+      And 3 filters need to be preselected
           | Filter name       | Tag             |
           | Category          | Performance     |
           | Category          | Fault Tolerance |
+          | Status            | Enabled         |
      When user clicks on "x" icon displayed on "Performance" filter tag
      Then table with several columns should be displayed
           | Column name    |
@@ -657,9 +671,10 @@ Feature: Filtering on Advisor recommendations page behaviour on Hybrid Cloud Con
           | High   | 10 days ago | Security    | Important  | Moderate       | 1        |
           | Medium | 10 days ago | Security    | Important  | Moderate       | 1        |
           | Low    | 10 days ago | Performance | Important  | Low            | 1        |
-      And one filter needs to be preselected
+      And 2 filters need to be preselected
           | Filter name       | Tag         |
           | Clusters impacted | 1 or more   |
+          | Status            | Enabled     |
      When user clicks on "x" icon displayed on "1 or more" filter tag
      Then table with advisor recommendation should contain recommendations names with 0 clusters
           | Name   | Modified    | Category    | Total risk | Risk of change | Clusters |
@@ -686,9 +701,10 @@ Feature: Filtering on Advisor recommendations page behaviour on Hybrid Cloud Con
       And that table should contain exactly 1 row
           | Name   | Modified    | Category    | Total risk | Risk of change | Clusters |
           | High   | 10 days ago | Security    | Important  | Moderate       | 1        |
-      And one filter needs to be preselected
-          | Filter name | Tag  |
-          | Likelihood  | High |
+      And 2 filters need to be preselected
+          | Filter name | Tag     |
+          | Likelihood  | High    |
+          | Status      | Enabled |
      When user selects "Likelihood" in filter names pull-down menu
      Then search input field becomes a pull-down menu with several options
           | Option name |
@@ -709,10 +725,11 @@ Feature: Filtering on Advisor recommendations page behaviour on Hybrid Cloud Con
           | Name   | Modified    | Category    | Total risk | Risk of change | Clusters |
           | High   | 10 days ago | Security    | Important  | Moderate       | 1        |
           | Low    | 10 days ago | Performance | Important  | Low            | 1        |
-      And two filters needs to be preselected
-          | Filter name | Tag  |
-          | Likelihood  | High |
-          | Likelihood  | Low  |
+      And 3 filters need to be preselected
+          | Filter name | Tag     |
+          | Likelihood  | High    |
+          | Likelihood  | Low     |
+          | Status      | Enabled |
      When user clicks on "x" icon displayed on "High" filter tag
      Then table with several columns should be displayed
           | Column name    |
@@ -788,9 +805,10 @@ Feature: Filtering on Advisor recommendations page behaviour on Hybrid Cloud Con
           | High   | 10 days ago | Security    | Important  | Moderate       | 1        |
           | Medium | 10 days ago | Security    | Important  | Moderate       | 1        |
           | Low    | 10 days ago | Performance | Important  | Low            | 1        |
-      And one filter needs to be preselected
+      And 2 filters need to be preselected
           | Filter name       | Tag         |
           | Clusters impacted | 1 or more   |
+          | Status            | Enabled     |
      When user selects "Likelihood" in filter names pull-down menu
      Then search input field becomes a pull-down menu with several options
           | Option name |
@@ -849,9 +867,10 @@ Feature: Filtering on Advisor recommendations page behaviour on Hybrid Cloud Con
       And that table should contain exactly 1 row
           | Name        | Modified    | Category             | Total risk | Risk of change | Clusters |
           | Bug12345    | 10 days ago | Service Availability | Important  | High           | 1        |
-      And one filter needs to be preselected
+      And 2 filters need to be preselected
           | Filter name       | Tag         |
           | Clusters impacted | 1 or more   |
+          | Status            | Enabled     |
      When user clicks on "x" icon displayed on "1 or more" filter tag
      Then table with advisor recommendation should contain recommendations names with 0 clusters
           | Name        | Modified    | Category             | Total risk | Risk of change | Clusters |
@@ -878,9 +897,10 @@ Feature: Filtering on Advisor recommendations page behaviour on Hybrid Cloud Con
       And that table should contain exactly 1 row
           | Name        | Modified    | Category             | Total risk | Risk of change | Clusters |
           | Xyz12345    | 10 days ago | Performance          | Moderate   | Low            | 0        |
-      And one filter needs to be preselected
+      And 2 filters need to be preselected
           | Filter name     | Tag        |
           | Risk of change  | Low        |
+          | Status          | Enabled    |
      When user selects "Risk of change" in filter names pull-down menu
      Then search input field becomes a pull-down menu with several options
           | Option name |
@@ -902,10 +922,11 @@ Feature: Filtering on Advisor recommendations page behaviour on Hybrid Cloud Con
           | Abc12345    | 10 days ago | Service Availability | Important  | High           | 0        |
           | Bug12345    | 10 days ago | Service Availability | Important  | High           | 1        |
           | Xyz12345    | 10 days ago | Performance          | Moderate   | Low            | 0        |
-      And two filters needs to be preselected
+      And 3 filters need to be preselected
           | Filter name     | Tag        |
           | Risk of change  | Low        |
           | Risk of change  | High       |
+          | Status          | Enabled    |
      When user clicks on "x" icon displayed on "Low" filter tag
      Then table with several columns should be displayed
           | Column name    |

--- a/features/Insights_Advisor/recommendations_page_filtering.feature
+++ b/features/Insights_Advisor/recommendations_page_filtering.feature
@@ -8,8 +8,8 @@ Feature: Filtering on Advisor recommendations page behaviour on Hybrid Cloud Con
           | 00000000-0000-0000-0000-000000000000 |
           | 11111111-0000-0000-0000-000000000000 |
       And 1 issue is detected for cluster 00000000-0000-0000-0000-000000000000
-          | Title    | Modified    | Total risk |
-          | Bug12345 | 10 days ago | Important  |
+          | Title    | Modified    | Total risk | Risk of change | Category             |
+          | Bug12345 | 10 days ago | Important  | High           | Service Availability |
       And the user USER1 is already logged in into Hybrid Cloud Console
      When user looks at Hybrid Cloud Console main page
      Then menu on the left side should be displayed
@@ -34,14 +34,16 @@ Feature: Filtering on Advisor recommendations page behaviour on Hybrid Cloud Con
      Then an "Advisor recommendations" page should be displayed right of the left menu bar
       And widget with filter settings should be displayed
       And table with several columns should be displayed
-          | Column name |
-          | Name        |
-          | Modified    |
-          | Total risk  |
-          | Clusters    |
+          | Column name    |
+          | Name           |
+          | Modified       |
+          | Category       |
+          | Total risk     |
+          | Risk of change |
+          | Clusters       |
       And that table should contain exactly 1 row
-          | Name        | Modified    | Total risk | Clusters |
-          | Bug12345    | 10 days ago | Important  | 1        |
+          | Name        | Modified    | Category             | Total risk | Risk of change | Clusters |
+          | Bug12345    | 10 days ago | Service Availability | Important  | High           | 1        |
       And one filter needs to be preselected
           | Filter name       | Tag         |
           | Clusters impacted | 1 or more   |
@@ -54,12 +56,12 @@ Feature: Filtering on Advisor recommendations page behaviour on Hybrid Cloud Con
           | 00000000-0000-0000-0000-000000000000 |
           | 11111111-0000-0000-0000-000000000000 |
       And 1 issue is detected for cluster 00000000-0000-0000-0000-000000000000
-          | Title    | Modified    | Total risk |
-          | Bug12345 | 10 days ago | Important  |
+          | Title    | Modified    | Total risk | Risk of change | Category             |
+          | Bug12345 | 10 days ago | Important  | High           | Service Availability |
       And 2 another recommendations are available (but not detected)
-          | Title    | Modified    | Total risk |
-          | Abc12345 | 10 days ago | Important  |
-          | Xyz12345 | 10 days ago | Important  |
+          | Title    | Modified    | Total risk | Risk of change | Category             |
+          | Abc12345 | 10 days ago | Important  | High           | Service Availability |
+          | Xyz12345 | 10 days ago | Important  | Low            | Performance          |
       And the user USER1 is already logged in into Hybrid Cloud Console
      When user looks at Hybrid Cloud Console main page
      Then menu on the left side should be displayed
@@ -84,24 +86,26 @@ Feature: Filtering on Advisor recommendations page behaviour on Hybrid Cloud Con
      Then an "Advisor recommendations" page should be displayed right of the left menu bar
       And widget with filter settings should be displayed
       And table with several columns should be displayed
-          | Column name |
-          | Name        |
-          | Modified    |
-          | Total risk  |
-          | Clusters    |
+          | Column name    |
+          | Name           |
+          | Modified       |
+          | Category       |
+          | Total risk     |
+          | Risk of change |
+          | Clusters       |
       And that table should contain exactly 1 row
-          | Name        | Modified    | Total risk | Clusters |
-          | Bug12345    | 10 days ago | Important  | 1        |
+          | Name        | Modified    | Category             | Total risk | Risk of change | Clusters |
+          | Bug12345    | 10 days ago | Service Availability | Important  | High           | 1        |
       And one filter needs to be preselected
           | Filter name       | Tag         |
           | Clusters impacted | 1 or more   |
      When user clicks on "x" icon displayed on "1 or more" filter tag
      Then table with advisor recommendation should contain recommendations names with 0 clusters
       And that table should contain 3 rows
-          | Name        | Modified    | Total risk | Clusters |
-          | Abc12345    | 10 days ago | Important  | 0        |
-          | Bug12345    | 10 days ago | Important  | 1        |
-          | Xyz12345    | 10 days ago | Important  | 0        |
+          | Name        | Modified    | Category             | Total risk | Risk of change | Clusters |
+          | Abc12345    | 10 days ago | Service Availability | Important  | High           | 0        |
+          | Bug12345    | 10 days ago | Service Availability | Important  | High           | 1        |
+          | Xyz12345    | 10 days ago | Performance          | Important  | Low            | 0        |
 
 
   Scenario: Set filter "Name" on Advisor's "Recommendations" page on Hybrid Cloud Console with at least one recommendation and two clusters
@@ -111,12 +115,12 @@ Feature: Filtering on Advisor recommendations page behaviour on Hybrid Cloud Con
           | 00000000-0000-0000-0000-000000000000 |
           | 11111111-0000-0000-0000-000000000000 |
       And 1 issue is detected for cluster 00000000-0000-0000-0000-000000000000
-          | Title    | Modified    | Total risk |
-          | Bug12345 | 10 days ago | Important  |
+          | Title    | Modified    | Total risk | Risk of change | Category             |
+          | Bug12345 | 10 days ago | Important  | High           | Service Availability |
       And 2 another recommendations are available (but not detected)
-          | Title    | Modified    | Total risk |
-          | Abc12345 | 10 days ago | Important  |
-          | Xyz12345 | 10 days ago | Important  |
+          | Title    | Modified    | Total risk | Risk of change | Category             |
+          | Abc12345 | 10 days ago | Important  | High           | Service Availability |
+          | Xyz12345 | 10 days ago | Important  | Low            | Performance          |
       And the user USER1 is already logged in into Hybrid Cloud Console
      When user looks at Hybrid Cloud Console main page
      Then menu on the left side should be displayed
@@ -141,50 +145,56 @@ Feature: Filtering on Advisor recommendations page behaviour on Hybrid Cloud Con
      Then an "Advisor recommendations" page should be displayed right of the left menu bar
       And widget with filter settings should be displayed
       And table with several columns should be displayed
-          | Column name |
-          | Name        |
-          | Modified    |
-          | Total risk  |
-          | Clusters    |
+          | Column name    |
+          | Name           |
+          | Modified       |
+          | Category       |
+          | Total risk     |
+          | Risk of change |
+          | Clusters       |
       And that table should contain exactly 1 row
-          | Name        | Modified    | Total risk | Clusters |
-          | Bug12345    | 10 days ago | Important  | 1        |
+          | Name        | Modified    | Category             | Total risk | Risk of change | Clusters |
+          | Bug12345    | 10 days ago | Service Availability | Important  | High           | 1        |
       And one filter needs to be preselected
           | Filter name       | Tag         |
           | Clusters impacted | 1 or more   |
      When user clicks on "x" icon displayed on "1 or more" filter tag
      Then table with advisor recommendation should contain recommendations names with 0 clusters
-          | Name        | Modified    | Total risk | Clusters |
-          | Abc12345    | 10 days ago | Important  | 0        |
-          | Bug12345    | 10 days ago | Important  | 1        |
-          | Xyz12345    | 10 days ago | Important  | 0        |
+          | Name        | Modified    | Category             | Total risk | Risk of change | Clusters |
+          | Abc12345    | 10 days ago | Service Availability | Important  | High           | 0        |
+          | Bug12345    | 10 days ago | Service Availability | Important  | High           | 1        |
+          | Xyz12345    | 10 days ago | Performance          | Important  | Low            | 0        |
       And filter widget should consists of filter names pull-down menu and filter search input field
      When user selects "Name" in filter names pull-down menu
       And user fill in "Abc" into filter search input field
      Then table with several columns should be displayed
-          | Column name |
-          | Name        |
-          | Modified    |
-          | Total risk  |
-          | Clusters    |
+          | Column name    |
+          | Name           |
+          | Modified       |
+          | Category       |
+          | Total risk     |
+          | Risk of change |
+          | Clusters       |
       And that table should contain exactly 1 row
-          | Name        | Modified    | Total risk | Clusters |
-          | Abc12345    | 10 days ago | Important  | 0        |
+          | Name        | Modified    | Category             | Total risk | Risk of change | Clusters |
+          | Abc12345    | 10 days ago | Service Availability | Important  | High           | 0        |
       And one filter needs to be preselected
           | Filter name | Tag     |
           | Name        | "Abc"   |
      When user clicks on "x" icon displayed on "Abc" filter tag
      Then table with several columns should be displayed
-          | Column name |
-          | Name        |
-          | Modified    |
-          | Total risk  |
-          | Clusters    |
+          | Column name    |
+          | Name           |
+          | Modified       |
+          | Category       |
+          | Total risk     |
+          | Risk of change |
+          | Clusters       |
       And that table should contain three rows
-          | Name        | Modified    | Total risk | Clusters |
-          | Abc12345    | 10 days ago | Important  | 0        |
-          | Bug12345    | 10 days ago | Important  | 1        |
-          | Xyz12345    | 10 days ago | Important  | 0        |
+          | Name        | Modified    | Category             | Total risk | Risk of change | Clusters |
+          | Abc12345    | 10 days ago | Service Availability | Important  | High           | 0        |
+          | Bug12345    | 10 days ago | Service Availability | Important  | High           | 1        |
+          | Xyz12345    | 10 days ago | Performance          | Important  | Low            | 0        |
 
 
   Scenario: Set filter "Total risk" on Advisor's "Recommendations" page on Hybrid Cloud Console with at least one recommendation and two clusters
@@ -194,12 +204,12 @@ Feature: Filtering on Advisor recommendations page behaviour on Hybrid Cloud Con
           | 00000000-0000-0000-0000-000000000000 |
           | 11111111-0000-0000-0000-000000000000 |
       And 1 issue is detected for cluster 00000000-0000-0000-0000-000000000000
-          | Title    | Modified    | Total risk |
-          | Bug12345 | 10 days ago | Important  |
+          | Title    | Modified    | Total risk | Risk of change | Category             |
+          | Bug12345 | 10 days ago | Important  | High           | Service Availability |
       And 2 another recommendations are available (but not detected)
-          | Title    | Modified    | Total risk |
-          | Abc12345 | 10 days ago | Important  |
-          | Xyz12345 | 10 days ago | Moderate   |
+          | Title    | Modified    | Total risk | Risk of change | Category             |
+          | Abc12345 | 10 days ago | Important  | High           | Service Availability |
+          | Xyz12345 | 10 days ago | Moderate   | Low            | Performance          |
       And the user USER1 is already logged in into Hybrid Cloud Console
      When user looks at Hybrid Cloud Console main page
      Then menu on the left side should be displayed
@@ -224,23 +234,25 @@ Feature: Filtering on Advisor recommendations page behaviour on Hybrid Cloud Con
      Then an "Advisor recommendations" page should be displayed right of the left menu bar
       And widget with filter settings should be displayed
       And table with several columns should be displayed
-          | Column name |
-          | Name        |
-          | Modified    |
-          | Total risk  |
-          | Clusters    |
+          | Column name    |
+          | Name           |
+          | Modified       |
+          | Category       |
+          | Total risk     |
+          | Risk of change |
+          | Clusters       |
       And that table should contain exactly 1 row
-          | Name        | Modified    | Total risk | Clusters |
-          | Bug12345    | 10 days ago | Important  | 1        |
+          | Name        | Modified    | Category             | Total risk | Risk of change | Clusters |
+          | Bug12345    | 10 days ago | Service Availability | Important  | High           | 1        |
       And one filter needs to be preselected
           | Filter name       | Tag         |
           | Clusters impacted | 1 or more   |
      When user clicks on "x" icon displayed on "1 or more" filter tag
      Then table with advisor recommendation should contain recommendations names with 0 clusters
-          | Name        | Modified    | Total risk | Clusters |
-          | Abc12345    | 10 days ago | Important  | 0        |
-          | Bug12345    | 10 days ago | Important  | 1        |
-          | Xyz12345    | 10 days ago | Moderate   | 0        |
+          | Name        | Modified    | Category             | Total risk | Risk of change | Clusters |
+          | Abc12345    | 10 days ago | Service Availability | Important  | High           | 0        |
+          | Bug12345    | 10 days ago | Service Availability | Important  | High           | 1        |
+          | Xyz12345    | 10 days ago | Performance          | Moderate   | Low            | 0        |
       And filter widget should consists of filter names pull-down menu and filter search input field
      When user selects "Total risk" in filter names pull-down menu
      Then search input field becomes a pull-down menu with several options
@@ -251,29 +263,33 @@ Feature: Filtering on Advisor recommendations page behaviour on Hybrid Cloud Con
           | Low         |
      When user select "Moderate" from the rigth pull-down menu
      Then table with several columns should be displayed
-          | Column name |
-          | Name        |
-          | Modified    |
-          | Total risk  |
-          | Clusters    |
+          | Column name    |
+          | Name           |
+          | Modified       |
+          | Category       |
+          | Total risk     |
+          | Risk of change |
+          | Clusters       |
       And that table should contain exactly 1 row
-          | Name        | Modified    | Total risk | Clusters |
-          | Xyz12345    | 10 days ago | Moderate   | 0        |
+          | Name        | Modified    | Category             | Total risk | Risk of change | Clusters |
+          | Xyz12345    | 10 days ago | Performance          | Moderate   | Low            | 0        |
       And one filter needs to be preselected
           | Filter name | Tag        |
           | Total risk  | "Moderate" |
      When user clicks on "x" icon displayed on "Moderate" filter tag
      Then table with several columns should be displayed
-          | Column name |
-          | Name        |
-          | Modified    |
-          | Total risk  |
-          | Clusters    |
+          | Column name    |
+          | Name           |
+          | Modified       |
+          | Category       |
+          | Total risk     |
+          | Risk of change |
+          | Clusters       |
       And that table should contain three rows
-          | Name        | Modified    | Total risk | Clusters |
-          | Abc12345    | 10 days ago | Important  | 0        |
-          | Bug12345    | 10 days ago | Important  | 1        |
-          | Xyz12345    | 10 days ago | Moderate   | 0        |
+          | Name        | Modified    | Category             | Total risk | Risk of change | Clusters |
+          | Abc12345    | 10 days ago | Service Availability | Important  | High           | 0        |
+          | Bug12345    | 10 days ago | Service Availability | Important  | High           | 1        |
+          | Xyz12345    | 10 days ago | Performance          | Moderate   | Low            | 0        |
 
 
   Scenario: Set filter "Clusters impacted" on Advisor's "Recommendations" page on Hybrid Cloud Console with at least one recommendation and two clusters
@@ -283,12 +299,12 @@ Feature: Filtering on Advisor recommendations page behaviour on Hybrid Cloud Con
           | 00000000-0000-0000-0000-000000000000 |
           | 11111111-0000-0000-0000-000000000000 |
       And 1 issue is detected for cluster 00000000-0000-0000-0000-000000000000
-          | Title    | Modified    | Total risk |
-          | Bug12345 | 10 days ago | Important  |
+          | Title    | Modified    | Total risk | Risk of change | Category             |
+          | Bug12345 | 10 days ago | Important  | High           | Service Availability |
       And 2 another recommendations are available (but not detected)
-          | Title    | Modified    | Total risk |
-          | Abc12345 | 10 days ago | Important  |
-          | Xyz12345 | 10 days ago | Moderate   |
+          | Title    | Modified    | Total risk | Risk of change | Category             |
+          | Abc12345 | 10 days ago | Important  | High           | Service Availability |
+          | Xyz12345 | 10 days ago | Moderate   | Low            | Performance          |
       And the user USER1 is already logged in into Hybrid Cloud Console
      When user looks at Hybrid Cloud Console main page
      Then menu on the left side should be displayed
@@ -313,50 +329,56 @@ Feature: Filtering on Advisor recommendations page behaviour on Hybrid Cloud Con
      Then an "Advisor recommendations" page should be displayed right of the left menu bar
       And widget with filter settings should be displayed
       And table with several columns should be displayed
-          | Column name |
-          | Name        |
-          | Modified    |
-          | Total risk  |
-          | Clusters    |
+          | Column name    |
+          | Name           |
+          | Modified       |
+          | Category       |
+          | Total risk     |
+          | Risk of change |
+          | Clusters       |
       And that table should contain exactly 1 row
-          | Name        | Modified    | Total risk | Clusters |
-          | Bug12345    | 10 days ago | Important  | 1        |
+          | Name        | Modified    | Category             | Total risk | Risk of change | Clusters |
+          | Bug12345    | 10 days ago | Service Availability | Important  | High           | 1        |
       And one filter needs to be preselected
           | Filter name       | Tag         |
           | Clusters impacted | 1 or more   |
      When user clicks on "x" icon displayed on "1 or more" filter tag
      Then table with advisor recommendation should contain recommendations names with 0 clusters
-          | Name        | Modified    | Total risk | Clusters |
-          | Abc12345    | 10 days ago | Important  | 0        |
-          | Bug12345    | 10 days ago | Important  | 1        |
-          | Xyz12345    | 10 days ago | Moderate   | 0        |
+          | Name        | Modified    | Category             | Total risk | Risk of change | Clusters |
+          | Abc12345    | 10 days ago | Service Availability | Important  | High           | 0        |
+          | Bug12345    | 10 days ago | Service Availability | Important  | High           | 1        |
+          | Xyz12345    | 10 days ago | Performance          | Moderate   | Low            | 0        |
       And filter widget should consists of filter names pull-down menu and filter search input field
      When user selects "Clusters impacted" in filter names pull-down menu
       And user select "1 or more" from the rigth pull-down menu
      Then table with several columns should be displayed
-          | Column name |
-          | Name        |
-          | Modified    |
-          | Total risk  |
-          | Clusters    |
+          | Column name    |
+          | Name           |
+          | Modified       |
+          | Category       |
+          | Total risk     |
+          | Risk of change |
+          | Clusters       |
       And that table should contain exactly 1 row
-          | Name        | Modified    | Total risk | Clusters |
-          | Bug12345    | 10 days ago | Important  | 1        |
+          | Name        | Modified    | Category             | Total risk | Risk of change | Clusters |
+          | Bug12345    | 10 days ago | Service Availability | Important  | High           | 1        |
       And one filter needs to be preselected
           | Filter name       | Tag       |
           | Clusters impacted | 1 or more |
      When user clicks on "x" icon displayed on "1 or more" filter tag
      Then table with several columns should be displayed
-          | Column name |
-          | Name        |
-          | Modified    |
-          | Total risk  |
-          | Clusters    |
+          | Column name    |
+          | Name           |
+          | Modified       |
+          | Category       |
+          | Total risk     |
+          | Risk of change |
+          | Clusters       |
       And that table should contain three rows
-          | Name        | Modified    | Total risk | Clusters |
-          | Abc12345    | 10 days ago | Important  | 0        |
-          | Bug12345    | 10 days ago | Important  | 1        |
-          | Xyz12345    | 10 days ago | Moderate   | 0        |
+          | Name        | Modified    | Category             | Total risk | Risk of change | Clusters |
+          | Abc12345    | 10 days ago | Service Availability | Important  | High           | 0        |
+          | Bug12345    | 10 days ago | Service Availability | Important  | High           | 1        |
+          | Xyz12345    | 10 days ago | Performance          | Moderate   | Low            | 0        |
 
 
   Scenario: Reset filter to default value on Advisor's "Recommendations" page on Hybrid Cloud Console with at least one recommendation and two clusters
@@ -366,12 +388,12 @@ Feature: Filtering on Advisor recommendations page behaviour on Hybrid Cloud Con
           | 00000000-0000-0000-0000-000000000000 |
           | 11111111-0000-0000-0000-000000000000 |
       And 1 issue is detected for cluster 00000000-0000-0000-0000-000000000000
-          | Title    | Modified    | Total risk |
-          | Bug12345 | 10 days ago | Important  |
+          | Title    | Modified    | Total risk | Risk of change | Category             |
+          | Bug12345 | 10 days ago | Important  | High           | Service Availability |
       And 2 another recommendations are available (but not detected)
-          | Title    | Modified    | Total risk |
-          | Abc12345 | 10 days ago | Important  |
-          | Xyz12345 | 10 days ago | Moderate   |
+          | Title    | Modified    | Total risk | Risk of change | Category             |
+          | Abc12345 | 10 days ago | Important  | High           | Service Availability |
+          | Xyz12345 | 10 days ago | Moderate   | Low            | Performance          |
       And the user USER1 is already logged in into Hybrid Cloud Console
      When user looks at Hybrid Cloud Console main page
      Then menu on the left side should be displayed
@@ -396,23 +418,25 @@ Feature: Filtering on Advisor recommendations page behaviour on Hybrid Cloud Con
      Then an "Advisor recommendations" page should be displayed right of the left menu bar
       And widget with filter settings should be displayed
       And table with several columns should be displayed
-          | Column name |
-          | Name        |
-          | Modified    |
-          | Total risk  |
-          | Clusters    |
+          | Column name    |
+          | Name           |
+          | Modified       |
+          | Category       |
+          | Total risk     |
+          | Risk of change |
+          | Clusters       |
       And that table should contain exactly 1 row
-          | Name        | Modified    | Total risk | Clusters |
-          | Bug12345    | 10 days ago | Important  | 1        |
+          | Name        | Modified    | Category             | Total risk | Risk of change | Clusters |
+          | Bug12345    | 10 days ago | Service Availability | Important  | High           | 1        |
       And one filter needs to be preselected
           | Filter name       | Tag         |
           | Clusters impacted | 1 or more   |
      When user clicks on "x" icon displayed on "1 or more" filter tag
      Then table with advisor recommendation should contain recommendations names with 0 clusters
-          | Name        | Modified    | Total risk | Clusters |
-          | Abc12345    | 10 days ago | Important  | 0        |
-          | Bug12345    | 10 days ago | Important  | 1        |
-          | Xyz12345    | 10 days ago | Moderate   | 0        |
+          | Name        | Modified    | Category             | Total risk | Risk of change | Clusters |
+          | Abc12345    | 10 days ago | Service Availability | Important  | High           | 0        |
+          | Bug12345    | 10 days ago | Service Availability | Important  | High           | 1        |
+          | Xyz12345    | 10 days ago | Performance          | Moderate   | Low            | 0        |
       And filter widget should consists of filter names pull-down menu and filter search input field
      When user selects "Total risk" in filter names pull-down menu
      Then search input field becomes a pull-down menu with several options
@@ -423,29 +447,33 @@ Feature: Filtering on Advisor recommendations page behaviour on Hybrid Cloud Con
           | Low         |
      When user select "Moderate" from the rigth pull-down menu
      Then table with several columns should be displayed
-          | Column name |
-          | Name        |
-          | Modified    |
-          | Total risk  |
-          | Clusters    |
+          | Column name    |
+          | Name           |
+          | Modified       |
+          | Category       |
+          | Total risk     |
+          | Risk of change |
+          | Clusters       |
       And that table should contain exactly 1 row
-          | Name        | Modified    | Total risk | Clusters |
-          | Xyz12345    | 10 days ago | Moderate   | 0        |
+          | Name        | Modified    | Category             | Total risk | Risk of change | Clusters |
+          | Xyz12345    | 10 days ago | Performance          | Moderate   | Low            | 0        |
       And one filter needs to be preselected
           | Filter name | Tag        |
           | Total risk  | "Moderate" |
      When user clicks on "Reset filters" link
      Then table with several columns should be displayed
-          | Column name |
-          | Name        |
-          | Modified    |
-          | Total risk  |
-          | Clusters    |
+          | Column name    |
+          | Name           |
+          | Modified       |
+          | Category       |
+          | Total risk     |
+          | Risk of change |
+          | Clusters       |
       And that table should contain 1 row
-          | Name        | Modified    | Total risk | Clusters |
-          | Abc12345    | 10 days ago | Important  | 0        |
-          | Bug12345    | 10 days ago | Important  | 1        |
-          | Xyz12345    | 10 days ago | Moderate   | 0        |
+          | Name        | Modified    | Category             | Total risk | Risk of change | Clusters |
+          | Abc12345    | 10 days ago | Service Availability | Important  | High           | 0        |
+          | Bug12345    | 10 days ago | Service Availability | Important  | High           | 1        |
+          | Xyz12345    | 10 days ago | Performance          | Moderate   | Low            | 0        |
       And one filter needs to be preselected
           | Filter name       | Tag         |
           | Clusters impacted | 1 or more   |
@@ -458,10 +486,10 @@ Feature: Filtering on Advisor recommendations page behaviour on Hybrid Cloud Con
           | 00000000-0000-0000-0000-000000000000 |
           | 11111111-0000-0000-0000-000000000000 |
       And 3 issues are detected for cluster 00000000-0000-0000-0000-000000000000
-          | Title    | Modified    | Total risk | Category        |
-          | PerfBug  | 10 days ago | Important  | Performance     |
-          | FaultBug | 10 days ago | Important  | Fault tolerance |
-          | Security | 10 days ago | Important  | Security        |
+          | Title    | Modified    | Total risk | Category        | Risk of change |
+          | PerfBug  | 10 days ago | Important  | Performance     | Moderate       |
+          | FaultBug | 10 days ago | Important  | Fault tolerance | Low            |
+          | Security | 10 days ago | Important  | Security        | High           |
       And the user USER1 is already logged in into Hybrid Cloud Console
      When user looks at Hybrid Cloud Console main page
      Then menu on the left side should be displayed
@@ -486,25 +514,27 @@ Feature: Filtering on Advisor recommendations page behaviour on Hybrid Cloud Con
      Then an "Advisor recommendations" page should be displayed right of the left menu bar
       And widget with filter settings should be displayed
       And table with several columns should be displayed
-          | Column name |
-          | Name        |
-          | Modified    |
-          | Total risk  |
-          | Clusters    |
+          | Column name    |
+          | Name           |
+          | Modified       |
+          | Category       |
+          | Total risk     |
+          | Risk of change |
+          | Clusters       |
       And that table should contain exactly 3 roww
-          | Name     | Modified    | Total risk | Clusters |
-          | PerfBug  | 10 days ago | Important  | 1        |
-          | FaultBug | 10 days ago | Important  | 1        |
-          | Security | 10 days ago | Important  | 1        |
+          | Name     | Modified    | Category        | Total risk | Risk of change | Clusters |
+          | PerfBug  | 10 days ago | Performance     | Important  | Moderate       | 1        |
+          | FaultBug | 10 days ago | Fault tolerance | Important  | Low            | 1        |
+          | Security | 10 days ago | Security        | Important  | High           | 1        |
       And one filter needs to be preselected
           | Filter name       | Tag         |
           | Clusters impacted | 1 or more   |
      When user clicks on "x" icon displayed on "1 or more" filter tag
      Then table with advisor recommendation should contain recommendations names with 0 clusters
-          | Name     | Modified    | Total risk | Clusters |
-          | PerfBug  | 10 days ago | Important  | 1        |
-          | FaultBug | 10 days ago | Important  | 1        |
-          | Security | 10 days ago | Important  | 1        |
+          | Name     | Modified    | Category        | Total risk | Risk of change | Clusters |
+          | PerfBug  | 10 days ago | Performance     | Important  | Moderate       | 1        |
+          | FaultBug | 10 days ago | Fault tolerance | Important  | Low            | 1        |
+          | Security | 10 days ago | Security        | Important  | High           | 1        |
       And filter widget should consists of filter names pull-down menu and filter search input field
      When user selects "Category" in filter names pull-down menu
      Then search input field becomes a pull-down menu with several options
@@ -515,14 +545,16 @@ Feature: Filtering on Advisor recommendations page behaviour on Hybrid Cloud Con
           | Security             |
      When user select "Performance" from the rigth pull-down menu
      Then table with several columns should be displayed
-          | Column name |
-          | Name        |
-          | Modified    |
-          | Total risk  |
-          | Clusters    |
+          | Column name    |
+          | Name           |
+          | Modified       |
+          | Category       |
+          | Total risk     |
+          | Risk of change |
+          | Clusters       |
       And that table should contain exactly 1 row
-          | Name     | Modified    | Total risk | Clusters |
-          | PerfBug  | 10 days ago | Important  | 1        |
+          | Name     | Modified    | Category        | Total risk | Risk of change | Clusters |
+          | PerfBug  | 10 days ago | Performance     | Important  | Moderate       | 1        |
       And one filter needs to be preselected
           | Filter name       | Tag         |
           | Category          | Performance |
@@ -535,41 +567,47 @@ Feature: Filtering on Advisor recommendations page behaviour on Hybrid Cloud Con
           | Security             |
      When user select "Fault tolerance" from the rigth pull-down menu
      Then table with several columns should be displayed
-          | Column name |
-          | Name        |
-          | Modified    |
-          | Total risk  |
-          | Clusters    |
+          | Column name    |
+          | Name           |
+          | Modified       |
+          | Category       |
+          | Total risk     |
+          | Risk of change |
+          | Clusters       |
       And that table should contain 2 rows
-          | Name     | Modified    | Total risk | Clusters |
-          | PerfBug  | 10 days ago | Important  | 1        |
-          | FaultBug | 10 days ago | Important  | 1        |
+          | Name     | Modified    | Category        | Total risk | Risk of change | Clusters |
+          | PerfBug  | 10 days ago | Performance     | Important  | Moderate       | 1        |
+          | FaultBug | 10 days ago | Fault tolerance | Important  | Low            | 1        |
       And two filters needs to be preselected
           | Filter name       | Tag             |
           | Category          | Performance     |
           | Category          | Fault Tolerance |
      When user clicks on "x" icon displayed on "Performance" filter tag
      Then table with several columns should be displayed
-          | Column name |
-          | Name        |
-          | Modified    |
-          | Total risk  |
-          | Clusters    |
+          | Column name    |
+          | Name           |
+          | Modified       |
+          | Category       |
+          | Total risk     |
+          | Risk of change |
+          | Clusters       |
       And that table should contain one row
-          | Name     | Modified    | Total risk | Clusters |
-          | FaultBug | 10 days ago | Important  | 1        |
+          | Name     | Modified    | Category        | Total risk | Risk of change | Clusters |
+          | FaultBug | 10 days ago | Fault tolerance | Important  | Low            | 1        |
      When user clicks on "x" icon displayed on "Fault tolerance" filter tag
      Then table with several columns should be displayed
-          | Column name |
-          | Name        |
-          | Modified    |
-          | Total risk  |
-          | Clusters    |
+          | Column name    |
+          | Name           |
+          | Modified       |
+          | Category       |
+          | Total risk     |
+          | Risk of change |
+          | Clusters       |
       And that table should contain one row
-          | Name     | Modified    | Total risk | Clusters |
-          | PerfBug  | 10 days ago | Important  | 1        |
-          | FaultBug | 10 days ago | Important  | 1        |
-          | Security | 10 days ago | Important  | 1        |
+          | Name     | Modified    | Category        | Total risk | Risk of change | Clusters |
+          | PerfBug  | 10 days ago | Performance     | Important  | Moderate       | 1        |
+          | FaultBug | 10 days ago | Fault tolerance | Important  | Low            | 1        |
+          | Security | 10 days ago | Security        | Important  | High           | 1        |
 
 
   Scenario: Set filter "Likelihood" on Advisor's "Recommendations" page on Hybrid Cloud Console with at least one recommendation and two clusters
@@ -579,10 +617,10 @@ Feature: Filtering on Advisor recommendations page behaviour on Hybrid Cloud Con
           | 00000000-0000-0000-0000-000000000000 |
           | 11111111-0000-0000-0000-000000000000 |
       And 3 issues are detected for cluster 00000000-0000-0000-0000-000000000000
-          | Title  | Modified    | Total risk | Likelihood |
-          | High   | 10 days ago | Important  | High       |
-          | Medium | 10 days ago | Important  | Medium     |
-          | Low    | 10 days ago | Important  | Low        |
+          | Title  | Modified    | Category    | Total risk | Risk of change | Likelihood |
+          | High   | 10 days ago | Security    | Important  | Moderate       | High       |
+          | Medium | 10 days ago | Security    | Important  | Moderate       | Medium     |
+          | Low    | 10 days ago | Performance | Important  | Low            | Low        |
       And the user USER1 is already logged in into Hybrid Cloud Console
      When user looks at Hybrid Cloud Console main page
      Then menu on the left side should be displayed
@@ -607,25 +645,27 @@ Feature: Filtering on Advisor recommendations page behaviour on Hybrid Cloud Con
      Then an "Advisor recommendations" page should be displayed right of the left menu bar
       And widget with filter settings should be displayed
       And table with several columns should be displayed
-          | Column name |
-          | Name        |
-          | Modified    |
-          | Total risk  |
-          | Clusters    |
+          | Column name    |
+          | Name           |
+          | Modified       |
+          | Category       |
+          | Total risk     |
+          | Risk of change |
+          | Clusters       |
       And that table should contain exactly 3 roww
-          | Name   | Modified    | Total risk | Clusters |
-          | High   | 10 days ago | Important  | 1        |
-          | Medium | 10 days ago | Important  | 1        |
-          | Low    | 10 days ago | Important  | 1        |
+          | Name   | Modified    | Category    | Total risk | Risk of change | Clusters |
+          | High   | 10 days ago | Security    | Important  | Moderate       | 1        |
+          | Medium | 10 days ago | Security    | Important  | Moderate       | 1        |
+          | Low    | 10 days ago | Performance | Important  | Low            | 1        |
       And one filter needs to be preselected
           | Filter name       | Tag         |
           | Clusters impacted | 1 or more   |
      When user clicks on "x" icon displayed on "1 or more" filter tag
      Then table with advisor recommendation should contain recommendations names with 0 clusters
-          | Name   | Modified    | Total risk | Clusters |
-          | High   | 10 days ago | Important  | 1        |
-          | Medium | 10 days ago | Important  | 1        |
-          | Low    | 10 days ago | Important  | 1        |
+          | Name   | Modified    | Category    | Total risk | Risk of change | Clusters |
+          | High   | 10 days ago | Security    | Important  | Moderate       | 1        |
+          | Medium | 10 days ago | Security    | Important  | Moderate       | 1        |
+          | Low    | 10 days ago | Performance | Important  | Low            | 1        |
       And filter widget should consists of filter names pull-down menu and filter search input field
      When user selects "Likelihood" in filter names pull-down menu
      Then search input field becomes a pull-down menu with several options
@@ -636,14 +676,16 @@ Feature: Filtering on Advisor recommendations page behaviour on Hybrid Cloud Con
           | Low         |
      When user select "High" from the rigth pull-down menu
      Then table with several columns should be displayed
-          | Column name |
-          | Name        |
-          | Modified    |
-          | Total risk  |
-          | Clusters    |
+          | Column name    |
+          | Name           |
+          | Modified       |
+          | Category       |
+          | Total risk     |
+          | Risk of change |
+          | Clusters       |
       And that table should contain exactly 1 row
-          | Name   | Modified    | Total risk | Clusters |
-          | High   | 10 days ago | Important  | 1        |
+          | Name   | Modified    | Category    | Total risk | Risk of change | Clusters |
+          | High   | 10 days ago | Security    | Important  | Moderate       | 1        |
       And one filter needs to be preselected
           | Filter name | Tag  |
           | Likelihood  | High |
@@ -656,41 +698,47 @@ Feature: Filtering on Advisor recommendations page behaviour on Hybrid Cloud Con
           | Low         |
      When user select "Low" from the rigth pull-down menu
      Then table with several columns should be displayed
-          | Column name |
-          | Name        |
-          | Modified    |
-          | Total risk  |
-          | Clusters    |
+          | Column name    |
+          | Name           |
+          | Modified       |
+          | Category       |
+          | Total risk     |
+          | Risk of change |
+          | Clusters       |
       And that table should contain 2 rows
-          | Name   | Modified    | Total risk | Clusters |
-          | High   | 10 days ago | Important  | 1        |
-          | Low    | 10 days ago | Important  | 1        |
+          | Name   | Modified    | Category    | Total risk | Risk of change | Clusters |
+          | High   | 10 days ago | Security    | Important  | Moderate       | 1        |
+          | Low    | 10 days ago | Performance | Important  | Low            | 1        |
       And two filters needs to be preselected
           | Filter name | Tag  |
           | Likelihood  | High |
           | Likelihood  | Low  |
      When user clicks on "x" icon displayed on "High" filter tag
      Then table with several columns should be displayed
-          | Column name |
-          | Name        |
-          | Modified    |
-          | Total risk  |
-          | Clusters    |
+          | Column name    |
+          | Name           |
+          | Modified       |
+          | Category       |
+          | Total risk     |
+          | Risk of change |
+          | Clusters       |
       And that table should contain one row
-          | Name   | Modified    | Total risk | Clusters |
-          | Low    | 10 days ago | Important  | 1        |
+          | Name   | Modified    | Category    | Total risk | Risk of change | Clusters |
+          | Low    | 10 days ago | Performance | Important  | Low            | 1        |
      When user clicks on "x" icon displayed on "Low" filter tag
      Then table with several columns should be displayed
-          | Column name |
-          | Name        |
-          | Modified    |
-          | Total risk  |
-          | Clusters    |
+          | Column name    |
+          | Name           |
+          | Modified       |
+          | Category       |
+          | Total risk     |
+          | Risk of change |
+          | Clusters       |
       And that table should contain one row
-          | Name   | Modified    | Total risk | Clusters |
-          | High   | 10 days ago | Important  | 1        |
-          | Medium | 10 days ago | Important  | 1        |
-          | Low    | 10 days ago | Important  | 1        |
+          | Name   | Modified    | Category    | Total risk | Risk of change | Clusters |
+          | High   | 10 days ago | Security    | Important  | Moderate       | 1        |
+          | Medium | 10 days ago | Security    | Important  | Moderate       | 1        |
+          | Low    | 10 days ago | Performance | Important  | Low            | 1        |
 
 
   Scenario: No-op action in filter menu on Advisor's "Recommendations" page on Hybrid Cloud Console with at least one recommendation and two clusters
@@ -700,10 +748,10 @@ Feature: Filtering on Advisor recommendations page behaviour on Hybrid Cloud Con
           | 00000000-0000-0000-0000-000000000000 |
           | 11111111-0000-0000-0000-000000000000 |
       And 3 issues are detected for cluster 00000000-0000-0000-0000-000000000000
-          | Title  | Modified    | Total risk | Likelihood |
-          | High   | 10 days ago | Important  | High       |
-          | Medium | 10 days ago | Important  | Medium     |
-          | Low    | 10 days ago | Important  | Low        |
+          | Title  | Modified    | Category    | Total risk | Risk of change | Likelihood |
+          | High   | 10 days ago | Security    | Important  | Moderate       | High       |
+          | Medium | 10 days ago | Security    | Important  | Moderate       | Medium     |
+          | Low    | 10 days ago | Performance | Important  | Low            | Low        |
       And the user USER1 is already logged in into Hybrid Cloud Console
      When user looks at Hybrid Cloud Console main page
      Then menu on the left side should be displayed
@@ -728,16 +776,18 @@ Feature: Filtering on Advisor recommendations page behaviour on Hybrid Cloud Con
      Then an "Advisor recommendations" page should be displayed right of the left menu bar
       And widget with filter settings should be displayed
       And table with several columns should be displayed
-          | Column name |
-          | Name        |
-          | Modified    |
-          | Total risk  |
-          | Clusters    |
+          | Column name    |
+          | Name           |
+          | Modified       |
+          | Category       |
+          | Total risk     |
+          | Risk of change |
+          | Clusters       |
       And that table should contain exactly 3 roww
-          | Name   | Modified    | Total risk | Clusters |
-          | High   | 10 days ago | Important  | 1        |
-          | Medium | 10 days ago | Important  | 1        |
-          | Low    | 10 days ago | Important  | 1        |
+          | Name   | Modified    | Category    | Total risk | Risk of change | Clusters |
+          | High   | 10 days ago | Security    | Important  | Moderate       | 1        |
+          | Medium | 10 days ago | Security    | Important  | Moderate       | 1        |
+          | Low    | 10 days ago | Performance | Important  | Low            | 1        |
       And one filter needs to be preselected
           | Filter name       | Tag         |
           | Clusters impacted | 1 or more   |
@@ -750,3 +800,136 @@ Feature: Filtering on Advisor recommendations page behaviour on Hybrid Cloud Con
           | Low         |
      When user select "None" from the rigth pull-down menu
      Then content of the table will remain unchanged
+
+
+  Scenario: Set and reset filter "Risk of change" on Advisor's "Recommendations" page on Hybrid Cloud Console with at least one recommendation and two clusters
+    Given user USER1 is part of account (organization) ACCOUNT1
+      And account (organization) ACCOUNT1 owns 2 clusters
+          | Cluster name                         |
+          | 00000000-0000-0000-0000-000000000000 |
+          | 11111111-0000-0000-0000-000000000000 |
+      And 1 issue is detected for cluster 00000000-0000-0000-0000-000000000000
+          | Title    | Modified    | Total risk | Risk of change | Category             |
+          | Bug12345 | 10 days ago | Important  | High           | Service Availability |
+      And 2 another recommendations are available (but not detected)
+          | Title    | Modified    | Total risk | Risk of change | Category             |
+          | Abc12345 | 10 days ago | Important  | High           | Service Availability |
+          | Xyz12345 | 10 days ago | Moderate   | Low            | Performance          |
+      And the user USER1 is already logged in into Hybrid Cloud Console
+     When user looks at Hybrid Cloud Console main page
+     Then menu on the left side should be displayed
+      And the left menu might contain these top level items
+          | Left menu item           | Required for this test |
+          | Overview                 | no                     |
+          | Releases                 | no                     |
+          | Downloads                | no                     |
+          | Advisor                  | yes                    |
+          | Subscriptions            | no                     |
+          | Cost Management          | no                     |
+          | Cluster Manager Feedback | no                     |
+          | Red Hat Marketplace      | no                     |
+          | Documentation            | no                     |
+     When user expand "Advisor" top level item
+     Then the menu should be expanded under "Advisor" top level item
+      And following new items should be displayed in the sub-menu on the left side
+          | Expanded menu item  | Required for this test |
+          | Clusters            | no                     |
+          | Recommendations     | yes                    |
+     When user select "Recommendations" menu item from this sub-menu
+     Then an "Advisor recommendations" page should be displayed right of the left menu bar
+      And widget with filter settings should be displayed
+      And table with several columns should be displayed
+          | Column name    |
+          | Name           |
+          | Modified       |
+          | Category       |
+          | Total risk     |
+          | Risk of change |
+          | Clusters       |
+      And that table should contain exactly 1 row
+          | Name        | Modified    | Category             | Total risk | Risk of change | Clusters |
+          | Bug12345    | 10 days ago | Service Availability | Important  | High           | 1        |
+      And one filter needs to be preselected
+          | Filter name       | Tag         |
+          | Clusters impacted | 1 or more   |
+     When user clicks on "x" icon displayed on "1 or more" filter tag
+     Then table with advisor recommendation should contain recommendations names with 0 clusters
+          | Name        | Modified    | Category             | Total risk | Risk of change | Clusters |
+          | Abc12345    | 10 days ago | Service Availability | Important  | High           | 0        |
+          | Bug12345    | 10 days ago | Service Availability | Important  | High           | 1        |
+          | Xyz12345    | 10 days ago | Performance          | Moderate   | Low            | 0        |
+      And filter widget should consists of filter names pull-down menu and filter search input field
+     When user selects "Risk of change" in filter names pull-down menu
+     Then search input field becomes a pull-down menu with several options
+          | Option name |
+          | High        |
+          | Moderate    |
+          | Low         |
+          | Very Low    |
+     When user select "Low" from the rigth pull-down menu
+     Then table with several columns should be displayed
+          | Column name    |
+          | Name           |
+          | Modified       |
+          | Category       |
+          | Total risk     |
+          | Risk of change |
+          | Clusters       |
+      And that table should contain exactly 1 row
+          | Name        | Modified    | Category             | Total risk | Risk of change | Clusters |
+          | Xyz12345    | 10 days ago | Performance          | Moderate   | Low            | 0        |
+      And one filter needs to be preselected
+          | Filter name     | Tag        |
+          | Risk of change  | Low        |
+     When user selects "Risk of change" in filter names pull-down menu
+     Then search input field becomes a pull-down menu with several options
+          | Option name |
+          | High        |
+          | Moderate    |
+          | Low         |
+          | Very Low    |
+     When user select "High" from the rigth pull-down menu
+     Then table with several columns should be displayed
+          | Column name    |
+          | Name           |
+          | Modified       |
+          | Category       |
+          | Total risk     |
+          | Risk of change |
+          | Clusters       |
+      And that table should contain exactly 3 rows
+          | Name        | Modified    | Category             | Total risk | Risk of change | Clusters |
+          | Abc12345    | 10 days ago | Service Availability | Important  | High           | 0        |
+          | Bug12345    | 10 days ago | Service Availability | Important  | High           | 1        |
+          | Xyz12345    | 10 days ago | Performance          | Moderate   | Low            | 0        |
+      And two filters needs to be preselected
+          | Filter name     | Tag        |
+          | Risk of change  | Low        |
+          | Risk of change  | High       |
+     When user clicks on "x" icon displayed on "Low" filter tag
+     Then table with several columns should be displayed
+          | Column name    |
+          | Name           |
+          | Modified       |
+          | Category       |
+          | Total risk     |
+          | Risk of change |
+          | Clusters       |
+      And that table should contain 2 rows
+          | Name        | Modified    | Category             | Total risk | Risk of change | Clusters |
+          | Abc12345    | 10 days ago | Service Availability | Important  | High           | 0        |
+          | Bug12345    | 10 days ago | Service Availability | Important  | High           | 1        |
+     When user clicks on "x" icon displayed on "High" filter tag
+     Then table with several columns should be displayed
+          | Column name    |
+          | Name           |
+          | Modified       |
+          | Category       |
+          | Total risk     |
+          | Risk of change |
+          | Clusters       |
+      And that table should contain 2 rows
+          | Name        | Modified    | Category             | Total risk | Risk of change | Clusters |
+          | Abc12345    | 10 days ago | Service Availability | Important  | High           | 0        |
+          | Bug12345    | 10 days ago | Service Availability | Important  | High           | 1        |
+          | Xyz12345    | 10 days ago | Performance          | Moderate   | Low            | 0        |

--- a/features/Insights_Advisor/recommendations_page_filtering.feature
+++ b/features/Insights_Advisor/recommendations_page_filtering.feature
@@ -14,13 +14,25 @@ Feature: Filtering on Advisor recommendations page behaviour on Hybrid Cloud Con
      When user looks at Hybrid Cloud Console main page
      Then menu on the left side should be displayed
       And the left menu might contain these top level items
+          | Left menu item                | Required for this test |
+          | Application and Data Services | no                     |
+          | OpenShift                     | yes                    |
+          | Red Hat Enterprise Linux      | no                     |
+          | Ansible Automation Platform   | no                     |
+     When user selects "OpenShift" from the left side menu
+     Then menu on the left side should be changed
+      And the left menu might contain these top level items
           | Left menu item           | Required for this test |
+          | Clusters                 | no                     |
           | Overview                 | no                     |
           | Releases                 | no                     |
+          | Developer Sandbox        | no                     |
           | Downloads                | no                     |
           | Advisor                  | yes                    |
+          | Vulnerability            | no                     |
           | Subscriptions            | no                     |
           | Cost Management          | no                     |
+          | Support Cases            | no                     |
           | Cluster Manager Feedback | no                     |
           | Red Hat Marketplace      | no                     |
           | Documentation            | no                     |
@@ -67,13 +79,25 @@ Feature: Filtering on Advisor recommendations page behaviour on Hybrid Cloud Con
      When user looks at Hybrid Cloud Console main page
      Then menu on the left side should be displayed
       And the left menu might contain these top level items
+          | Left menu item                | Required for this test |
+          | Application and Data Services | no                     |
+          | OpenShift                     | yes                    |
+          | Red Hat Enterprise Linux      | no                     |
+          | Ansible Automation Platform   | no                     |
+     When user selects "OpenShift" from the left side menu
+     Then menu on the left side should be changed
+      And the left menu might contain these top level items
           | Left menu item           | Required for this test |
+          | Clusters                 | no                     |
           | Overview                 | no                     |
           | Releases                 | no                     |
+          | Developer Sandbox        | no                     |
           | Downloads                | no                     |
           | Advisor                  | yes                    |
+          | Vulnerability            | no                     |
           | Subscriptions            | no                     |
           | Cost Management          | no                     |
+          | Support Cases            | no                     |
           | Cluster Manager Feedback | no                     |
           | Red Hat Marketplace      | no                     |
           | Documentation            | no                     |
@@ -127,13 +151,25 @@ Feature: Filtering on Advisor recommendations page behaviour on Hybrid Cloud Con
      When user looks at Hybrid Cloud Console main page
      Then menu on the left side should be displayed
       And the left menu might contain these top level items
+          | Left menu item                | Required for this test |
+          | Application and Data Services | no                     |
+          | OpenShift                     | yes                    |
+          | Red Hat Enterprise Linux      | no                     |
+          | Ansible Automation Platform   | no                     |
+     When user selects "OpenShift" from the left side menu
+     Then menu on the left side should be changed
+      And the left menu might contain these top level items
           | Left menu item           | Required for this test |
+          | Clusters                 | no                     |
           | Overview                 | no                     |
           | Releases                 | no                     |
+          | Developer Sandbox        | no                     |
           | Downloads                | no                     |
           | Advisor                  | yes                    |
+          | Vulnerability            | no                     |
           | Subscriptions            | no                     |
           | Cost Management          | no                     |
+          | Support Cases            | no                     |
           | Cluster Manager Feedback | no                     |
           | Red Hat Marketplace      | no                     |
           | Documentation            | no                     |
@@ -218,13 +254,25 @@ Feature: Filtering on Advisor recommendations page behaviour on Hybrid Cloud Con
      When user looks at Hybrid Cloud Console main page
      Then menu on the left side should be displayed
       And the left menu might contain these top level items
+          | Left menu item                | Required for this test |
+          | Application and Data Services | no                     |
+          | OpenShift                     | yes                    |
+          | Red Hat Enterprise Linux      | no                     |
+          | Ansible Automation Platform   | no                     |
+     When user selects "OpenShift" from the left side menu
+     Then menu on the left side should be changed
+      And the left menu might contain these top level items
           | Left menu item           | Required for this test |
+          | Clusters                 | no                     |
           | Overview                 | no                     |
           | Releases                 | no                     |
+          | Developer Sandbox        | no                     |
           | Downloads                | no                     |
           | Advisor                  | yes                    |
+          | Vulnerability            | no                     |
           | Subscriptions            | no                     |
           | Cost Management          | no                     |
+          | Support Cases            | no                     |
           | Cluster Manager Feedback | no                     |
           | Red Hat Marketplace      | no                     |
           | Documentation            | no                     |
@@ -315,13 +363,25 @@ Feature: Filtering on Advisor recommendations page behaviour on Hybrid Cloud Con
      When user looks at Hybrid Cloud Console main page
      Then menu on the left side should be displayed
       And the left menu might contain these top level items
+          | Left menu item                | Required for this test |
+          | Application and Data Services | no                     |
+          | OpenShift                     | yes                    |
+          | Red Hat Enterprise Linux      | no                     |
+          | Ansible Automation Platform   | no                     |
+     When user selects "OpenShift" from the left side menu
+     Then menu on the left side should be changed
+      And the left menu might contain these top level items
           | Left menu item           | Required for this test |
+          | Clusters                 | no                     |
           | Overview                 | no                     |
           | Releases                 | no                     |
+          | Developer Sandbox        | no                     |
           | Downloads                | no                     |
           | Advisor                  | yes                    |
+          | Vulnerability            | no                     |
           | Subscriptions            | no                     |
           | Cost Management          | no                     |
+          | Support Cases            | no                     |
           | Cluster Manager Feedback | no                     |
           | Red Hat Marketplace      | no                     |
           | Documentation            | no                     |
@@ -406,13 +466,25 @@ Feature: Filtering on Advisor recommendations page behaviour on Hybrid Cloud Con
      When user looks at Hybrid Cloud Console main page
      Then menu on the left side should be displayed
       And the left menu might contain these top level items
+          | Left menu item                | Required for this test |
+          | Application and Data Services | no                     |
+          | OpenShift                     | yes                    |
+          | Red Hat Enterprise Linux      | no                     |
+          | Ansible Automation Platform   | no                     |
+     When user selects "OpenShift" from the left side menu
+     Then menu on the left side should be changed
+      And the left menu might contain these top level items
           | Left menu item           | Required for this test |
+          | Clusters                 | no                     |
           | Overview                 | no                     |
           | Releases                 | no                     |
+          | Developer Sandbox        | no                     |
           | Downloads                | no                     |
           | Advisor                  | yes                    |
+          | Vulnerability            | no                     |
           | Subscriptions            | no                     |
           | Cost Management          | no                     |
+          | Support Cases            | no                     |
           | Cluster Manager Feedback | no                     |
           | Red Hat Marketplace      | no                     |
           | Documentation            | no                     |
@@ -505,13 +577,25 @@ Feature: Filtering on Advisor recommendations page behaviour on Hybrid Cloud Con
      When user looks at Hybrid Cloud Console main page
      Then menu on the left side should be displayed
       And the left menu might contain these top level items
+          | Left menu item                | Required for this test |
+          | Application and Data Services | no                     |
+          | OpenShift                     | yes                    |
+          | Red Hat Enterprise Linux      | no                     |
+          | Ansible Automation Platform   | no                     |
+     When user selects "OpenShift" from the left side menu
+     Then menu on the left side should be changed
+      And the left menu might contain these top level items
           | Left menu item           | Required for this test |
+          | Clusters                 | no                     |
           | Overview                 | no                     |
           | Releases                 | no                     |
+          | Developer Sandbox        | no                     |
           | Downloads                | no                     |
           | Advisor                  | yes                    |
+          | Vulnerability            | no                     |
           | Subscriptions            | no                     |
           | Cost Management          | no                     |
+          | Support Cases            | no                     |
           | Cluster Manager Feedback | no                     |
           | Red Hat Marketplace      | no                     |
           | Documentation            | no                     |
@@ -639,13 +723,25 @@ Feature: Filtering on Advisor recommendations page behaviour on Hybrid Cloud Con
      When user looks at Hybrid Cloud Console main page
      Then menu on the left side should be displayed
       And the left menu might contain these top level items
+          | Left menu item                | Required for this test |
+          | Application and Data Services | no                     |
+          | OpenShift                     | yes                    |
+          | Red Hat Enterprise Linux      | no                     |
+          | Ansible Automation Platform   | no                     |
+     When user selects "OpenShift" from the left side menu
+     Then menu on the left side should be changed
+      And the left menu might contain these top level items
           | Left menu item           | Required for this test |
+          | Clusters                 | no                     |
           | Overview                 | no                     |
           | Releases                 | no                     |
+          | Developer Sandbox        | no                     |
           | Downloads                | no                     |
           | Advisor                  | yes                    |
+          | Vulnerability            | no                     |
           | Subscriptions            | no                     |
           | Cost Management          | no                     |
+          | Support Cases            | no                     |
           | Cluster Manager Feedback | no                     |
           | Red Hat Marketplace      | no                     |
           | Documentation            | no                     |
@@ -773,13 +869,25 @@ Feature: Filtering on Advisor recommendations page behaviour on Hybrid Cloud Con
      When user looks at Hybrid Cloud Console main page
      Then menu on the left side should be displayed
       And the left menu might contain these top level items
+          | Left menu item                | Required for this test |
+          | Application and Data Services | no                     |
+          | OpenShift                     | yes                    |
+          | Red Hat Enterprise Linux      | no                     |
+          | Ansible Automation Platform   | no                     |
+     When user selects "OpenShift" from the left side menu
+     Then menu on the left side should be changed
+      And the left menu might contain these top level items
           | Left menu item           | Required for this test |
+          | Clusters                 | no                     |
           | Overview                 | no                     |
           | Releases                 | no                     |
+          | Developer Sandbox        | no                     |
           | Downloads                | no                     |
           | Advisor                  | yes                    |
+          | Vulnerability            | no                     |
           | Subscriptions            | no                     |
           | Cost Management          | no                     |
+          | Support Cases            | no                     |
           | Cluster Manager Feedback | no                     |
           | Red Hat Marketplace      | no                     |
           | Documentation            | no                     |
@@ -837,13 +945,25 @@ Feature: Filtering on Advisor recommendations page behaviour on Hybrid Cloud Con
      When user looks at Hybrid Cloud Console main page
      Then menu on the left side should be displayed
       And the left menu might contain these top level items
+          | Left menu item                | Required for this test |
+          | Application and Data Services | no                     |
+          | OpenShift                     | yes                    |
+          | Red Hat Enterprise Linux      | no                     |
+          | Ansible Automation Platform   | no                     |
+     When user selects "OpenShift" from the left side menu
+     Then menu on the left side should be changed
+      And the left menu might contain these top level items
           | Left menu item           | Required for this test |
+          | Clusters                 | no                     |
           | Overview                 | no                     |
           | Releases                 | no                     |
+          | Developer Sandbox        | no                     |
           | Downloads                | no                     |
           | Advisor                  | yes                    |
+          | Vulnerability            | no                     |
           | Subscriptions            | no                     |
           | Cost Management          | no                     |
+          | Support Cases            | no                     |
           | Cluster Manager Feedback | no                     |
           | Red Hat Marketplace      | no                     |
           | Documentation            | no                     |

--- a/features/Insights_Advisor/recommendations_page_pagination.feature
+++ b/features/Insights_Advisor/recommendations_page_pagination.feature
@@ -5,37 +5,37 @@ Feature: Pagination feature in Advisor recommendations page on Hybrid Cloud Cons
     Given user USER1 is part of account (organization) ACCOUNT1
       And account (organization) ACCOUNT1 owns one cluster
       And 30 issues are detected for this cluster
-          | Title    | Modified    | Total risk |
-          | Bug01    | 10 days ago | Important  |
-          | Bug02    | 10 days ago | Important  |
-          | Bug03    | 10 days ago | Important  |
-          | Bug04    | 10 days ago | Important  |
-          | Bug05    | 10 days ago | Important  |
-          | Bug06    | 10 days ago | Important  |
-          | Bug07    | 10 days ago | Important  |
-          | Bug08    | 10 days ago | Important  |
-          | Bug09    | 10 days ago | Important  |
-          | Bug10    | 10 days ago | Important  |
-          | Bug11    | 10 days ago | Moderate   |
-          | Bug12    | 10 days ago | Moderate   |
-          | Bug13    | 10 days ago | Moderate   |
-          | Bug14    | 10 days ago | Moderate   |
-          | Bug15    | 10 days ago | Moderate   |
-          | Bug16    | 10 days ago | Moderate   |
-          | Bug17    | 10 days ago | Moderate   |
-          | Bug18    | 10 days ago | Moderate   |
-          | Bug19    | 10 days ago | Moderate   |
-          | Bug20    | 10 days ago | Moderate   |
-          | Bug21    | 10 days ago | Low        |
-          | Bug22    | 10 days ago | Low        |
-          | Bug23    | 10 days ago | Low        |
-          | Bug24    | 10 days ago | Low        |
-          | Bug25    | 10 days ago | Low        |
-          | Bug26    | 10 days ago | Low        |
-          | Bug27    | 10 days ago | Low        |
-          | Bug28    | 10 days ago | Low        |
-          | Bug29    | 10 days ago | Low        |
-          | Bug30    | 10 days ago | Low        |
+          | Title    | Modified    | Category | Total risk | Risk of change |
+          | Bug01    | 10 days ago | Security | Important  | High           |
+          | Bug02    | 10 days ago | Security | Important  | High           |
+          | Bug03    | 10 days ago | Security | Important  | High           |
+          | Bug04    | 10 days ago | Security | Important  | High           |
+          | Bug05    | 10 days ago | Security | Important  | High           |
+          | Bug06    | 10 days ago | Security | Important  | High           |
+          | Bug07    | 10 days ago | Security | Important  | High           |
+          | Bug08    | 10 days ago | Security | Important  | High           |
+          | Bug09    | 10 days ago | Security | Important  | High           |
+          | Bug10    | 10 days ago | Security | Important  | High           |
+          | Bug11    | 10 days ago | Security | Moderate   | Moderate       |
+          | Bug12    | 10 days ago | Security | Moderate   | Moderate       |
+          | Bug13    | 10 days ago | Security | Moderate   | Moderate       |
+          | Bug14    | 10 days ago | Security | Moderate   | Moderate       |
+          | Bug15    | 10 days ago | Security | Moderate   | Moderate       |
+          | Bug16    | 10 days ago | Security | Moderate   | Moderate       |
+          | Bug17    | 10 days ago | Security | Moderate   | Moderate       |
+          | Bug18    | 10 days ago | Security | Moderate   | Moderate       |
+          | Bug19    | 10 days ago | Security | Moderate   | Moderate       |
+          | Bug20    | 10 days ago | Security | Moderate   | Moderate       |
+          | Bug21    | 10 days ago | Security | Low        | Very Low       |
+          | Bug22    | 10 days ago | Security | Low        | Very Low       |
+          | Bug23    | 10 days ago | Security | Low        | Very Low       |
+          | Bug24    | 10 days ago | Security | Low        | Very Low       |
+          | Bug25    | 10 days ago | Security | Low        | Very Low       |
+          | Bug26    | 10 days ago | Security | Low        | Very Low       |
+          | Bug27    | 10 days ago | Security | Low        | Very Low       |
+          | Bug28    | 10 days ago | Security | Low        | Very Low       |
+          | Bug29    | 10 days ago | Security | Low        | Very Low       |
+          | Bug30    | 10 days ago | Security | Low        | Very Low       |
       And the user USER1 is already logged in into Hybrid Cloud Console
      When user looks at Hybrid Cloud Console main page
      Then menu on the left side should be displayed
@@ -60,33 +60,35 @@ Feature: Pagination feature in Advisor recommendations page on Hybrid Cloud Cons
      Then an "Advisor recommendations" page should be displayed right of the left menu bar
       And widget with filter settings should be displayed
       And table with several columns should be displayed
-          | Column name |
-          | Name        |
-          | Modified    |
-          | Total risk  |
-          | Clusters    |
+          | Column name    |
+          | Name           |
+          | Modified       |
+          | Category       |
+          | Total risk     |
+          | Risk of change |
+          | Clusters       |
       And that table should contain the following 20 rows
-          | Name  | Modified    | Total risk | Clusters |
-          | Bug01 | 10 days ago | Important  | 1        |
-          | Bug02 | 10 days ago | Important  | 1        |
-          | Bug03 | 10 days ago | Important  | 1        |
-          | Bug04 | 10 days ago | Important  | 1        |
-          | Bug05 | 10 days ago | Important  | 1        |
-          | Bug06 | 10 days ago | Important  | 1        |
-          | Bug07 | 10 days ago | Important  | 1        |
-          | Bug08 | 10 days ago | Important  | 1        |
-          | Bug09 | 10 days ago | Important  | 1        |
-          | Bug10 | 10 days ago | Important  | 1        |
-          | Bug11 | 10 days ago | Moderate   | 1        |
-          | Bug12 | 10 days ago | Moderate   | 1        |
-          | Bug13 | 10 days ago | Moderate   | 1        |
-          | Bug14 | 10 days ago | Moderate   | 1        |
-          | Bug15 | 10 days ago | Moderate   | 1        |
-          | Bug16 | 10 days ago | Moderate   | 1        |
-          | Bug17 | 10 days ago | Moderate   | 1        |
-          | Bug18 | 10 days ago | Moderate   | 1        |
-          | Bug19 | 10 days ago | Moderate   | 1        |
-          | Bug20 | 10 days ago | Moderate   | 1        |
+          | Name  | Modified    | Category | Total risk | Risk of change | Clusters |
+          | Bug01 | 10 days ago | Security | Important  | High           | 1        |
+          | Bug02 | 10 days ago | Security | Important  | High           | 1        |
+          | Bug03 | 10 days ago | Security | Important  | High           | 1        |
+          | Bug04 | 10 days ago | Security | Important  | High           | 1        |
+          | Bug05 | 10 days ago | Security | Important  | High           | 1        |
+          | Bug06 | 10 days ago | Security | Important  | High           | 1        |
+          | Bug07 | 10 days ago | Security | Important  | High           | 1        |
+          | Bug08 | 10 days ago | Security | Important  | High           | 1        |
+          | Bug09 | 10 days ago | Security | Important  | High           | 1        |
+          | Bug10 | 10 days ago | Security | Important  | High           | 1        |
+          | Bug11 | 10 days ago | Security | Moderate   | Moderate       | 1        |
+          | Bug12 | 10 days ago | Security | Moderate   | Moderate       | 1        |
+          | Bug13 | 10 days ago | Security | Moderate   | Moderate       | 1        |
+          | Bug14 | 10 days ago | Security | Moderate   | Moderate       | 1        |
+          | Bug15 | 10 days ago | Security | Moderate   | Moderate       | 1        |
+          | Bug16 | 10 days ago | Security | Moderate   | Moderate       | 1        |
+          | Bug17 | 10 days ago | Security | Moderate   | Moderate       | 1        |
+          | Bug18 | 10 days ago | Security | Moderate   | Moderate       | 1        |
+          | Bug19 | 10 days ago | Security | Moderate   | Moderate       | 1        |
+          | Bug20 | 10 days ago | Security | Moderate   | Moderate       | 1        |
       And pagination widget needs to be displayed in the top right corner
       And pagination widget needs to be displayed in the bottom right
      When user look at top right pagination widget
@@ -126,37 +128,37 @@ Feature: Pagination feature in Advisor recommendations page on Hybrid Cloud Cons
     Given user USER1 is part of account (organization) ACCOUNT1
       And account (organization) ACCOUNT1 owns one cluster
       And 30 issues are detected for this cluster
-          | Title    | Modified    | Total risk |
-          | Bug01    | 10 days ago | Important  |
-          | Bug02    | 10 days ago | Important  |
-          | Bug03    | 10 days ago | Important  |
-          | Bug04    | 10 days ago | Important  |
-          | Bug05    | 10 days ago | Important  |
-          | Bug06    | 10 days ago | Important  |
-          | Bug07    | 10 days ago | Important  |
-          | Bug08    | 10 days ago | Important  |
-          | Bug09    | 10 days ago | Important  |
-          | Bug10    | 10 days ago | Important  |
-          | Bug11    | 10 days ago | Moderate   |
-          | Bug12    | 10 days ago | Moderate   |
-          | Bug13    | 10 days ago | Moderate   |
-          | Bug14    | 10 days ago | Moderate   |
-          | Bug15    | 10 days ago | Moderate   |
-          | Bug16    | 10 days ago | Moderate   |
-          | Bug17    | 10 days ago | Moderate   |
-          | Bug18    | 10 days ago | Moderate   |
-          | Bug19    | 10 days ago | Moderate   |
-          | Bug20    | 10 days ago | Moderate   |
-          | Bug21    | 10 days ago | Low        |
-          | Bug22    | 10 days ago | Low        |
-          | Bug23    | 10 days ago | Low        |
-          | Bug24    | 10 days ago | Low        |
-          | Bug25    | 10 days ago | Low        |
-          | Bug26    | 10 days ago | Low        |
-          | Bug27    | 10 days ago | Low        |
-          | Bug28    | 10 days ago | Low        |
-          | Bug29    | 10 days ago | Low        |
-          | Bug30    | 10 days ago | Low        |
+          | Title    | Modified    | Category | Total risk | Risk of change |
+          | Bug01    | 10 days ago | Security | Important  | High           |
+          | Bug02    | 10 days ago | Security | Important  | High           |
+          | Bug03    | 10 days ago | Security | Important  | High           |
+          | Bug04    | 10 days ago | Security | Important  | High           |
+          | Bug05    | 10 days ago | Security | Important  | High           |
+          | Bug06    | 10 days ago | Security | Important  | High           |
+          | Bug07    | 10 days ago | Security | Important  | High           |
+          | Bug08    | 10 days ago | Security | Important  | High           |
+          | Bug09    | 10 days ago | Security | Important  | High           |
+          | Bug10    | 10 days ago | Security | Important  | High           |
+          | Bug11    | 10 days ago | Security | Moderate   | Moderate       |
+          | Bug12    | 10 days ago | Security | Moderate   | Moderate       |
+          | Bug13    | 10 days ago | Security | Moderate   | Moderate       |
+          | Bug14    | 10 days ago | Security | Moderate   | Moderate       |
+          | Bug15    | 10 days ago | Security | Moderate   | Moderate       |
+          | Bug16    | 10 days ago | Security | Moderate   | Moderate       |
+          | Bug17    | 10 days ago | Security | Moderate   | Moderate       |
+          | Bug18    | 10 days ago | Security | Moderate   | Moderate       |
+          | Bug19    | 10 days ago | Security | Moderate   | Moderate       |
+          | Bug20    | 10 days ago | Security | Moderate   | Moderate       |
+          | Bug21    | 10 days ago | Security | Low        | Very Low       |
+          | Bug22    | 10 days ago | Security | Low        | Very Low       |
+          | Bug23    | 10 days ago | Security | Low        | Very Low       |
+          | Bug24    | 10 days ago | Security | Low        | Very Low       |
+          | Bug25    | 10 days ago | Security | Low        | Very Low       |
+          | Bug26    | 10 days ago | Security | Low        | Very Low       |
+          | Bug27    | 10 days ago | Security | Low        | Very Low       |
+          | Bug28    | 10 days ago | Security | Low        | Very Low       |
+          | Bug29    | 10 days ago | Security | Low        | Very Low       |
+          | Bug30    | 10 days ago | Security | Low        | Very Low       |
       And the user USER1 is already logged in into Hybrid Cloud Console
      When user looks at Hybrid Cloud Console main page
      Then menu on the left side should be displayed
@@ -181,33 +183,35 @@ Feature: Pagination feature in Advisor recommendations page on Hybrid Cloud Cons
      Then an "Advisor recommendations" page should be displayed right of the left menu bar
       And widget with filter settings should be displayed
       And table with several columns should be displayed
-          | Column name |
-          | Name        |
-          | Modified    |
-          | Total risk  |
-          | Clusters    |
+          | Column name    |
+          | Name           |
+          | Modified       |
+          | Category       |
+          | Total risk     |
+          | Risk of change |
+          | Clusters       |
       And that table should contain the following 20 rows
-          | Name  | Modified    | Total risk | Clusters |
-          | Bug01 | 10 days ago | Important  | 1        |
-          | Bug02 | 10 days ago | Important  | 1        |
-          | Bug03 | 10 days ago | Important  | 1        |
-          | Bug04 | 10 days ago | Important  | 1        |
-          | Bug05 | 10 days ago | Important  | 1        |
-          | Bug06 | 10 days ago | Important  | 1        |
-          | Bug07 | 10 days ago | Important  | 1        |
-          | Bug08 | 10 days ago | Important  | 1        |
-          | Bug09 | 10 days ago | Important  | 1        |
-          | Bug10 | 10 days ago | Important  | 1        |
-          | Bug11 | 10 days ago | Moderate   | 1        |
-          | Bug12 | 10 days ago | Moderate   | 1        |
-          | Bug13 | 10 days ago | Moderate   | 1        |
-          | Bug14 | 10 days ago | Moderate   | 1        |
-          | Bug15 | 10 days ago | Moderate   | 1        |
-          | Bug16 | 10 days ago | Moderate   | 1        |
-          | Bug17 | 10 days ago | Moderate   | 1        |
-          | Bug18 | 10 days ago | Moderate   | 1        |
-          | Bug19 | 10 days ago | Moderate   | 1        |
-          | Bug20 | 10 days ago | Moderate   | 1        |
+          | Name  | Modified    | Category | Total risk | Risk of change | Clusters |
+          | Bug01 | 10 days ago | Security | Important  | High           | 1        |
+          | Bug02 | 10 days ago | Security | Important  | High           | 1        |
+          | Bug03 | 10 days ago | Security | Important  | High           | 1        |
+          | Bug04 | 10 days ago | Security | Important  | High           | 1        |
+          | Bug05 | 10 days ago | Security | Important  | High           | 1        |
+          | Bug06 | 10 days ago | Security | Important  | High           | 1        |
+          | Bug07 | 10 days ago | Security | Important  | High           | 1        |
+          | Bug08 | 10 days ago | Security | Important  | High           | 1        |
+          | Bug09 | 10 days ago | Security | Important  | High           | 1        |
+          | Bug10 | 10 days ago | Security | Important  | High           | 1        |
+          | Bug11 | 10 days ago | Security | Moderate   | Moderate       | 1        |
+          | Bug12 | 10 days ago | Security | Moderate   | Moderate       | 1        |
+          | Bug13 | 10 days ago | Security | Moderate   | Moderate       | 1        |
+          | Bug14 | 10 days ago | Security | Moderate   | Moderate       | 1        |
+          | Bug15 | 10 days ago | Security | Moderate   | Moderate       | 1        |
+          | Bug16 | 10 days ago | Security | Moderate   | Moderate       | 1        |
+          | Bug17 | 10 days ago | Security | Moderate   | Moderate       | 1        |
+          | Bug18 | 10 days ago | Security | Moderate   | Moderate       | 1        |
+          | Bug19 | 10 days ago | Security | Moderate   | Moderate       | 1        |
+          | Bug20 | 10 days ago | Security | Moderate   | Moderate       | 1        |
       And pagination widget needs to be displayed in the top right corner
       And pagination widget needs to be displayed in the bottom right
      When user look at top right pagination widget
@@ -220,17 +224,17 @@ Feature: Pagination feature in Advisor recommendations page on Hybrid Cloud Cons
      When user click on ">" arrow on the pagination widget
      Then table with recommendations should be refreshed with new content
       And that table should contain the following 10 rows
-          | Name  | Modified    | Total risk | Clusters |
-          | Bug21 | 10 days ago | Low        | 1        |
-          | Bug22 | 10 days ago | Low        | 1        |
-          | Bug23 | 10 days ago | Low        | 1        |
-          | Bug24 | 10 days ago | Low        | 1        |
-          | Bug25 | 10 days ago | Low        | 1        |
-          | Bug26 | 10 days ago | Low        | 1        |
-          | Bug27 | 10 days ago | Low        | 1        |
-          | Bug28 | 10 days ago | Low        | 1        |
-          | Bug29 | 10 days ago | Low        | 1        |
-          | Bug30 | 10 days ago | Low        | 1        |
+          | Name  | Modified    | Category | Total risk | Risk of change | Clusters |
+          | Bug21 | 10 days ago | Security | Low        | Very Low       | 1        |
+          | Bug22 | 10 days ago | Security | Low        | Very Low       | 1        |
+          | Bug23 | 10 days ago | Security | Low        | Very Low       | 1        |
+          | Bug24 | 10 days ago | Security | Low        | Very Low       | 1        |
+          | Bug25 | 10 days ago | Security | Low        | Very Low       | 1        |
+          | Bug26 | 10 days ago | Security | Low        | Very Low       | 1        |
+          | Bug27 | 10 days ago | Security | Low        | Very Low       | 1        |
+          | Bug28 | 10 days ago | Security | Low        | Very Low       | 1        |
+          | Bug29 | 10 days ago | Security | Low        | Very Low       | 1        |
+          | Bug30 | 10 days ago | Security | Low        | Very Low       | 1        |
       And pagination widget needs to be displayed in the top right corner
       And pagination widget needs to be displayed in the bottom right
      When user look at top right pagination widget
@@ -256,37 +260,37 @@ Feature: Pagination feature in Advisor recommendations page on Hybrid Cloud Cons
     Given user USER1 is part of account (organization) ACCOUNT1
       And account (organization) ACCOUNT1 owns one cluster
       And 30 issues are detected for this cluster
-          | Title    | Modified    | Total risk |
-          | Bug01    | 10 days ago | Important  |
-          | Bug02    | 10 days ago | Important  |
-          | Bug03    | 10 days ago | Important  |
-          | Bug04    | 10 days ago | Important  |
-          | Bug05    | 10 days ago | Important  |
-          | Bug06    | 10 days ago | Important  |
-          | Bug07    | 10 days ago | Important  |
-          | Bug08    | 10 days ago | Important  |
-          | Bug09    | 10 days ago | Important  |
-          | Bug10    | 10 days ago | Important  |
-          | Bug11    | 10 days ago | Moderate   |
-          | Bug12    | 10 days ago | Moderate   |
-          | Bug13    | 10 days ago | Moderate   |
-          | Bug14    | 10 days ago | Moderate   |
-          | Bug15    | 10 days ago | Moderate   |
-          | Bug16    | 10 days ago | Moderate   |
-          | Bug17    | 10 days ago | Moderate   |
-          | Bug18    | 10 days ago | Moderate   |
-          | Bug19    | 10 days ago | Moderate   |
-          | Bug20    | 10 days ago | Moderate   |
-          | Bug21    | 10 days ago | Low        |
-          | Bug22    | 10 days ago | Low        |
-          | Bug23    | 10 days ago | Low        |
-          | Bug24    | 10 days ago | Low        |
-          | Bug25    | 10 days ago | Low        |
-          | Bug26    | 10 days ago | Low        |
-          | Bug27    | 10 days ago | Low        |
-          | Bug28    | 10 days ago | Low        |
-          | Bug29    | 10 days ago | Low        |
-          | Bug30    | 10 days ago | Low        |
+          | Title    | Modified    | Category | Total risk | Risk of change |
+          | Bug01    | 10 days ago | Security | Important  | High           |
+          | Bug02    | 10 days ago | Security | Important  | High           |
+          | Bug03    | 10 days ago | Security | Important  | High           |
+          | Bug04    | 10 days ago | Security | Important  | High           |
+          | Bug05    | 10 days ago | Security | Important  | High           |
+          | Bug06    | 10 days ago | Security | Important  | High           |
+          | Bug07    | 10 days ago | Security | Important  | High           |
+          | Bug08    | 10 days ago | Security | Important  | High           |
+          | Bug09    | 10 days ago | Security | Important  | High           |
+          | Bug10    | 10 days ago | Security | Important  | High           |
+          | Bug11    | 10 days ago | Security | Moderate   | Moderate       |
+          | Bug12    | 10 days ago | Security | Moderate   | Moderate       |
+          | Bug13    | 10 days ago | Security | Moderate   | Moderate       |
+          | Bug14    | 10 days ago | Security | Moderate   | Moderate       |
+          | Bug15    | 10 days ago | Security | Moderate   | Moderate       |
+          | Bug16    | 10 days ago | Security | Moderate   | Moderate       |
+          | Bug17    | 10 days ago | Security | Moderate   | Moderate       |
+          | Bug18    | 10 days ago | Security | Moderate   | Moderate       |
+          | Bug19    | 10 days ago | Security | Moderate   | Moderate       |
+          | Bug20    | 10 days ago | Security | Moderate   | Moderate       |
+          | Bug21    | 10 days ago | Security | Low        | Very Low       |
+          | Bug22    | 10 days ago | Security | Low        | Very Low       |
+          | Bug23    | 10 days ago | Security | Low        | Very Low       |
+          | Bug24    | 10 days ago | Security | Low        | Very Low       |
+          | Bug25    | 10 days ago | Security | Low        | Very Low       |
+          | Bug26    | 10 days ago | Security | Low        | Very Low       |
+          | Bug27    | 10 days ago | Security | Low        | Very Low       |
+          | Bug28    | 10 days ago | Security | Low        | Very Low       |
+          | Bug29    | 10 days ago | Security | Low        | Very Low       |
+          | Bug30    | 10 days ago | Security | Low        | Very Low       |
       And the user USER1 is already logged in into Hybrid Cloud Console
      When user looks at Hybrid Cloud Console main page
      Then menu on the left side should be displayed
@@ -311,33 +315,35 @@ Feature: Pagination feature in Advisor recommendations page on Hybrid Cloud Cons
      Then an "Advisor recommendations" page should be displayed right of the left menu bar
       And widget with filter settings should be displayed
       And table with several columns should be displayed
-          | Column name |
-          | Name        |
-          | Modified    |
-          | Total risk  |
-          | Clusters    |
+          | Column name    |
+          | Name           |
+          | Modified       |
+          | Category       |
+          | Total risk     |
+          | Risk of change |
+          | Clusters       |
       And that table should contain the following 20 rows
-          | Name  | Modified    | Total risk | Clusters |
-          | Bug01 | 10 days ago | Important  | 1        |
-          | Bug02 | 10 days ago | Important  | 1        |
-          | Bug03 | 10 days ago | Important  | 1        |
-          | Bug04 | 10 days ago | Important  | 1        |
-          | Bug05 | 10 days ago | Important  | 1        |
-          | Bug06 | 10 days ago | Important  | 1        |
-          | Bug07 | 10 days ago | Important  | 1        |
-          | Bug08 | 10 days ago | Important  | 1        |
-          | Bug09 | 10 days ago | Important  | 1        |
-          | Bug10 | 10 days ago | Important  | 1        |
-          | Bug11 | 10 days ago | Moderate   | 1        |
-          | Bug12 | 10 days ago | Moderate   | 1        |
-          | Bug13 | 10 days ago | Moderate   | 1        |
-          | Bug14 | 10 days ago | Moderate   | 1        |
-          | Bug15 | 10 days ago | Moderate   | 1        |
-          | Bug16 | 10 days ago | Moderate   | 1        |
-          | Bug17 | 10 days ago | Moderate   | 1        |
-          | Bug18 | 10 days ago | Moderate   | 1        |
-          | Bug19 | 10 days ago | Moderate   | 1        |
-          | Bug20 | 10 days ago | Moderate   | 1        |
+          | Name  | Modified    | Category | Total risk | Risk of change | Clusters |
+          | Bug01 | 10 days ago | Security | Important  | High           | 1        |
+          | Bug02 | 10 days ago | Security | Important  | High           | 1        |
+          | Bug03 | 10 days ago | Security | Important  | High           | 1        |
+          | Bug04 | 10 days ago | Security | Important  | High           | 1        |
+          | Bug05 | 10 days ago | Security | Important  | High           | 1        |
+          | Bug06 | 10 days ago | Security | Important  | High           | 1        |
+          | Bug07 | 10 days ago | Security | Important  | High           | 1        |
+          | Bug08 | 10 days ago | Security | Important  | High           | 1        |
+          | Bug09 | 10 days ago | Security | Important  | High           | 1        |
+          | Bug10 | 10 days ago | Security | Important  | High           | 1        |
+          | Bug11 | 10 days ago | Security | Moderate   | Moderate       | 1        |
+          | Bug12 | 10 days ago | Security | Moderate   | Moderate       | 1        |
+          | Bug13 | 10 days ago | Security | Moderate   | Moderate       | 1        |
+          | Bug14 | 10 days ago | Security | Moderate   | Moderate       | 1        |
+          | Bug15 | 10 days ago | Security | Moderate   | Moderate       | 1        |
+          | Bug16 | 10 days ago | Security | Moderate   | Moderate       | 1        |
+          | Bug17 | 10 days ago | Security | Moderate   | Moderate       | 1        |
+          | Bug18 | 10 days ago | Security | Moderate   | Moderate       | 1        |
+          | Bug19 | 10 days ago | Security | Moderate   | Moderate       | 1        |
+          | Bug20 | 10 days ago | Security | Moderate   | Moderate       | 1        |
       And pagination widget needs to be displayed in the top right corner
       And pagination widget needs to be displayed in the bottom right
      When user look at bottom right pagination widget
@@ -352,17 +358,17 @@ Feature: Pagination feature in Advisor recommendations page on Hybrid Cloud Cons
      When user click on ">>" arrow on the pagination widget
      Then table with recommendations should be refreshed with new content
       And that table should contain the following 10 rows
-          | Name  | Modified    | Total risk | Clusters |
-          | Bug21 | 10 days ago | Low        | 1        |
-          | Bug22 | 10 days ago | Low        | 1        |
-          | Bug23 | 10 days ago | Low        | 1        |
-          | Bug24 | 10 days ago | Low        | 1        |
-          | Bug25 | 10 days ago | Low        | 1        |
-          | Bug26 | 10 days ago | Low        | 1        |
-          | Bug27 | 10 days ago | Low        | 1        |
-          | Bug28 | 10 days ago | Low        | 1        |
-          | Bug29 | 10 days ago | Low        | 1        |
-          | Bug30 | 10 days ago | Low        | 1        |
+          | Name  | Modified    | Category | Total risk | Risk of change | Clusters |
+          | Bug21 | 10 days ago | Security | Low        | Very Low       | 1        |
+          | Bug22 | 10 days ago | Security | Low        | Very Low       | 1        |
+          | Bug23 | 10 days ago | Security | Low        | Very Low       | 1        |
+          | Bug24 | 10 days ago | Security | Low        | Very Low       | 1        |
+          | Bug25 | 10 days ago | Security | Low        | Very Low       | 1        |
+          | Bug26 | 10 days ago | Security | Low        | Very Low       | 1        |
+          | Bug27 | 10 days ago | Security | Low        | Very Low       | 1        |
+          | Bug28 | 10 days ago | Security | Low        | Very Low       | 1        |
+          | Bug29 | 10 days ago | Security | Low        | Very Low       | 1        |
+          | Bug30 | 10 days ago | Security | Low        | Very Low       | 1        |
       And pagination widget needs to be displayed in the top right corner
       And pagination widget needs to be displayed in the bottom right
      When user look at top right pagination widget
@@ -388,37 +394,37 @@ Feature: Pagination feature in Advisor recommendations page on Hybrid Cloud Cons
     Given user USER1 is part of account (organization) ACCOUNT1
       And account (organization) ACCOUNT1 owns one cluster
       And 30 issues are detected for this cluster
-          | Title    | Modified    | Total risk |
-          | Bug01    | 10 days ago | Important  |
-          | Bug02    | 10 days ago | Important  |
-          | Bug03    | 10 days ago | Important  |
-          | Bug04    | 10 days ago | Important  |
-          | Bug05    | 10 days ago | Important  |
-          | Bug06    | 10 days ago | Important  |
-          | Bug07    | 10 days ago | Important  |
-          | Bug08    | 10 days ago | Important  |
-          | Bug09    | 10 days ago | Important  |
-          | Bug10    | 10 days ago | Important  |
-          | Bug11    | 10 days ago | Moderate   |
-          | Bug12    | 10 days ago | Moderate   |
-          | Bug13    | 10 days ago | Moderate   |
-          | Bug14    | 10 days ago | Moderate   |
-          | Bug15    | 10 days ago | Moderate   |
-          | Bug16    | 10 days ago | Moderate   |
-          | Bug17    | 10 days ago | Moderate   |
-          | Bug18    | 10 days ago | Moderate   |
-          | Bug19    | 10 days ago | Moderate   |
-          | Bug20    | 10 days ago | Moderate   |
-          | Bug21    | 10 days ago | Low        |
-          | Bug22    | 10 days ago | Low        |
-          | Bug23    | 10 days ago | Low        |
-          | Bug24    | 10 days ago | Low        |
-          | Bug25    | 10 days ago | Low        |
-          | Bug26    | 10 days ago | Low        |
-          | Bug27    | 10 days ago | Low        |
-          | Bug28    | 10 days ago | Low        |
-          | Bug29    | 10 days ago | Low        |
-          | Bug30    | 10 days ago | Low        |
+          | Title    | Modified    | Category | Total risk | Risk of change |
+          | Bug01    | 10 days ago | Security | Important  | High           |
+          | Bug02    | 10 days ago | Security | Important  | High           |
+          | Bug03    | 10 days ago | Security | Important  | High           |
+          | Bug04    | 10 days ago | Security | Important  | High           |
+          | Bug05    | 10 days ago | Security | Important  | High           |
+          | Bug06    | 10 days ago | Security | Important  | High           |
+          | Bug07    | 10 days ago | Security | Important  | High           |
+          | Bug08    | 10 days ago | Security | Important  | High           |
+          | Bug09    | 10 days ago | Security | Important  | High           |
+          | Bug10    | 10 days ago | Security | Important  | High           |
+          | Bug11    | 10 days ago | Security | Moderate   | Moderate       |
+          | Bug12    | 10 days ago | Security | Moderate   | Moderate       |
+          | Bug13    | 10 days ago | Security | Moderate   | Moderate       |
+          | Bug14    | 10 days ago | Security | Moderate   | Moderate       |
+          | Bug15    | 10 days ago | Security | Moderate   | Moderate       |
+          | Bug16    | 10 days ago | Security | Moderate   | Moderate       |
+          | Bug17    | 10 days ago | Security | Moderate   | Moderate       |
+          | Bug18    | 10 days ago | Security | Moderate   | Moderate       |
+          | Bug19    | 10 days ago | Security | Moderate   | Moderate       |
+          | Bug20    | 10 days ago | Security | Moderate   | Moderate       |
+          | Bug21    | 10 days ago | Security | Low        | Very Low       |
+          | Bug22    | 10 days ago | Security | Low        | Very Low       |
+          | Bug23    | 10 days ago | Security | Low        | Very Low       |
+          | Bug24    | 10 days ago | Security | Low        | Very Low       |
+          | Bug25    | 10 days ago | Security | Low        | Very Low       |
+          | Bug26    | 10 days ago | Security | Low        | Very Low       |
+          | Bug27    | 10 days ago | Security | Low        | Very Low       |
+          | Bug28    | 10 days ago | Security | Low        | Very Low       |
+          | Bug29    | 10 days ago | Security | Low        | Very Low       |
+          | Bug30    | 10 days ago | Security | Low        | Very Low       |
       And the user USER1 is already logged in into Hybrid Cloud Console
      When user looks at Hybrid Cloud Console main page
      Then menu on the left side should be displayed
@@ -443,33 +449,35 @@ Feature: Pagination feature in Advisor recommendations page on Hybrid Cloud Cons
      Then an "Advisor recommendations" page should be displayed right of the left menu bar
       And widget with filter settings should be displayed
       And table with several columns should be displayed
-          | Column name |
-          | Name        |
-          | Modified    |
-          | Total risk  |
-          | Clusters    |
+          | Column name    |
+          | Name           |
+          | Modified       |
+          | Category       |
+          | Total risk     |
+          | Risk of change |
+          | Clusters       |
       And that table should contain the following 20 rows
-          | Name  | Modified    | Total risk | Clusters |
-          | Bug01 | 10 days ago | Important  | 1        |
-          | Bug02 | 10 days ago | Important  | 1        |
-          | Bug03 | 10 days ago | Important  | 1        |
-          | Bug04 | 10 days ago | Important  | 1        |
-          | Bug05 | 10 days ago | Important  | 1        |
-          | Bug06 | 10 days ago | Important  | 1        |
-          | Bug07 | 10 days ago | Important  | 1        |
-          | Bug08 | 10 days ago | Important  | 1        |
-          | Bug09 | 10 days ago | Important  | 1        |
-          | Bug10 | 10 days ago | Important  | 1        |
-          | Bug11 | 10 days ago | Moderate   | 1        |
-          | Bug12 | 10 days ago | Moderate   | 1        |
-          | Bug13 | 10 days ago | Moderate   | 1        |
-          | Bug14 | 10 days ago | Moderate   | 1        |
-          | Bug15 | 10 days ago | Moderate   | 1        |
-          | Bug16 | 10 days ago | Moderate   | 1        |
-          | Bug17 | 10 days ago | Moderate   | 1        |
-          | Bug18 | 10 days ago | Moderate   | 1        |
-          | Bug19 | 10 days ago | Moderate   | 1        |
-          | Bug20 | 10 days ago | Moderate   | 1        |
+          | Name  | Modified    | Category | Total risk | Risk of change | Clusters |
+          | Bug01 | 10 days ago | Security | Important  | High           | 1        |
+          | Bug02 | 10 days ago | Security | Important  | High           | 1        |
+          | Bug03 | 10 days ago | Security | Important  | High           | 1        |
+          | Bug04 | 10 days ago | Security | Important  | High           | 1        |
+          | Bug05 | 10 days ago | Security | Important  | High           | 1        |
+          | Bug06 | 10 days ago | Security | Important  | High           | 1        |
+          | Bug07 | 10 days ago | Security | Important  | High           | 1        |
+          | Bug08 | 10 days ago | Security | Important  | High           | 1        |
+          | Bug09 | 10 days ago | Security | Important  | High           | 1        |
+          | Bug10 | 10 days ago | Security | Important  | High           | 1        |
+          | Bug11 | 10 days ago | Security | Moderate   | Moderate       | 1        |
+          | Bug12 | 10 days ago | Security | Moderate   | Moderate       | 1        |
+          | Bug13 | 10 days ago | Security | Moderate   | Moderate       | 1        |
+          | Bug14 | 10 days ago | Security | Moderate   | Moderate       | 1        |
+          | Bug15 | 10 days ago | Security | Moderate   | Moderate       | 1        |
+          | Bug16 | 10 days ago | Security | Moderate   | Moderate       | 1        |
+          | Bug17 | 10 days ago | Security | Moderate   | Moderate       | 1        |
+          | Bug18 | 10 days ago | Security | Moderate   | Moderate       | 1        |
+          | Bug19 | 10 days ago | Security | Moderate   | Moderate       | 1        |
+          | Bug20 | 10 days ago | Security | Moderate   | Moderate       | 1        |
       And pagination widget needs to be displayed in the top right corner
       And pagination widget needs to be displayed in the bottom right
      When user look at top right pagination widget
@@ -482,17 +490,17 @@ Feature: Pagination feature in Advisor recommendations page on Hybrid Cloud Cons
      When user click on ">" arrow on the pagination widget
      Then table with recommendations should be refreshed with new content
       And that table should contain the following 10 rows
-          | Name  | Modified    | Total risk | Clusters |
-          | Bug21 | 10 days ago | Low        | 1        |
-          | Bug22 | 10 days ago | Low        | 1        |
-          | Bug23 | 10 days ago | Low        | 1        |
-          | Bug24 | 10 days ago | Low        | 1        |
-          | Bug25 | 10 days ago | Low        | 1        |
-          | Bug26 | 10 days ago | Low        | 1        |
-          | Bug27 | 10 days ago | Low        | 1        |
-          | Bug28 | 10 days ago | Low        | 1        |
-          | Bug29 | 10 days ago | Low        | 1        |
-          | Bug30 | 10 days ago | Low        | 1        |
+          | Name  | Modified    | Category | Total risk | Risk of change | Clusters |
+          | Bug21 | 10 days ago | Security | Low        | Very Low       | 1        |
+          | Bug22 | 10 days ago | Security | Low        | Very Low       | 1        |
+          | Bug23 | 10 days ago | Security | Low        | Very Low       | 1        |
+          | Bug24 | 10 days ago | Security | Low        | Very Low       | 1        |
+          | Bug25 | 10 days ago | Security | Low        | Very Low       | 1        |
+          | Bug26 | 10 days ago | Security | Low        | Very Low       | 1        |
+          | Bug27 | 10 days ago | Security | Low        | Very Low       | 1        |
+          | Bug28 | 10 days ago | Security | Low        | Very Low       | 1        |
+          | Bug29 | 10 days ago | Security | Low        | Very Low       | 1        |
+          | Bug30 | 10 days ago | Security | Low        | Very Low       | 1        |
       And pagination widget needs to be displayed in the top right corner
       And pagination widget needs to be displayed in the bottom right
      When user look at top right pagination widget
@@ -514,27 +522,27 @@ Feature: Pagination feature in Advisor recommendations page on Hybrid Cloud Cons
      When user click on "<" arrow on the pagination widget
      Then table with recommendations should be refreshed with new content
       And that table should contain the following 20 rows
-          | Name  | Modified    | Total risk | Clusters |
-          | Bug01 | 10 days ago | Important  | 1        |
-          | Bug02 | 10 days ago | Important  | 1        |
-          | Bug03 | 10 days ago | Important  | 1        |
-          | Bug04 | 10 days ago | Important  | 1        |
-          | Bug05 | 10 days ago | Important  | 1        |
-          | Bug06 | 10 days ago | Important  | 1        |
-          | Bug07 | 10 days ago | Important  | 1        |
-          | Bug08 | 10 days ago | Important  | 1        |
-          | Bug09 | 10 days ago | Important  | 1        |
-          | Bug10 | 10 days ago | Important  | 1        |
-          | Bug11 | 10 days ago | Moderate   | 1        |
-          | Bug12 | 10 days ago | Moderate   | 1        |
-          | Bug13 | 10 days ago | Moderate   | 1        |
-          | Bug14 | 10 days ago | Moderate   | 1        |
-          | Bug15 | 10 days ago | Moderate   | 1        |
-          | Bug16 | 10 days ago | Moderate   | 1        |
-          | Bug17 | 10 days ago | Moderate   | 1        |
-          | Bug18 | 10 days ago | Moderate   | 1        |
-          | Bug19 | 10 days ago | Moderate   | 1        |
-          | Bug20 | 10 days ago | Moderate   | 1        |
+          | Name  | Modified    | Category | Total risk | Risk of change | Clusters |
+          | Bug01 | 10 days ago | Security | Important  | High           | 1        |
+          | Bug02 | 10 days ago | Security | Important  | High           | 1        |
+          | Bug03 | 10 days ago | Security | Important  | High           | 1        |
+          | Bug04 | 10 days ago | Security | Important  | High           | 1        |
+          | Bug05 | 10 days ago | Security | Important  | High           | 1        |
+          | Bug06 | 10 days ago | Security | Important  | High           | 1        |
+          | Bug07 | 10 days ago | Security | Important  | High           | 1        |
+          | Bug08 | 10 days ago | Security | Important  | High           | 1        |
+          | Bug09 | 10 days ago | Security | Important  | High           | 1        |
+          | Bug10 | 10 days ago | Security | Important  | High           | 1        |
+          | Bug11 | 10 days ago | Security | Moderate   | Moderate       | 1        |
+          | Bug12 | 10 days ago | Security | Moderate   | Moderate       | 1        |
+          | Bug13 | 10 days ago | Security | Moderate   | Moderate       | 1        |
+          | Bug14 | 10 days ago | Security | Moderate   | Moderate       | 1        |
+          | Bug15 | 10 days ago | Security | Moderate   | Moderate       | 1        |
+          | Bug16 | 10 days ago | Security | Moderate   | Moderate       | 1        |
+          | Bug17 | 10 days ago | Security | Moderate   | Moderate       | 1        |
+          | Bug18 | 10 days ago | Security | Moderate   | Moderate       | 1        |
+          | Bug19 | 10 days ago | Security | Moderate   | Moderate       | 1        |
+          | Bug20 | 10 days ago | Security | Moderate   | Moderate       | 1        |
       And pagination widget needs to be displayed in the top right corner
       And pagination widget needs to be displayed in the bottom right
      When user look at top right pagination widget
@@ -560,37 +568,37 @@ Feature: Pagination feature in Advisor recommendations page on Hybrid Cloud Cons
     Given user USER1 is part of account (organization) ACCOUNT1
       And account (organization) ACCOUNT1 owns one cluster
       And 30 issues are detected for this cluster
-          | Title    | Modified    | Total risk |
-          | Bug01    | 10 days ago | Important  |
-          | Bug02    | 10 days ago | Important  |
-          | Bug03    | 10 days ago | Important  |
-          | Bug04    | 10 days ago | Important  |
-          | Bug05    | 10 days ago | Important  |
-          | Bug06    | 10 days ago | Important  |
-          | Bug07    | 10 days ago | Important  |
-          | Bug08    | 10 days ago | Important  |
-          | Bug09    | 10 days ago | Important  |
-          | Bug10    | 10 days ago | Important  |
-          | Bug11    | 10 days ago | Moderate   |
-          | Bug12    | 10 days ago | Moderate   |
-          | Bug13    | 10 days ago | Moderate   |
-          | Bug14    | 10 days ago | Moderate   |
-          | Bug15    | 10 days ago | Moderate   |
-          | Bug16    | 10 days ago | Moderate   |
-          | Bug17    | 10 days ago | Moderate   |
-          | Bug18    | 10 days ago | Moderate   |
-          | Bug19    | 10 days ago | Moderate   |
-          | Bug20    | 10 days ago | Moderate   |
-          | Bug21    | 10 days ago | Low        |
-          | Bug22    | 10 days ago | Low        |
-          | Bug23    | 10 days ago | Low        |
-          | Bug24    | 10 days ago | Low        |
-          | Bug25    | 10 days ago | Low        |
-          | Bug26    | 10 days ago | Low        |
-          | Bug27    | 10 days ago | Low        |
-          | Bug28    | 10 days ago | Low        |
-          | Bug29    | 10 days ago | Low        |
-          | Bug30    | 10 days ago | Low        |
+          | Title    | Modified    | Category | Total risk | Risk of change |
+          | Bug01    | 10 days ago | Security | Important  | High           |
+          | Bug02    | 10 days ago | Security | Important  | High           |
+          | Bug03    | 10 days ago | Security | Important  | High           |
+          | Bug04    | 10 days ago | Security | Important  | High           |
+          | Bug05    | 10 days ago | Security | Important  | High           |
+          | Bug06    | 10 days ago | Security | Important  | High           |
+          | Bug07    | 10 days ago | Security | Important  | High           |
+          | Bug08    | 10 days ago | Security | Important  | High           |
+          | Bug09    | 10 days ago | Security | Important  | High           |
+          | Bug10    | 10 days ago | Security | Important  | High           |
+          | Bug11    | 10 days ago | Security | Moderate   | Moderate       |
+          | Bug12    | 10 days ago | Security | Moderate   | Moderate       |
+          | Bug13    | 10 days ago | Security | Moderate   | Moderate       |
+          | Bug14    | 10 days ago | Security | Moderate   | Moderate       |
+          | Bug15    | 10 days ago | Security | Moderate   | Moderate       |
+          | Bug16    | 10 days ago | Security | Moderate   | Moderate       |
+          | Bug17    | 10 days ago | Security | Moderate   | Moderate       |
+          | Bug18    | 10 days ago | Security | Moderate   | Moderate       |
+          | Bug19    | 10 days ago | Security | Moderate   | Moderate       |
+          | Bug20    | 10 days ago | Security | Moderate   | Moderate       |
+          | Bug21    | 10 days ago | Security | Low        | Very Low       |
+          | Bug22    | 10 days ago | Security | Low        | Very Low       |
+          | Bug23    | 10 days ago | Security | Low        | Very Low       |
+          | Bug24    | 10 days ago | Security | Low        | Very Low       |
+          | Bug25    | 10 days ago | Security | Low        | Very Low       |
+          | Bug26    | 10 days ago | Security | Low        | Very Low       |
+          | Bug27    | 10 days ago | Security | Low        | Very Low       |
+          | Bug28    | 10 days ago | Security | Low        | Very Low       |
+          | Bug29    | 10 days ago | Security | Low        | Very Low       |
+          | Bug30    | 10 days ago | Security | Low        | Very Low       |
       And the user USER1 is already logged in into Hybrid Cloud Console
      When user looks at Hybrid Cloud Console main page
      Then menu on the left side should be displayed
@@ -615,33 +623,35 @@ Feature: Pagination feature in Advisor recommendations page on Hybrid Cloud Cons
      Then an "Advisor recommendations" page should be displayed right of the left menu bar
       And widget with filter settings should be displayed
       And table with several columns should be displayed
-          | Column name |
-          | Name        |
-          | Modified    |
-          | Total risk  |
-          | Clusters    |
+          | Column name    |
+          | Name           |
+          | Modified       |
+          | Category       |
+          | Total risk     |
+          | Risk of change |
+          | Clusters       |
       And that table should contain the following 20 rows
-          | Name  | Modified    | Total risk | Clusters |
-          | Bug01 | 10 days ago | Important  | 1        |
-          | Bug02 | 10 days ago | Important  | 1        |
-          | Bug03 | 10 days ago | Important  | 1        |
-          | Bug04 | 10 days ago | Important  | 1        |
-          | Bug05 | 10 days ago | Important  | 1        |
-          | Bug06 | 10 days ago | Important  | 1        |
-          | Bug07 | 10 days ago | Important  | 1        |
-          | Bug08 | 10 days ago | Important  | 1        |
-          | Bug09 | 10 days ago | Important  | 1        |
-          | Bug10 | 10 days ago | Important  | 1        |
-          | Bug11 | 10 days ago | Moderate   | 1        |
-          | Bug12 | 10 days ago | Moderate   | 1        |
-          | Bug13 | 10 days ago | Moderate   | 1        |
-          | Bug14 | 10 days ago | Moderate   | 1        |
-          | Bug15 | 10 days ago | Moderate   | 1        |
-          | Bug16 | 10 days ago | Moderate   | 1        |
-          | Bug17 | 10 days ago | Moderate   | 1        |
-          | Bug18 | 10 days ago | Moderate   | 1        |
-          | Bug19 | 10 days ago | Moderate   | 1        |
-          | Bug20 | 10 days ago | Moderate   | 1        |
+          | Name  | Modified    | Category | Total risk | Risk of change | Clusters |
+          | Bug01 | 10 days ago | Security | Important  | High           | 1        |
+          | Bug02 | 10 days ago | Security | Important  | High           | 1        |
+          | Bug03 | 10 days ago | Security | Important  | High           | 1        |
+          | Bug04 | 10 days ago | Security | Important  | High           | 1        |
+          | Bug05 | 10 days ago | Security | Important  | High           | 1        |
+          | Bug06 | 10 days ago | Security | Important  | High           | 1        |
+          | Bug07 | 10 days ago | Security | Important  | High           | 1        |
+          | Bug08 | 10 days ago | Security | Important  | High           | 1        |
+          | Bug09 | 10 days ago | Security | Important  | High           | 1        |
+          | Bug10 | 10 days ago | Security | Important  | High           | 1        |
+          | Bug11 | 10 days ago | Security | Moderate   | Moderate       | 1        |
+          | Bug12 | 10 days ago | Security | Moderate   | Moderate       | 1        |
+          | Bug13 | 10 days ago | Security | Moderate   | Moderate       | 1        |
+          | Bug14 | 10 days ago | Security | Moderate   | Moderate       | 1        |
+          | Bug15 | 10 days ago | Security | Moderate   | Moderate       | 1        |
+          | Bug16 | 10 days ago | Security | Moderate   | Moderate       | 1        |
+          | Bug17 | 10 days ago | Security | Moderate   | Moderate       | 1        |
+          | Bug18 | 10 days ago | Security | Moderate   | Moderate       | 1        |
+          | Bug19 | 10 days ago | Security | Moderate   | Moderate       | 1        |
+          | Bug20 | 10 days ago | Security | Moderate   | Moderate       | 1        |
       And pagination widget needs to be displayed in the top right corner
       And pagination widget needs to be displayed in the bottom right
      When user look at top right pagination widget
@@ -654,17 +664,17 @@ Feature: Pagination feature in Advisor recommendations page on Hybrid Cloud Cons
      When user click on ">" arrow on the pagination widget
      Then table with recommendations should be refreshed with new content
       And that table should contain the following 10 rows
-          | Name  | Modified    | Total risk | Clusters |
-          | Bug21 | 10 days ago | Low        | 1        |
-          | Bug22 | 10 days ago | Low        | 1        |
-          | Bug23 | 10 days ago | Low        | 1        |
-          | Bug24 | 10 days ago | Low        | 1        |
-          | Bug25 | 10 days ago | Low        | 1        |
-          | Bug26 | 10 days ago | Low        | 1        |
-          | Bug27 | 10 days ago | Low        | 1        |
-          | Bug28 | 10 days ago | Low        | 1        |
-          | Bug29 | 10 days ago | Low        | 1        |
-          | Bug30 | 10 days ago | Low        | 1        |
+          | Name  | Modified    | Category | Total risk | Risk of change | Clusters |
+          | Bug21 | 10 days ago | Security | Low        | Very Low       | 1        |
+          | Bug22 | 10 days ago | Security | Low        | Very Low       | 1        |
+          | Bug23 | 10 days ago | Security | Low        | Very Low       | 1        |
+          | Bug24 | 10 days ago | Security | Low        | Very Low       | 1        |
+          | Bug25 | 10 days ago | Security | Low        | Very Low       | 1        |
+          | Bug26 | 10 days ago | Security | Low        | Very Low       | 1        |
+          | Bug27 | 10 days ago | Security | Low        | Very Low       | 1        |
+          | Bug28 | 10 days ago | Security | Low        | Very Low       | 1        |
+          | Bug29 | 10 days ago | Security | Low        | Very Low       | 1        |
+          | Bug30 | 10 days ago | Security | Low        | Very Low       | 1        |
       And pagination widget needs to be displayed in the top right corner
       And pagination widget needs to be displayed in the bottom right
      When user look at top right pagination widget
@@ -686,27 +696,27 @@ Feature: Pagination feature in Advisor recommendations page on Hybrid Cloud Cons
      When user click on "<<" arrow on the pagination widget
      Then table with recommendations should be refreshed with new content
       And that table should contain the following 20 rows
-          | Name  | Modified    | Total risk | Clusters |
-          | Bug01 | 10 days ago | Important  | 1        |
-          | Bug02 | 10 days ago | Important  | 1        |
-          | Bug03 | 10 days ago | Important  | 1        |
-          | Bug04 | 10 days ago | Important  | 1        |
-          | Bug05 | 10 days ago | Important  | 1        |
-          | Bug06 | 10 days ago | Important  | 1        |
-          | Bug07 | 10 days ago | Important  | 1        |
-          | Bug08 | 10 days ago | Important  | 1        |
-          | Bug09 | 10 days ago | Important  | 1        |
-          | Bug10 | 10 days ago | Important  | 1        |
-          | Bug11 | 10 days ago | Moderate   | 1        |
-          | Bug12 | 10 days ago | Moderate   | 1        |
-          | Bug13 | 10 days ago | Moderate   | 1        |
-          | Bug14 | 10 days ago | Moderate   | 1        |
-          | Bug15 | 10 days ago | Moderate   | 1        |
-          | Bug16 | 10 days ago | Moderate   | 1        |
-          | Bug17 | 10 days ago | Moderate   | 1        |
-          | Bug18 | 10 days ago | Moderate   | 1        |
-          | Bug19 | 10 days ago | Moderate   | 1        |
-          | Bug20 | 10 days ago | Moderate   | 1        |
+          | Name  | Modified    | Category | Total risk | Risk of change | Clusters |
+          | Bug01 | 10 days ago | Security | Important  | High           | 1        |
+          | Bug02 | 10 days ago | Security | Important  | High           | 1        |
+          | Bug03 | 10 days ago | Security | Important  | High           | 1        |
+          | Bug04 | 10 days ago | Security | Important  | High           | 1        |
+          | Bug05 | 10 days ago | Security | Important  | High           | 1        |
+          | Bug06 | 10 days ago | Security | Important  | High           | 1        |
+          | Bug07 | 10 days ago | Security | Important  | High           | 1        |
+          | Bug08 | 10 days ago | Security | Important  | High           | 1        |
+          | Bug09 | 10 days ago | Security | Important  | High           | 1        |
+          | Bug10 | 10 days ago | Security | Important  | High           | 1        |
+          | Bug11 | 10 days ago | Security | Moderate   | Moderate       | 1        |
+          | Bug12 | 10 days ago | Security | Moderate   | Moderate       | 1        |
+          | Bug13 | 10 days ago | Security | Moderate   | Moderate       | 1        |
+          | Bug14 | 10 days ago | Security | Moderate   | Moderate       | 1        |
+          | Bug15 | 10 days ago | Security | Moderate   | Moderate       | 1        |
+          | Bug16 | 10 days ago | Security | Moderate   | Moderate       | 1        |
+          | Bug17 | 10 days ago | Security | Moderate   | Moderate       | 1        |
+          | Bug18 | 10 days ago | Security | Moderate   | Moderate       | 1        |
+          | Bug19 | 10 days ago | Security | Moderate   | Moderate       | 1        |
+          | Bug20 | 10 days ago | Security | Moderate   | Moderate       | 1        |
       And pagination widget needs to be displayed in the top right corner
       And pagination widget needs to be displayed in the bottom right
      When user look at top right pagination widget

--- a/features/Insights_Advisor/recommendations_page_pagination.feature
+++ b/features/Insights_Advisor/recommendations_page_pagination.feature
@@ -40,13 +40,25 @@ Feature: Pagination feature in Advisor recommendations page on Hybrid Cloud Cons
      When user looks at Hybrid Cloud Console main page
      Then menu on the left side should be displayed
       And the left menu might contain these top level items
+          | Left menu item                | Required for this test |
+          | Application and Data Services | no                     |
+          | OpenShift                     | yes                    |
+          | Red Hat Enterprise Linux      | no                     |
+          | Ansible Automation Platform   | no                     |
+     When user selects "OpenShift" from the left side menu
+     Then menu on the left side should be changed
+      And the left menu might contain these top level items
           | Left menu item           | Required for this test |
+          | Clusters                 | no                     |
           | Overview                 | no                     |
           | Releases                 | no                     |
+          | Developer Sandbox        | no                     |
           | Downloads                | no                     |
           | Advisor                  | yes                    |
+          | Vulnerability            | no                     |
           | Subscriptions            | no                     |
           | Cost Management          | no                     |
+          | Support Cases            | no                     |
           | Cluster Manager Feedback | no                     |
           | Red Hat Marketplace      | no                     |
           | Documentation            | no                     |
@@ -163,13 +175,25 @@ Feature: Pagination feature in Advisor recommendations page on Hybrid Cloud Cons
      When user looks at Hybrid Cloud Console main page
      Then menu on the left side should be displayed
       And the left menu might contain these top level items
+          | Left menu item                | Required for this test |
+          | Application and Data Services | no                     |
+          | OpenShift                     | yes                    |
+          | Red Hat Enterprise Linux      | no                     |
+          | Ansible Automation Platform   | no                     |
+     When user selects "OpenShift" from the left side menu
+     Then menu on the left side should be changed
+      And the left menu might contain these top level items
           | Left menu item           | Required for this test |
+          | Clusters                 | no                     |
           | Overview                 | no                     |
           | Releases                 | no                     |
+          | Developer Sandbox        | no                     |
           | Downloads                | no                     |
           | Advisor                  | yes                    |
+          | Vulnerability            | no                     |
           | Subscriptions            | no                     |
           | Cost Management          | no                     |
+          | Support Cases            | no                     |
           | Cluster Manager Feedback | no                     |
           | Red Hat Marketplace      | no                     |
           | Documentation            | no                     |
@@ -295,13 +319,25 @@ Feature: Pagination feature in Advisor recommendations page on Hybrid Cloud Cons
      When user looks at Hybrid Cloud Console main page
      Then menu on the left side should be displayed
       And the left menu might contain these top level items
+          | Left menu item                | Required for this test |
+          | Application and Data Services | no                     |
+          | OpenShift                     | yes                    |
+          | Red Hat Enterprise Linux      | no                     |
+          | Ansible Automation Platform   | no                     |
+     When user selects "OpenShift" from the left side menu
+     Then menu on the left side should be changed
+      And the left menu might contain these top level items
           | Left menu item           | Required for this test |
+          | Clusters                 | no                     |
           | Overview                 | no                     |
           | Releases                 | no                     |
+          | Developer Sandbox        | no                     |
           | Downloads                | no                     |
           | Advisor                  | yes                    |
+          | Vulnerability            | no                     |
           | Subscriptions            | no                     |
           | Cost Management          | no                     |
+          | Support Cases            | no                     |
           | Cluster Manager Feedback | no                     |
           | Red Hat Marketplace      | no                     |
           | Documentation            | no                     |
@@ -429,13 +465,25 @@ Feature: Pagination feature in Advisor recommendations page on Hybrid Cloud Cons
      When user looks at Hybrid Cloud Console main page
      Then menu on the left side should be displayed
       And the left menu might contain these top level items
+          | Left menu item                | Required for this test |
+          | Application and Data Services | no                     |
+          | OpenShift                     | yes                    |
+          | Red Hat Enterprise Linux      | no                     |
+          | Ansible Automation Platform   | no                     |
+     When user selects "OpenShift" from the left side menu
+     Then menu on the left side should be changed
+      And the left menu might contain these top level items
           | Left menu item           | Required for this test |
+          | Clusters                 | no                     |
           | Overview                 | no                     |
           | Releases                 | no                     |
+          | Developer Sandbox        | no                     |
           | Downloads                | no                     |
           | Advisor                  | yes                    |
+          | Vulnerability            | no                     |
           | Subscriptions            | no                     |
           | Cost Management          | no                     |
+          | Support Cases            | no                     |
           | Cluster Manager Feedback | no                     |
           | Red Hat Marketplace      | no                     |
           | Documentation            | no                     |
@@ -603,13 +651,25 @@ Feature: Pagination feature in Advisor recommendations page on Hybrid Cloud Cons
      When user looks at Hybrid Cloud Console main page
      Then menu on the left side should be displayed
       And the left menu might contain these top level items
+          | Left menu item                | Required for this test |
+          | Application and Data Services | no                     |
+          | OpenShift                     | yes                    |
+          | Red Hat Enterprise Linux      | no                     |
+          | Ansible Automation Platform   | no                     |
+     When user selects "OpenShift" from the left side menu
+     Then menu on the left side should be changed
+      And the left menu might contain these top level items
           | Left menu item           | Required for this test |
+          | Clusters                 | no                     |
           | Overview                 | no                     |
           | Releases                 | no                     |
+          | Developer Sandbox        | no                     |
           | Downloads                | no                     |
           | Advisor                  | yes                    |
+          | Vulnerability            | no                     |
           | Subscriptions            | no                     |
           | Cost Management          | no                     |
+          | Support Cases            | no                     |
           | Cluster Manager Feedback | no                     |
           | Red Hat Marketplace      | no                     |
           | Documentation            | no                     |

--- a/features/Insights_Advisor/recommendations_page_pagination.feature
+++ b/features/Insights_Advisor/recommendations_page_pagination.feature
@@ -3,7 +3,7 @@ Feature: Pagination feature in Advisor recommendations page on Hybrid Cloud Cons
 
   Scenario: Pagination widgets displayed in Advisor recommendations page on Hybrid Cloud Console
     Given user USER1 is part of account (organization) ACCOUNT1
-      And account (organization) ACCOUNT1 owns one cluster
+      And account (organization) ACCOUNT1 owns 1 cluster
       And 30 issues are detected for this cluster
           | Title    | Modified    | Category | Total risk | Risk of change |
           | Bug01    | 10 days ago | Security | Important  | High           |
@@ -126,7 +126,7 @@ Feature: Pagination feature in Advisor recommendations page on Hybrid Cloud Cons
 
   Scenario: Goto to next page in Advisor recommendations page on Hybrid Cloud Console using top right pagination widget
     Given user USER1 is part of account (organization) ACCOUNT1
-      And account (organization) ACCOUNT1 owns one cluster
+      And account (organization) ACCOUNT1 owns 1 cluster
       And 30 issues are detected for this cluster
           | Title    | Modified    | Category | Total risk | Risk of change |
           | Bug01    | 10 days ago | Security | Important  | High           |
@@ -258,7 +258,7 @@ Feature: Pagination feature in Advisor recommendations page on Hybrid Cloud Cons
 
   Scenario: Goto to last page in Advisor recommendations page on Hybrid Cloud Console using top right pagination widget
     Given user USER1 is part of account (organization) ACCOUNT1
-      And account (organization) ACCOUNT1 owns one cluster
+      And account (organization) ACCOUNT1 owns 1 cluster
       And 30 issues are detected for this cluster
           | Title    | Modified    | Category | Total risk | Risk of change |
           | Bug01    | 10 days ago | Security | Important  | High           |
@@ -392,7 +392,7 @@ Feature: Pagination feature in Advisor recommendations page on Hybrid Cloud Cons
 
   Scenario: Goto to previous page in Advisor recommendations page on Hybrid Cloud Console using top right pagination widget
     Given user USER1 is part of account (organization) ACCOUNT1
-      And account (organization) ACCOUNT1 owns one cluster
+      And account (organization) ACCOUNT1 owns 1 cluster
       And 30 issues are detected for this cluster
           | Title    | Modified    | Category | Total risk | Risk of change |
           | Bug01    | 10 days ago | Security | Important  | High           |
@@ -566,7 +566,7 @@ Feature: Pagination feature in Advisor recommendations page on Hybrid Cloud Cons
 
   Scenario: Goto to first page in Advisor recommendations page on Hybrid Cloud Console using top right pagination widget
     Given user USER1 is part of account (organization) ACCOUNT1
-      And account (organization) ACCOUNT1 owns one cluster
+      And account (organization) ACCOUNT1 owns 1 cluster
       And 30 issues are detected for this cluster
           | Title    | Modified    | Category | Total risk | Risk of change |
           | Bug01    | 10 days ago | Security | Important  | High           |

--- a/features/Insights_Advisor/recommendations_page_sorting.feature
+++ b/features/Insights_Advisor/recommendations_page_sorting.feature
@@ -34,13 +34,25 @@ Feature: Sorting on Advisor recommendations page behaviour on Hybrid Cloud Conso
      When user looks at Hybrid Cloud Console main page
      Then menu on the left side should be displayed
       And the left menu might contain these top level items
+          | Left menu item                | Required for this test |
+          | Application and Data Services | no                     |
+          | OpenShift                     | yes                    |
+          | Red Hat Enterprise Linux      | no                     |
+          | Ansible Automation Platform   | no                     |
+     When user selects "OpenShift" from the left side menu
+     Then menu on the left side should be changed
+      And the left menu might contain these top level items
           | Left menu item           | Required for this test |
+          | Clusters                 | no                     |
           | Overview                 | no                     |
           | Releases                 | no                     |
+          | Developer Sandbox        | no                     |
           | Downloads                | no                     |
           | Advisor                  | yes                    |
+          | Vulnerability            | no                     |
           | Subscriptions            | no                     |
           | Cost Management          | no                     |
+          | Support Cases            | no                     |
           | Cluster Manager Feedback | no                     |
           | Red Hat Marketplace      | no                     |
           | Documentation            | no                     |
@@ -102,13 +114,25 @@ Feature: Sorting on Advisor recommendations page behaviour on Hybrid Cloud Conso
      When user looks at Hybrid Cloud Console main page
      Then menu on the left side should be displayed
       And the left menu might contain these top level items
+          | Left menu item                | Required for this test |
+          | Application and Data Services | no                     |
+          | OpenShift                     | yes                    |
+          | Red Hat Enterprise Linux      | no                     |
+          | Ansible Automation Platform   | no                     |
+     When user selects "OpenShift" from the left side menu
+     Then menu on the left side should be changed
+      And the left menu might contain these top level items
           | Left menu item           | Required for this test |
+          | Clusters                 | no                     |
           | Overview                 | no                     |
           | Releases                 | no                     |
+          | Developer Sandbox        | no                     |
           | Downloads                | no                     |
           | Advisor                  | yes                    |
+          | Vulnerability            | no                     |
           | Subscriptions            | no                     |
           | Cost Management          | no                     |
+          | Support Cases            | no                     |
           | Cluster Manager Feedback | no                     |
           | Red Hat Marketplace      | no                     |
           | Documentation            | no                     |
@@ -200,13 +224,25 @@ Feature: Sorting on Advisor recommendations page behaviour on Hybrid Cloud Conso
      When user looks at Hybrid Cloud Console main page
      Then menu on the left side should be displayed
       And the left menu might contain these top level items
+          | Left menu item                | Required for this test |
+          | Application and Data Services | no                     |
+          | OpenShift                     | yes                    |
+          | Red Hat Enterprise Linux      | no                     |
+          | Ansible Automation Platform   | no                     |
+     When user selects "OpenShift" from the left side menu
+     Then menu on the left side should be changed
+      And the left menu might contain these top level items
           | Left menu item           | Required for this test |
+          | Clusters                 | no                     |
           | Overview                 | no                     |
           | Releases                 | no                     |
+          | Developer Sandbox        | no                     |
           | Downloads                | no                     |
           | Advisor                  | yes                    |
+          | Vulnerability            | no                     |
           | Subscriptions            | no                     |
           | Cost Management          | no                     |
+          | Support Cases            | no                     |
           | Cluster Manager Feedback | no                     |
           | Red Hat Marketplace      | no                     |
           | Documentation            | no                     |
@@ -298,13 +334,25 @@ Feature: Sorting on Advisor recommendations page behaviour on Hybrid Cloud Conso
      When user looks at Hybrid Cloud Console main page
      Then menu on the left side should be displayed
       And the left menu might contain these top level items
+          | Left menu item                | Required for this test |
+          | Application and Data Services | no                     |
+          | OpenShift                     | yes                    |
+          | Red Hat Enterprise Linux      | no                     |
+          | Ansible Automation Platform   | no                     |
+     When user selects "OpenShift" from the left side menu
+     Then menu on the left side should be changed
+      And the left menu might contain these top level items
           | Left menu item           | Required for this test |
+          | Clusters                 | no                     |
           | Overview                 | no                     |
           | Releases                 | no                     |
+          | Developer Sandbox        | no                     |
           | Downloads                | no                     |
           | Advisor                  | yes                    |
+          | Vulnerability            | no                     |
           | Subscriptions            | no                     |
           | Cost Management          | no                     |
+          | Support Cases            | no                     |
           | Cluster Manager Feedback | no                     |
           | Red Hat Marketplace      | no                     |
           | Documentation            | no                     |
@@ -396,13 +444,25 @@ Feature: Sorting on Advisor recommendations page behaviour on Hybrid Cloud Conso
      When user looks at Hybrid Cloud Console main page
      Then menu on the left side should be displayed
       And the left menu might contain these top level items
+          | Left menu item                | Required for this test |
+          | Application and Data Services | no                     |
+          | OpenShift                     | yes                    |
+          | Red Hat Enterprise Linux      | no                     |
+          | Ansible Automation Platform   | no                     |
+     When user selects "OpenShift" from the left side menu
+     Then menu on the left side should be changed
+      And the left menu might contain these top level items
           | Left menu item           | Required for this test |
+          | Clusters                 | no                     |
           | Overview                 | no                     |
           | Releases                 | no                     |
+          | Developer Sandbox        | no                     |
           | Downloads                | no                     |
           | Advisor                  | yes                    |
+          | Vulnerability            | no                     |
           | Subscriptions            | no                     |
           | Cost Management          | no                     |
+          | Support Cases            | no                     |
           | Cluster Manager Feedback | no                     |
           | Red Hat Marketplace      | no                     |
           | Documentation            | no                     |
@@ -494,13 +554,25 @@ Feature: Sorting on Advisor recommendations page behaviour on Hybrid Cloud Conso
      When user looks at Hybrid Cloud Console main page
      Then menu on the left side should be displayed
       And the left menu might contain these top level items
+          | Left menu item                | Required for this test |
+          | Application and Data Services | no                     |
+          | OpenShift                     | yes                    |
+          | Red Hat Enterprise Linux      | no                     |
+          | Ansible Automation Platform   | no                     |
+     When user selects "OpenShift" from the left side menu
+     Then menu on the left side should be changed
+      And the left menu might contain these top level items
           | Left menu item           | Required for this test |
+          | Clusters                 | no                     |
           | Overview                 | no                     |
           | Releases                 | no                     |
+          | Developer Sandbox        | no                     |
           | Downloads                | no                     |
           | Advisor                  | yes                    |
+          | Vulnerability            | no                     |
           | Subscriptions            | no                     |
           | Cost Management          | no                     |
+          | Support Cases            | no                     |
           | Cluster Manager Feedback | no                     |
           | Red Hat Marketplace      | no                     |
           | Documentation            | no                     |
@@ -623,13 +695,25 @@ Feature: Sorting on Advisor recommendations page behaviour on Hybrid Cloud Conso
      When user looks at Hybrid Cloud Console main page
      Then menu on the left side should be displayed
       And the left menu might contain these top level items
+          | Left menu item                | Required for this test |
+          | Application and Data Services | no                     |
+          | OpenShift                     | yes                    |
+          | Red Hat Enterprise Linux      | no                     |
+          | Ansible Automation Platform   | no                     |
+     When user selects "OpenShift" from the left side menu
+     Then menu on the left side should be changed
+      And the left menu might contain these top level items
           | Left menu item           | Required for this test |
+          | Clusters                 | no                     |
           | Overview                 | no                     |
           | Releases                 | no                     |
+          | Developer Sandbox        | no                     |
           | Downloads                | no                     |
           | Advisor                  | yes                    |
+          | Vulnerability            | no                     |
           | Subscriptions            | no                     |
           | Cost Management          | no                     |
+          | Support Cases            | no                     |
           | Cluster Manager Feedback | no                     |
           | Red Hat Marketplace      | no                     |
           | Documentation            | no                     |

--- a/features/Insights_Advisor/recommendations_page_sorting.feature
+++ b/features/Insights_Advisor/recommendations_page_sorting.feature
@@ -10,26 +10,26 @@ Feature: Sorting on Advisor recommendations page behaviour on Hybrid Cloud Conso
           | 22222222-0000-0000-0000-000000000000 |
           | 33333333-0000-0000-0000-000000000000 |
       And 4 issues are detected for cluster 00000000-0000-0000-0000-000000000000
-          | Title    | Modified    | Total risk | Category                  |
-          | Bug12345 | 10 days ago | Critical   | Availability, Security    |
-          | Abc12345 | 10 days ago | Important  | Availability              |
-          | Xyz12345 | 10 days ago | Moderate   | Performance               |
-          | Uvw12345 | 10 days ago | Low        | Security                  |
+          | Title    | Modified    | Total risk | Category                  | Risk of change |
+          | Bug12345 | 10 days ago | Critical   | Availability, Security    | High           |
+          | Abc12345 | 10 days ago | Important  | Availability              | Moderate       |
+          | Xyz12345 | 10 days ago | Moderate   | Performance               | Low            |
+          | Uvw12345 | 10 days ago | Low        | Security                  | Very Low       |
       And 3 issues are detected for cluster 11111111-0000-0000-0000-000000000000
-          | Title    | Modified    | Total risk | Category                  |
-          | Bug12345 | 10 days ago | Critical   | Availability, Security    |
-          | Abc12345 | 10 days ago | Important  | Availability              |
-          | Xyz12345 | 10 days ago | Moderate   | Performance               |
+          | Title    | Modified    | Total risk | Category                  | Risk of change |
+          | Bug12345 | 10 days ago | Critical   | Availability, Security    | High           |
+          | Abc12345 | 10 days ago | Important  | Availability              | Moderate       |
+          | Xyz12345 | 10 days ago | Moderate   | Performance               | Low            |
       And 2 issues are detected for cluster 22222222-0000-0000-0000-000000000000
-          | Title    | Modified    | Total risk | Category                  |
-          | Bug12345 | 10 days ago | Critical   | Availability, Security    |
-          | Abc12345 | 10 days ago | Important  | Availability              |
+          | Title    | Modified    | Total risk | Category                  | Risk of change |
+          | Bug12345 | 10 days ago | Critical   | Availability, Security    | High           |
+          | Abc12345 | 10 days ago | Important  | Availability              | Moderate       |
       And 1 issue is detected for cluster 33333333-0000-0000-0000-000000000000
-          | Title    | Modified    | Total risk | Category                  |
-          | Bug12345 | 10 days ago | Critical   | Availability, Security    |
+          | Title    | Modified    | Total risk | Category                  | Risk of change |
+          | Bug12345 | 10 days ago | Critical   | Availability, Security    | High           |
       And 1 another issue without cluster hit exists
-          | Title    | Modified    | Total risk | Category                  |
-          | Nohit    | 10 days ago | Critical   | Fault tolerance           |
+          | Title    | Modified    | Total risk | Category                  | Risk of change |
+          | Nohit    | 10 days ago | Critical   | Fault tolerance           | Very Low       |
       And the user USER1 is already logged in into Hybrid Cloud Console
      When user looks at Hybrid Cloud Console main page
      Then menu on the left side should be displayed
@@ -54,18 +54,19 @@ Feature: Sorting on Advisor recommendations page behaviour on Hybrid Cloud Conso
      Then an "Advisor recommendations" page should be displayed right of the left menu bar
       And widget with filter settings should be displayed
       And table with several columns should be displayed with sorting setting
-          | Column name | Sort | Highlighted |
-          | Name        | ↕    | no          |
-          | Modified    | ↕    | no          |
-          | Category    | ↕    | no          |
-          | Total risk  | ↓    | yes         |
-          | Clusters    | ↕    | no          |
+          | Column name    | Sort | Highlighted |
+          | Name           | ↕    | no          |
+          | Modified       | ↕    | no          |
+          | Category       | ↕    | no          |
+          | Total risk     | ↓    | yes         |
+          | Risk of change | ↕    | no          |
+          | Clusters       | ↕    | no          |
       And that table should contain following four rows in that order
-          | Name        | Modified    | Category             | Total risk | Clusters |
-          | Bug12345    | 10 days ago | Availability, 1 more | Critical   | 4        |
-          | Abc12345    | 10 days ago | Availability         | Important  | 3        |
-          | Xyz12345    | 10 days ago | Performance          | Moderate   | 2        |
-          | Uvw12345    | 10 days ago | Security             | Low        | 1        |
+          | Name        | Modified    | Category             | Total risk | Risk of change | Clusters |
+          | Bug12345    | 10 days ago | Availability, 1 more | Critical   | High           | 4        |
+          | Abc12345    | 10 days ago | Availability         | Important  | Moderate       | 3        |
+          | Xyz12345    | 10 days ago | Performance          | Moderate   | Low            | 2        |
+          | Uvw12345    | 10 days ago | Security             | Low        | Very Low       | 1        |
 
 
   Scenario: Sorting by name on Advisor's "Recommendations" page on Hybrid Cloud Console with five recommendations and four clusters
@@ -77,26 +78,26 @@ Feature: Sorting on Advisor recommendations page behaviour on Hybrid Cloud Conso
           | 22222222-0000-0000-0000-000000000000 |
           | 33333333-0000-0000-0000-000000000000 |
       And 4 issues are detected for cluster 00000000-0000-0000-0000-000000000000
-          | Title    | Modified    | Total risk |
-          | Bug12345 | 10 days ago | Critical   |
-          | Abc12345 | 10 days ago | Important  |
-          | Xyz12345 | 10 days ago | Moderate   |
-          | Uvw12345 | 10 days ago | Low        |
+          | Title    | Modified    | Total risk | Risk of change | Category             |
+          | Bug12345 | 10 days ago | Critical   | High           | Service Availability |
+          | Abc12345 | 10 days ago | Important  | Moderate       | Performance          |
+          | Xyz12345 | 10 days ago | Moderate   | Low            | Fault Tolerance      |
+          | Uvw12345 | 10 days ago | Low        | Very low       | Security             |
       And 3 issues are detected for cluster 11111111-0000-0000-0000-000000000000
-          | Title    | Modified    | Total risk |
-          | Bug12345 | 10 days ago | Critical   |
-          | Abc12345 | 10 days ago | Important  |
-          | Xyz12345 | 10 days ago | Moderate   |
+          | Title    | Modified    | Total risk | Risk of change | Category             |
+          | Bug12345 | 10 days ago | Critical   | High           | Service Availability |
+          | Abc12345 | 10 days ago | Important  | Moderate       | Performance          |
+          | Xyz12345 | 10 days ago | Moderate   | Low            | Fault Tolerance      |
       And 2 issues are detected for cluster 22222222-0000-0000-0000-000000000000
-          | Title    | Modified    | Total risk |
-          | Bug12345 | 10 days ago | Critical   |
-          | Abc12345 | 10 days ago | Important  |
+          | Title    | Modified    | Total risk | Risk of change | Category             |
+          | Bug12345 | 10 days ago | Critical   | High           | Service Availability |
+          | Abc12345 | 10 days ago | Important  | Moderate       | Performance          |
       And 1 issue is detected for cluster 33333333-0000-0000-0000-000000000000
-          | Title    | Modified    | Total risk |
-          | Bug12345 | 10 days ago | Critical   |
+          | Title    | Modified    | Total risk | Risk of change | Category             |
+          | Bug12345 | 10 days ago | Critical   | High           | Service Availability |
       And 1 another issue without cluster hit exists
-          | Title    | Modified    | Total risk |
-          | Nohit    | 10 days ago | Critical   |
+          | Title    | Modified    | Total risk | Risk of change | Category             |
+          | Nohit    | 10 days ago | Critical   | High           | Service Availability |
       And the user USER1 is already logged in into Hybrid Cloud Console
      When user looks at Hybrid Cloud Console main page
      Then menu on the left side should be displayed
@@ -121,46 +122,49 @@ Feature: Sorting on Advisor recommendations page behaviour on Hybrid Cloud Conso
      Then an "Advisor recommendations" page should be displayed right of the left menu bar
       And widget with filter settings should be displayed
       And table with several columns should be displayed with sorting setting
-          | Column name | Sort | Highlighted |
-          | Name        | ↕    | no          |
-          | Modified    | ↕    | no          |
-          | Category    | ↕    | no          |
-          | Total risk  | ↓    | yes         |
-          | Clusters    | ↕    | no          |
+          | Column name    | Sort | Highlighted |
+          | Name           | ↕    | no          |
+          | Modified       | ↕    | no          |
+          | Category       | ↕    | no          |
+          | Total risk     | ↓    | yes         |
+          | Risk of change | ↕    | no          |
+          | Clusters       | ↕    | no          |
       And that table should contain following four rows in that order
-          | Name        | Modified    | Total risk | Clusters |
-          | Bug12345    | 10 days ago | Critical   | 4        |
-          | Abc12345    | 10 days ago | Important  | 3        |
-          | Xyz12345    | 10 days ago | Moderate   | 2        |
-          | Uvw12345    | 10 days ago | Low        | 1        |
+          | Name        | Modified    | Category             | Total risk | Risk of change | Clusters |
+          | Bug12345    | 10 days ago | Service Availability | Critical   | High           | 4        |
+          | Abc12345    | 10 days ago | Performance          | Important  | Moderate       | 3        |
+          | Xyz12345    | 10 days ago | Fault Tolerance      | Moderate   | Low            | 2        |
+          | Uvw12345    | 10 days ago | Security             | Low        | Very Low       | 1        |
      When user clicks on ↕ symbol in "Name" column title
       And table with several columns should be displayed with sorting setting
-          | Column name | Sort | Highlighted |
-          | Name        | ↓    | yes         |
-          | Modified    | ↕    | no          |
-          | Category    | ↕    | no          |
-          | Total risk  | ↕    | no          |
-          | Clusters    | ↕    | no          |
+          | Column name    | Sort | Highlighted |
+          | Name           | ↓    | yes         |
+          | Modified       | ↕    | no          |
+          | Category       | ↕    | no          |
+          | Total risk     | ↕    | no          |
+          | Risk of change | ↕    | no          |
+          | Clusters       | ↕    | no          |
       And that table should contain following four rows in that order
-          | Name        | Modified    | Total risk | Clusters |
-          | Abc12345    | 10 days ago | Important  | 3        |
-          | Bug12345    | 10 days ago | Critical   | 4        |
-          | Uvw12345    | 10 days ago | Low        | 1        |
-          | Xyz12345    | 10 days ago | Moderate   | 2        |
+          | Name        | Modified    | Category             | Total risk | Risk of change | Clusters |
+          | Abc12345    | 10 days ago | Performance          | Important  | Moderate       | 3        |
+          | Bug12345    | 10 days ago | Service Availability | Critical   | High           | 4        |
+          | Uvw12345    | 10 days ago | Security             | Low        | Very Low       | 1        |
+          | Xyz12345    | 10 days ago | Fault Tolerance      | Moderate   | Low            | 2        |
      When user clicks on ↓ symbol in "Name" column title
       And table with several columns should be displayed with sorting setting
-          | Column name | Sort | Highlighted |
-          | Name        | ↑    | yes         |
-          | Modified    | ↕    | no          |
-          | Category    | ↕    | no          |
-          | Total risk  | ↕    | no          |
-          | Clusters    | ↕    | no          |
+          | Column name    | Sort | Highlighted |
+          | Name           | ↑    | yes         |
+          | Modified       | ↕    | no          |
+          | Category       | ↕    | no          |
+          | Total risk     | ↕    | no          |
+          | Risk of change | ↕    | no          |
+          | Clusters       | ↕    | no          |
       And that table should contain following four rows in that order
-          | Name        | Modified    | Total risk | Clusters |
-          | Xyz12345    | 10 days ago | Moderate   | 2        |
-          | Uvw12345    | 10 days ago | Low        | 1        |
-          | Bug12345    | 10 days ago | Critical   | 4        |
-          | Abc12345    | 10 days ago | Important  | 3        |
+          | Name        | Modified    | Category             | Total risk | Risk of change | Clusters |
+          | Xyz12345    | 10 days ago | Fault Tolerance      | Moderate   | Low            | 2        |
+          | Uvw12345    | 10 days ago | Security             | Low        | Very Low       | 1        |
+          | Bug12345    | 10 days ago | Service Availability | Critical   | High           | 4        |
+          | Abc12345    | 10 days ago | Performance          | Important  | Moderate       | 3        |
 
 
   Scenario: Sorting by total risk on Advisor's "Recommendations" page on Hybrid Cloud Console with five recommendations and four clusters
@@ -172,26 +176,26 @@ Feature: Sorting on Advisor recommendations page behaviour on Hybrid Cloud Conso
           | 22222222-0000-0000-0000-000000000000 |
           | 33333333-0000-0000-0000-000000000000 |
       And 4 issues are detected for cluster 00000000-0000-0000-0000-000000000000
-          | Title    | Modified    | Total risk |
-          | Bug12345 | 10 days ago | Critical   |
-          | Abc12345 | 10 days ago | Important  |
-          | Xyz12345 | 10 days ago | Moderate   |
-          | Uvw12345 | 10 days ago | Low        |
+          | Title    | Modified    | Total risk | Risk of change | Category             |
+          | Bug12345 | 10 days ago | Critical   | High           | Service Availability |
+          | Abc12345 | 10 days ago | Important  | Moderate       | Performance          |
+          | Xyz12345 | 10 days ago | Moderate   | Low            | Fault Tolerance      |
+          | Uvw12345 | 10 days ago | Low        | Very low       | Security             |
       And 3 issues are detected for cluster 11111111-0000-0000-0000-000000000000
-          | Title    | Modified    | Total risk |
-          | Bug12345 | 10 days ago | Critical   |
-          | Abc12345 | 10 days ago | Important  |
-          | Xyz12345 | 10 days ago | Moderate   |
+          | Title    | Modified    | Total risk | Risk of change | Category             |
+          | Bug12345 | 10 days ago | Critical   | High           | Service Availability |
+          | Abc12345 | 10 days ago | Important  | Moderate       | Performance          |
+          | Xyz12345 | 10 days ago | Moderate   | Low            | Fault Tolerance      |
       And 2 issues are detected for cluster 22222222-0000-0000-0000-000000000000
-          | Title    | Modified    | Total risk |
-          | Bug12345 | 10 days ago | Critical   |
-          | Abc12345 | 10 days ago | Important  |
+          | Title    | Modified    | Total risk | Risk of change | Category             |
+          | Bug12345 | 10 days ago | Critical   | High           | Service Availability |
+          | Abc12345 | 10 days ago | Important  | Moderate       | Performance          |
       And 1 issue is detected for cluster 33333333-0000-0000-0000-000000000000
-          | Title    | Modified    | Total risk |
-          | Bug12345 | 10 days ago | Critical   |
+          | Title    | Modified    | Total risk | Risk of change | Category             |
+          | Bug12345 | 10 days ago | Critical   | High           | Service Availability |
       And 1 another issue without cluster hit exists
-          | Title    | Modified    | Total risk |
-          | Nohit    | 10 days ago | Critical   |
+          | Title    | Modified    | Total risk | Risk of change | Category             |
+          | Nohit    | 10 days ago | Critical   | High           | Service Availability |
       And the user USER1 is already logged in into Hybrid Cloud Console
      When user looks at Hybrid Cloud Console main page
      Then menu on the left side should be displayed
@@ -216,46 +220,49 @@ Feature: Sorting on Advisor recommendations page behaviour on Hybrid Cloud Conso
      Then an "Advisor recommendations" page should be displayed right of the left menu bar
       And widget with filter settings should be displayed
       And table with several columns should be displayed with sorting setting
-          | Column name | Sort | Highlighted |
-          | Name        | ↕    | no          |
-          | Modified    | ↕    | no          |
-          | Category    | ↕    | no          |
-          | Total risk  | ↓    | yes         |
-          | Clusters    | ↕    | no          |
+          | Column name    | Sort | Highlighted |
+          | Name           | ↕    | no          |
+          | Modified       | ↕    | no          |
+          | Category       | ↕    | no          |
+          | Total risk     | ↓    | yes         |
+          | Risk of change | ↕    | no          |
+          | Clusters       | ↕    | no          |
       And that table should contain following four rows in that order
-          | Name        | Modified    | Total risk | Clusters |
-          | Bug12345    | 10 days ago | Critical   | 4        |
-          | Abc12345    | 10 days ago | Important  | 3        |
-          | Xyz12345    | 10 days ago | Moderate   | 2        |
-          | Uvw12345    | 10 days ago | Low        | 1        |
+          | Name        | Modified    | Category             | Total risk | Risk of change | Clusters |
+          | Bug12345    | 10 days ago | Service Availability | Critical   | High           | 4        |
+          | Abc12345    | 10 days ago | Performance          | Important  | Moderate       | 3        |
+          | Xyz12345    | 10 days ago | Fault Tolerance      | Moderate   | Low            | 2        |
+          | Uvw12345    | 10 days ago | Security             | Low        | Very Low       | 1        |
      When user clicks on ↓ symbol in "Total risk" column title
       And table with several columns should be displayed with sorting setting
-          | Column name | Sort | Highlighted |
-          | Name        | ↕    | no          |
-          | Modified    | ↕    | no          |
-          | Category    | ↕    | no          |
-          | Total risk  | ↑    | yes         |
-          | Clusters    | ↕    | no          |
+          | Column name    | Sort | Highlighted |
+          | Name           | ↕    | no          |
+          | Modified       | ↕    | no          |
+          | Category       | ↕    | no          |
+          | Total risk     | ↑    | yes         |
+          | Risk of change | ↕    | no          |
+          | Clusters       | ↕    | no          |
       And that table should contain following four rows in that order
-          | Name        | Modified    | Total risk | Clusters |
-          | Uvw12345    | 10 days ago | Low        | 1        |
-          | Xyz12345    | 10 days ago | Moderate   | 2        |
-          | Abc12345    | 10 days ago | Important  | 3        |
-          | Bug12345    | 10 days ago | Critical   | 4        |
+          | Name        | Modified    | Category             | Total risk | Risk of change | Clusters |
+          | Uvw12345    | 10 days ago | Security             | Low        | Very Low       | 1        |
+          | Xyz12345    | 10 days ago | Fault Tolerance      | Moderate   | Low            | 2        |
+          | Abc12345    | 10 days ago | Performance          | Important  | Moderate       | 3        |
+          | Bug12345    | 10 days ago | Service Availability | Critical   | High           | 4        |
      When user clicks on ↑ symbol in "Total risk" column title
       And table with several columns should be displayed with sorting setting
-          | Column name | Sort | Highlighted |
-          | Name        | ↕    | no          |
-          | Modified    | ↕    | no          |
-          | Category    | ↕    | no          |
-          | Total risk  | ↓    | yes         |
-          | Clusters    | ↕    | no          |
+          | Column name    | Sort | Highlighted |
+          | Name           | ↕    | no          |
+          | Modified       | ↕    | no          |
+          | Category       | ↕    | no          |
+          | Total risk     | ↓    | yes         |
+          | Risk of change | ↕    | no          |
+          | Clusters       | ↕    | no          |
       And that table should contain following four rows in that order
-          | Name        | Modified    | Total risk | Clusters |
-          | Bug12345    | 10 days ago | Critical   | 4        |
-          | Abc12345    | 10 days ago | Important  | 3        |
-          | Xyz12345    | 10 days ago | Moderate   | 2        |
-          | Uvw12345    | 10 days ago | Low        | 1        |
+          | Name        | Modified    | Category             | Total risk | Risk of change | Clusters |
+          | Bug12345    | 10 days ago | Service Availability | Critical   | High           | 4        |
+          | Abc12345    | 10 days ago | Performance          | Important  | Moderate       | 3        |
+          | Xyz12345    | 10 days ago | Fault Tolerance      | Moderate   | Low            | 2        |
+          | Uvw12345    | 10 days ago | Security             | Low        | Very Low       | 1        |
 
 
   Scenario: Sorting by clusters on Advisor's "Recommendations" page on Hybrid Cloud Console with five recommendations and four clusters
@@ -267,26 +274,26 @@ Feature: Sorting on Advisor recommendations page behaviour on Hybrid Cloud Conso
           | 22222222-0000-0000-0000-000000000000 |
           | 33333333-0000-0000-0000-000000000000 |
       And 4 issues are detected for cluster 00000000-0000-0000-0000-000000000000
-          | Title    | Modified    | Total risk |
-          | Bug12345 | 10 days ago | Critical   |
-          | Abc12345 | 10 days ago | Important  |
-          | Xyz12345 | 10 days ago | Moderate   |
-          | Uvw12345 | 10 days ago | Low        |
+          | Title    | Modified    | Total risk | Risk of change | Category             |
+          | Bug12345 | 10 days ago | Critical   | High           | Service Availability |
+          | Abc12345 | 10 days ago | Important  | Moderate       | Performance          |
+          | Xyz12345 | 10 days ago | Moderate   | Low            | Fault Tolerance      |
+          | Uvw12345 | 10 days ago | Low        | Very low       | Security             |
       And 3 issues are detected for cluster 11111111-0000-0000-0000-000000000000
-          | Title    | Modified    | Total risk |
-          | Bug12345 | 10 days ago | Critical   |
-          | Abc12345 | 10 days ago | Important  |
-          | Xyz12345 | 10 days ago | Moderate   |
+          | Title    | Modified    | Total risk | Risk of change | Category             |
+          | Bug12345 | 10 days ago | Critical   | High           | Service Availability |
+          | Abc12345 | 10 days ago | Important  | Moderate       | Performance          |
+          | Xyz12345 | 10 days ago | Moderate   | Low            | Fault Tolerance      |
       And 2 issues are detected for cluster 22222222-0000-0000-0000-000000000000
-          | Title    | Modified    | Total risk |
-          | Bug12345 | 10 days ago | Critical   |
-          | Abc12345 | 10 days ago | Important  |
+          | Title    | Modified    | Total risk | Risk of change | Category             |
+          | Bug12345 | 10 days ago | Critical   | High           | Service Availability |
+          | Abc12345 | 10 days ago | Important  | Moderate       | Performance          |
       And 1 issue is detected for cluster 33333333-0000-0000-0000-000000000000
-          | Title    | Modified    | Total risk |
-          | Bug12345 | 10 days ago | Critical   |
+          | Title    | Modified    | Total risk | Risk of change | Category             |
+          | Bug12345 | 10 days ago | Critical   | High           | Service Availability |
       And 1 another issue without cluster hit exists
-          | Title    | Modified    | Total risk |
-          | Nohit    | 10 days ago | Critical   |
+          | Title    | Modified    | Total risk | Risk of change | Category             |
+          | Nohit    | 10 days ago | Critical   | High           | Service Availability |
       And the user USER1 is already logged in into Hybrid Cloud Console
      When user looks at Hybrid Cloud Console main page
      Then menu on the left side should be displayed
@@ -311,46 +318,49 @@ Feature: Sorting on Advisor recommendations page behaviour on Hybrid Cloud Conso
      Then an "Advisor recommendations" page should be displayed right of the left menu bar
       And widget with filter settings should be displayed
       And table with several columns should be displayed with sorting setting
-          | Column name | Sort | Highlighted |
-          | Name        | ↕    | no          |
-          | Modified    | ↕    | no          |
-          | Category    | ↕    | no          |
-          | Total risk  | ↓    | yes         |
-          | Clusters    | ↕    | no          |
+          | Column name    | Sort | Highlighted |
+          | Name           | ↕    | no          |
+          | Modified       | ↕    | no          |
+          | Category       | ↕    | no          |
+          | Total risk     | ↓    | yes         |
+          | Risk of change | ↕    | no          |
+          | Clusters       | ↕    | no          |
       And that table should contain following four rows in that order
-          | Name        | Modified    | Total risk | Clusters |
-          | Bug12345    | 10 days ago | Critical   | 4        |
-          | Abc12345    | 10 days ago | Important  | 3        |
-          | Xyz12345    | 10 days ago | Moderate   | 2        |
-          | Uvw12345    | 10 days ago | Low        | 1        |
+          | Name        | Modified    | Category             | Total risk | Risk of change | Clusters |
+          | Bug12345    | 10 days ago | Service Availability | Critical   | High           | 4        |
+          | Abc12345    | 10 days ago | Performance          | Important  | Moderate       | 3        |
+          | Xyz12345    | 10 days ago | Fault Tolerance      | Moderate   | Low            | 2        |
+          | Uvw12345    | 10 days ago | Security             | Low        | Very Low       | 1        |
      When user clicks on ↕ symbol in "Clusters" column title
       And table with several columns should be displayed with sorting setting
-          | Column name | Sort | Highlighted |
-          | Name        | ↕    | no          |
-          | Modified    | ↕    | no          |
-          | Category    | ↕    | no          |
-          | Total risk  | ↕    | no          |
-          | Clusters    | ↓    | yes         |
+          | Column name    | Sort | Highlighted |
+          | Name           | ↕    | no          |
+          | Modified       | ↕    | no          |
+          | Category       | ↕    | no          |
+          | Total risk     | ↕    | no          |
+          | Risk of change | ↕    | no          |
+          | Clusters       | ↓    | yes         |
       And that table should contain following four rows in that order
-          | Name        | Modified    | Total risk | Clusters |
-          | Bug12345    | 10 days ago | Critical   | 4        |
-          | Abc12345    | 10 days ago | Important  | 3        |
-          | Xyz12345    | 10 days ago | Moderate   | 2        |
-          | Uvw12345    | 10 days ago | Low        | 1        |
+          | Name        | Modified    | Category             | Total risk | Risk of change | Clusters |
+          | Bug12345    | 10 days ago | Service Availability | Critical   | High           | 4        |
+          | Abc12345    | 10 days ago | Performance          | Important  | Moderate       | 3        |
+          | Xyz12345    | 10 days ago | Fault Tolerance      | Moderate   | Low            | 2        |
+          | Uvw12345    | 10 days ago | Security             | Low        | Very Low       | 1        |
      When user clicks on ↓ symbol in "Clusters" column title
       And table with several columns should be displayed with sorting setting
-          | Column name | Sort | Highlighted |
-          | Name        | ↕    | no          |
-          | Modified    | ↕    | no          |
-          | Category    | ↕    | no          |
-          | Total risk  | ↕    | no          |
-          | Clusters    | ↑    | yes         |
+          | Column name    | Sort | Highlighted |
+          | Name           | ↕    | no          |
+          | Modified       | ↕    | no          |
+          | Category       | ↕    | no          |
+          | Total risk     | ↕    | no          |
+          | Risk of change | ↕    | no          |
+          | Clusters       | ↑    | yes         |
       And that table should contain following four rows in that order
-          | Name        | Modified    | Total risk | Clusters |
-          | Uvw12345    | 10 days ago | Low        | 1        |
-          | Xyz12345    | 10 days ago | Moderate   | 2        |
-          | Abc12345    | 10 days ago | Important  | 3        |
-          | Bug12345    | 10 days ago | Critical   | 4        |
+          | Name        | Modified    | Category             | Total risk | Risk of change | Clusters |
+          | Uvw12345    | 10 days ago | Security             | Low        | Very Low       | 1        |
+          | Xyz12345    | 10 days ago | Fault Tolerance      | Moderate   | Low            | 2        |
+          | Abc12345    | 10 days ago | Performance          | Important  | Moderate       | 3        |
+          | Bug12345    | 10 days ago | Service Availability | Critical   | High           | 4        |
 
 
   Scenario: Sorting by added at on Advisor's "Recommendations" page on Hybrid Cloud Console with five recommendations and four clusters
@@ -362,26 +372,26 @@ Feature: Sorting on Advisor recommendations page behaviour on Hybrid Cloud Conso
           | 22222222-0000-0000-0000-000000000000 |
           | 33333333-0000-0000-0000-000000000000 |
       And 4 issues are detected for cluster 00000000-0000-0000-0000-000000000000
-          | Title    | Modified    | Total risk |
-          | Bug12345 | 30 days ago | Critical   |
-          | Abc12345 | 40 days ago | Important  |
-          | Xyz12345 | 20 days ago | Moderate   |
-          | Uvw12345 | 10 days ago | Low        |
+          | Title    | Modified    | Total risk | Risk of change | Category             |
+          | Bug12345 | 30 days ago | Critical   | High           | Service Availability |
+          | Abc12345 | 40 days ago | Important  | Moderate       | Performance          |
+          | Xyz12345 | 20 days ago | Moderate   | Low            | Fault Tolerance      |
+          | Uvw12345 | 10 days ago | Low        | Very low       | Security             |
       And 3 issues are detected for cluster 11111111-0000-0000-0000-000000000000
-          | Title    | Modified    | Total risk |
-          | Bug12345 | 30 days ago | Critical   |
-          | Abc12345 | 40 days ago | Important  |
-          | Xyz12345 | 20 days ago | Moderate   |
+          | Title    | Modified    | Total risk | Risk of change | Category             |
+          | Bug12345 | 30 days ago | Critical   | High           | Service Availability |
+          | Abc12345 | 40 days ago | Important  | Moderate       | Performance          |
+          | Xyz12345 | 20 days ago | Moderate   | Low            | Fault Tolerance      |
       And 2 issues are detected for cluster 22222222-0000-0000-0000-000000000000
-          | Title    | Modified    | Total risk |
-          | Bug12345 | 30 days ago | Critical   |
-          | Abc12345 | 40 days ago | Important  |
+          | Title    | Modified    | Total risk | Risk of change | Category             |
+          | Bug12345 | 30 days ago | Critical   | High           | Service Availability |
+          | Abc12345 | 40 days ago | Important  | Moderate       | Performance          |
       And 1 issue is detected for cluster 33333333-0000-0000-0000-000000000000
-          | Title    | Modified    | Total risk |
-          | Bug12345 | 30 days ago | Critical   |
+          | Title    | Modified    | Total risk | Risk of change | Category             |
+          | Bug12345 | 30 days ago | Critical   | High           | Service Availability |
       And 1 another issue without cluster hit exists
-          | Title    | Modified    | Total risk |
-          | Nohit    | 50 days ago | Critical   |
+          | Title    | Modified    | Total risk | Risk of change | Category             |
+          | Nohit    | 50 days ago | Critical   | High           | Service Availability |
       And the user USER1 is already logged in into Hybrid Cloud Console
      When user looks at Hybrid Cloud Console main page
      Then menu on the left side should be displayed
@@ -406,46 +416,49 @@ Feature: Sorting on Advisor recommendations page behaviour on Hybrid Cloud Conso
      Then an "Advisor recommendations" page should be displayed right of the left menu bar
       And widget with filter settings should be displayed
       And table with several columns should be displayed with sorting setting
-          | Column name | Sort | Highlighted |
-          | Name        | ↕    | no          |
-          | Modified    | ↕    | no          |
-          | Category    | ↕    | no          |
-          | Total risk  | ↓    | yes         |
-          | Clusters    | ↕    | no          |
+          | Column name    | Sort | Highlighted |
+          | Name           | ↕    | no          |
+          | Modified       | ↕    | no          |
+          | Category       | ↕    | no          |
+          | Total risk     | ↓    | yes         |
+          | Risk of change | ↕    | no          |
+          | Clusters       | ↕    | no          |
       And that table should contain following four rows in that order
-          | Name        | Modified    | Total risk | Clusters |
-          | Bug12345    | 30 days ago | Critical   | 4        |
-          | Abc12345    | 40 days ago | Important  | 3        |
-          | Xyz12345    | 20 days ago | Moderate   | 2        |
-          | Uvw12345    | 10 days ago | Low        | 1        |
+          | Name        | Modified    | Category             | Total risk | Risk of change | Clusters |
+          | Bug12345    | 30 days ago | Service Availability | Critical   | High           | 4        |
+          | Abc12345    | 40 days ago | Performance          | Important  | Moderate       | 3        |
+          | Xyz12345    | 20 days ago | Fault Tolerance      | Moderate   | Low            | 2        |
+          | Uvw12345    | 10 days ago | Security             | Low        | Very Low       | 1        |
      When user clicks on ↕ symbol in "Modified" column title
       And table with several columns should be displayed with sorting setting
-          | Column name | Sort | Highlighted |
-          | Name        | ↕    | no          |
-          | Modified    | ↓    | yes         |
-          | Category    | ↕    | no          |
-          | Total risk  | ↕    | no          |
-          | Clusters    | ↕    | no          |
+          | Column name    | Sort | Highlighted |
+          | Name           | ↕    | no          |
+          | Modified       | ↓    | yes         |
+          | Category       | ↕    | no          |
+          | Total risk     | ↕    | no          |
+          | Risk of change | ↕    | no          |
+          | Clusters       | ↕    | no          |
       And that table should contain following four rows in that order
-          | Name        | Modified    | Total risk | Clusters |
-          | Abc12345    | 40 days ago | Important  | 3        |
-          | Bug12345    | 30 days ago | Critical   | 4        |
-          | Xyz12345    | 20 days ago | Moderate   | 2        |
-          | Uvw12345    | 10 days ago | Low        | 1        |
+          | Name        | Modified    | Category             | Total risk | Risk of change | Clusters |
+          | Abc12345    | 40 days ago | Performance          | Important  | Moderate       | 3        |
+          | Bug12345    | 30 days ago | Service Availability | Critical   | High           | 4        |
+          | Xyz12345    | 20 days ago | Fault Tolerance      | Moderate   | Low            | 2        |
+          | Uvw12345    | 10 days ago | Security             | Low        | Very Low       | 1        |
      When user clicks on ↓ symbol in "Modified" column title
       And table with several columns should be displayed with sorting setting
-          | Column name | Sort | Highlighted |
-          | Name        | ↕    | no          |
-          | Modified    | ↑    | yes         |
-          | Category    | ↕    | no          |
-          | Total risk  | ↕    | no          |
-          | Clusters    | ↕    | no          |
+          | Column name    | Sort | Highlighted |
+          | Name           | ↕    | no          |
+          | Modified       | ↑    | yes         |
+          | Category       | ↕    | no          |
+          | Total risk     | ↕    | no          |
+          | Risk of change | ↕    | no          |
+          | Clusters       | ↕    | no          |
       And that table should contain following four rows in that order
-          | Name        | Modified    | Total risk | Clusters |
-          | Uvw12345    | 10 days ago | Low        | 1        |
-          | Xyz12345    | 20 days ago | Moderate   | 2        |
-          | Bug12345    | 30 days ago | Critical   | 4        |
-          | Abc12345    | 40 days ago | Important  | 3        |
+          | Name        | Modified    | Category             | Total risk | Risk of change | Clusters |
+          | Uvw12345    | 10 days ago | Security             | Low        | Very Low       | 1        |
+          | Xyz12345    | 20 days ago | Fault Tolerance      | Moderate   | Low            | 2        |
+          | Abc12345    | 40 days ago | Performance          | Important  | Moderate       | 3        |
+          | Bug12345    | 30 days ago | Service Availability | Critical   | High           | 4        |
 
 
   Scenario: Sorting by different columns at on Advisor's "Recommendations" page on Hybrid Cloud Console with five recommendations and four clusters
@@ -457,26 +470,26 @@ Feature: Sorting on Advisor recommendations page behaviour on Hybrid Cloud Conso
           | 22222222-0000-0000-0000-000000000000 |
           | 33333333-0000-0000-0000-000000000000 |
       And 4 issues are detected for cluster 00000000-0000-0000-0000-000000000000
-          | Title    | Modified    | Total risk |
-          | Bug12345 | 30 days ago | Critical   |
-          | Abc12345 | 40 days ago | Important  |
-          | Xyz12345 | 20 days ago | Moderate   |
-          | Uvw12345 | 10 days ago | Low        |
+          | Title    | Modified    | Total risk | Risk of change | Category             |
+          | Bug12345 | 30 days ago | Critical   | High           | Service Availability |
+          | Abc12345 | 40 days ago | Important  | Moderate       | Performance          |
+          | Xyz12345 | 20 days ago | Moderate   | Low            | Fault Tolerance      |
+          | Uvw12345 | 10 days ago | Low        | Very low       | Security             |
       And 3 issues are detected for cluster 11111111-0000-0000-0000-000000000000
-          | Title    | Modified    | Total risk |
-          | Bug12345 | 30 days ago | Critical   |
-          | Abc12345 | 40 days ago | Important  |
-          | Xyz12345 | 20 days ago | Moderate   |
+          | Title    | Modified    | Total risk | Risk of change | Category             |
+          | Bug12345 | 30 days ago | Critical   | High           | Service Availability |
+          | Abc12345 | 40 days ago | Important  | Moderate       | Performance          |
+          | Xyz12345 | 20 days ago | Moderate   | Low            | Fault Tolerance      |
       And 2 issues are detected for cluster 22222222-0000-0000-0000-000000000000
-          | Title    | Modified    | Total risk |
-          | Bug12345 | 30 days ago | Critical   |
-          | Abc12345 | 40 days ago | Important  |
+          | Title    | Modified    | Total risk | Risk of change | Category             |
+          | Bug12345 | 30 days ago | Critical   | High           | Service Availability |
+          | Abc12345 | 40 days ago | Important  | Moderate       | Performance          |
       And 1 issue is detected for cluster 33333333-0000-0000-0000-000000000000
-          | Title    | Modified    | Total risk |
-          | Bug12345 | 30 days ago | Critical   |
+          | Title    | Modified    | Total risk | Risk of change | Category             |
+          | Bug12345 | 30 days ago | Critical   | High           | Service Availability |
       And 1 another issue without cluster hit exists
-          | Title    | Modified    | Total risk |
-          | Nohit    | 50 days ago | Critical   |
+          | Title    | Modified    | Total risk | Risk of change | Category             |
+          | Nohit    | 50 days ago | Critical   | High           | Service Availability |
       And the user USER1 is already logged in into Hybrid Cloud Console
      When user looks at Hybrid Cloud Console main page
      Then menu on the left side should be displayed
@@ -501,71 +514,175 @@ Feature: Sorting on Advisor recommendations page behaviour on Hybrid Cloud Conso
      Then an "Advisor recommendations" page should be displayed right of the left menu bar
       And widget with filter settings should be displayed
       And table with several columns should be displayed with sorting setting
-          | Column name | Sort | Highlighted |
-          | Name        | ↕    | no          |
-          | Modified    | ↕    | no          |
-          | Category    | ↕    | no          |
-          | Total risk  | ↓    | yes         |
-          | Clusters    | ↕    | no          |
+          | Column name    | Sort | Highlighted |
+          | Name           | ↕    | no          |
+          | Modified       | ↕    | no          |
+          | Category       | ↕    | no          |
+          | Total risk     | ↓    | yes         |
+          | Risk of change | ↕    | no          |
+          | Clusters       | ↕    | no          |
       And that table should contain following four rows in that order
-          | Name        | Modified    | Total risk | Clusters |
-          | Bug12345    | 30 days ago | Critical   | 4        |
-          | Abc12345    | 40 days ago | Important  | 3        |
-          | Xyz12345    | 20 days ago | Moderate   | 2        |
-          | Uvw12345    | 10 days ago | Low        | 1        |
+          | Name        | Modified    | Category             | Total risk | Risk of change | Clusters |
+          | Bug12345    | 30 days ago | Service Availability | Critical   | High           | 4        |
+          | Abc12345    | 40 days ago | Performance          | Important  | Moderate       | 3        |
+          | Xyz12345    | 20 days ago | Fault Tolerance      | Moderate   | Low            | 2        |
+          | Uvw12345    | 10 days ago | Security             | Low        | Very Low       | 1        |
      When user clicks on ↕ symbol in "Name" column title
       And table with several columns should be displayed with sorting setting
-          | Column name | Sort | Highlighted |
-          | Name        | ↓    | yes         |
-          | Modified    | ↕    | no          |
-          | Category    | ↕    | no          |
-          | Total risk  | ↕    | no          |
-          | Clusters    | ↕    | no          |
+          | Column name    | Sort | Highlighted |
+          | Name           | ↓    | yes         |
+          | Modified       | ↕    | no          |
+          | Category       | ↕    | no          |
+          | Total risk     | ↕    | no          |
+          | Risk of change | ↕    | no          |
+          | Clusters       | ↕    | no          |
       And that table should contain following four rows in that order
-          | Name        | Modified    | Total risk | Clusters |
-          | Abc12345    | 40 days ago | Important  | 3        |
-          | Bug12345    | 30 days ago | Critical   | 4        |
-          | Uvw12345    | 10 days ago | Low        | 1        |
-          | Xyz12345    | 20 days ago | Moderate   | 2        |
+          | Name        | Modified    | Category             | Total risk | Risk of change | Clusters |
+          | Abc12345    | 40 days ago | Performance          | Important  | Moderate       | 3        |
+          | Bug12345    | 30 days ago | Service Availability | Critical   | High           | 4        |
+          | Uvw12345    | 10 days ago | Security             | Low        | Very Low       | 1        |
+          | Xyz12345    | 20 days ago | Fault Tolerance      | Moderate   | Low            | 2        |
      When user clicks on ↕ symbol in "Modified" column title
       And table with several columns should be displayed with sorting setting
-          | Column name | Sort | Highlighted |
-          | Name        | ↕    | no          |
-          | Modified    | ↓    | yes         |
-          | Category    | ↕    | no          |
-          | Total risk  | ↕    | no          |
-          | Clusters    | ↕    | no          |
+          | Column name    | Sort | Highlighted |
+          | Name           | ↕    | no          |
+          | Modified       | ↓    | yes         |
+          | Category       | ↕    | no          |
+          | Total risk     | ↕    | no          |
+          | Risk of change | ↕    | no          |
+          | Clusters       | ↕    | no          |
       And that table should contain following four rows in that order
-          | Name        | Modified    | Total risk | Clusters |
-          | Abc12345    | 40 days ago | Important  | 3        |
-          | Bug12345    | 30 days ago | Critical   | 4        |
-          | Xyz12345    | 20 days ago | Moderate   | 2        |
-          | Uvw12345    | 10 days ago | Low        | 1        |
+          | Name        | Modified    | Category             | Total risk | Risk of change | Clusters |
+          | Abc12345    | 40 days ago | Performance          | Important  | Moderate       | 3        |
+          | Bug12345    | 30 days ago | Service Availability | Critical   | High           | 4        |
+          | Xyz12345    | 20 days ago | Fault Tolerance      | Moderate   | Low            | 2        |
+          | Uvw12345    | 10 days ago | Security             | Low        | Very Low       | 1        |
      When user clicks on ↕ symbol in "Clusters" column title
       And table with several columns should be displayed with sorting setting
-          | Column name | Sort | Highlighted |
-          | Name        | ↕    | no          |
-          | Modified    | ↕    | no          |
-          | Category    | ↕    | no          |
-          | Total risk  | ↕    | no          |
-          | Clusters    | ↓    | yes         |
+          | Column name    | Sort | Highlighted |
+          | Name           | ↕    | no          |
+          | Modified       | ↕    | no          |
+          | Category       | ↕    | no          |
+          | Total risk     | ↕    | no          |
+          | Risk of change | ↕    | no          |
+          | Clusters       | ↓    | yes         |
       And that table should contain following four rows in that order
-          | Name        | Modified    | Total risk | Clusters |
-          | Bug12345    | 30 days ago | Critical   | 4        |
-          | Abc12345    | 40 days ago | Important  | 3        |
-          | Xyz12345    | 20 days ago | Moderate   | 2        |
-          | Uvw12345    | 10 days ago | Low        | 1        |
+          | Name        | Modified    | Category             | Total risk | Risk of change | Clusters |
+          | Bug12345    | 30 days ago | Service Availability | Critical   | High           | 4        |
+          | Abc12345    | 40 days ago | Performance          | Important  | Moderate       | 3        |
+          | Xyz12345    | 20 days ago | Fault Tolerance      | Moderate   | Low            | 2        |
+          | Uvw12345    | 10 days ago | Security             | Low        | Very Low       | 1        |
      When user clicks on ↕ symbol in "Category" column title
       And table with several columns should be displayed with sorting setting
-          | Column name | Sort | Highlighted |
-          | Name        | ↕    | no          |
-          | Modified    | ↕    | no          |
-          | Category    | ↑    | yes         |
-          | Total risk  | ↕    | no          |
-          | Clusters    | ↕    | no          |
+          | Column name    | Sort | Highlighted |
+          | Name           | ↕    | no          |
+          | Modified       | ↕    | no          |
+          | Category       | ↑    | yes         |
+          | Total risk     | ↕    | no          |
+          | Risk of change | ↕    | no          |
+          | Clusters       | ↕    | no          |
       And that table should contain following four rows in that order
-          | Name        | Modified    | Category                | Total risk | Clusters |
-          | Abc12345    | 40 days ago | Availability            | Important  | 3        |
-          | Bug12345    | 30 days ago | Availability, 1 more    | Critical   | 4        |
-          | Xyz12345    | 20 days ago | Performance             | Moderate   | 2        |
-          | Uvw12345    | 10 days ago | Security                | Low        | 1        |
+          | Name        | Modified    | Category             | Total risk | Risk of change | Clusters |
+          | Xyz12345    | 20 days ago | Fault Tolerance      | Moderate   | Low            | 2        |
+          | Abc12345    | 40 days ago | Performance          | Important  | Moderate       | 3        |
+          | Uvw12345    | 10 days ago | Security             | Low        | Very Low       | 1        |
+          | Bug12345    | 30 days ago | Service Availability | Critical   | High           | 4        |
+
+
+
+  Scenario: Sorting by Risk of change on Advisor's "Recommendations" page on Hybrid Cloud Console with five recommendations and four clusters
+    Given user USER1 is part of account (organization) ACCOUNT1
+      And account (organization) ACCOUNT1 owns 4 clusters
+          | Cluster name                         |
+          | 00000000-0000-0000-0000-000000000000 |
+          | 11111111-0000-0000-0000-000000000000 |
+          | 22222222-0000-0000-0000-000000000000 |
+          | 33333333-0000-0000-0000-000000000000 |
+      And 4 issues are detected for cluster 00000000-0000-0000-0000-000000000000
+          | Title    | Modified    | Total risk | Risk of change | Category             |
+          | Bug12345 | 10 days ago | Critical   | High           | Service Availability |
+          | Abc12345 | 10 days ago | Important  | Moderate       | Performance          |
+          | Xyz12345 | 10 days ago | Moderate   | Low            | Fault Tolerance      |
+          | Uvw12345 | 10 days ago | Low        | Very low       | Security             |
+      And 3 issues are detected for cluster 11111111-0000-0000-0000-000000000000
+          | Title    | Modified    | Total risk | Risk of change | Category             |
+          | Bug12345 | 10 days ago | Critical   | High           | Service Availability |
+          | Abc12345 | 10 days ago | Important  | Moderate       | Performance          |
+          | Xyz12345 | 10 days ago | Moderate   | Low            | Fault Tolerance      |
+      And 2 issues are detected for cluster 22222222-0000-0000-0000-000000000000
+          | Title    | Modified    | Total risk | Risk of change | Category             |
+          | Bug12345 | 10 days ago | Critical   | High           | Service Availability |
+          | Abc12345 | 10 days ago | Important  | Moderate       | Performance          |
+      And 1 issue is detected for cluster 33333333-0000-0000-0000-000000000000
+          | Title    | Modified    | Total risk | Risk of change | Category             |
+          | Bug12345 | 10 days ago | Critical   | High           | Service Availability |
+      And 1 another issue without cluster hit exists
+          | Title    | Modified    | Total risk | Risk of change | Category             |
+          | Nohit    | 10 days ago | Critical   | High           | Service Availability |
+      And the user USER1 is already logged in into Hybrid Cloud Console
+     When user looks at Hybrid Cloud Console main page
+     Then menu on the left side should be displayed
+      And the left menu might contain these top level items
+          | Left menu item           | Required for this test |
+          | Overview                 | no                     |
+          | Releases                 | no                     |
+          | Downloads                | no                     |
+          | Advisor                  | yes                    |
+          | Subscriptions            | no                     |
+          | Cost Management          | no                     |
+          | Cluster Manager Feedback | no                     |
+          | Red Hat Marketplace      | no                     |
+          | Documentation            | no                     |
+     When user expand "Advisor" top level item
+     Then the menu should be expanded under "Advisor" top level item
+      And following new items should be displayed in the sub-menu on the left side
+          | Expanded menu item  | Required for this test |
+          | Clusters            | no                     |
+          | Recommendations     | yes                    |
+     When user select "Recommendations" menu item from this sub-menu
+     Then an "Advisor recommendations" page should be displayed right of the left menu bar
+      And widget with filter settings should be displayed
+      And table with several columns should be displayed with sorting setting
+          | Column name    | Sort | Highlighted |
+          | Name           | ↕    | no          |
+          | Modified       | ↕    | no          |
+          | Category       | ↕    | no          |
+          | Total risk     | ↓    | yes         |
+          | Risk of change | ↕    | no          |
+          | Clusters       | ↕    | no          |
+      And that table should contain following four rows in that order
+          | Name        | Modified    | Category             | Total risk | Risk of change | Clusters |
+          | Bug12345    | 10 days ago | Service Availability | Critical   | High           | 4        |
+          | Abc12345    | 10 days ago | Performance          | Important  | Moderate       | 3        |
+          | Xyz12345    | 10 days ago | Fault Tolerance      | Moderate   | Low            | 2        |
+          | Uvw12345    | 10 days ago | Security             | Low        | Very Low       | 1        |
+     When user clicks on ↕ symbol in "Risk of change" column title
+      And table with several columns should be displayed with sorting setting
+          | Column name    | Sort | Highlighted |
+          | Name           | ↕    | no          |
+          | Modified       | ↕    | no          |
+          | Category       | ↕    | no          |
+          | Total risk     | ↕    | no          |
+          | Risk of change | ↑    | yes         |
+          | Clusters       | ↕    | no          |
+      And that table should contain following four rows in that order
+          | Name        | Modified    | Category             | Total risk | Risk of change | Clusters |
+          | Uvw12345    | 10 days ago | Security             | Low        | Very Low       | 1        |
+          | Xyz12345    | 10 days ago | Fault Tolerance      | Moderate   | Low            | 2        |
+          | Abc12345    | 10 days ago | Performance          | Important  | Moderate       | 3        |
+          | Bug12345    | 10 days ago | Service Availability | Critical   | High           | 4        |
+     When user clicks on ↑ symbol in "Risk of change" column title
+      And table with several columns should be displayed with sorting setting
+          | Column name    | Sort | Highlighted |
+          | Name           | ↕    | no          |
+          | Modified       | ↕    | no          |
+          | Category       | ↕    | no          |
+          | Total risk     | ↕    | no          |
+          | Risk of change | ↓    | yes         |
+          | Clusters       | ↕    | no          |
+      And that table should contain following four rows in that order
+          | Name        | Modified    | Category             | Total risk | Risk of change | Clusters |
+          | Bug12345    | 10 days ago | Service Availability | Critical   | High           | 4        |
+          | Abc12345    | 10 days ago | Performance          | Important  | Moderate       | 3        |
+          | Xyz12345    | 10 days ago | Fault Tolerance      | Moderate   | Low            | 2        |
+          | Uvw12345    | 10 days ago | Security             | Low        | Very Low       | 1        |


### PR DESCRIPTION
# Description
- add Risk of change / `resolution_risk` feature to all relevant definitions
  - add filtering and sorting behaviour for Risk of change
- add Category feature to all missing definitions
  - fix existing case about Category feature
- fix numbers of owned clusters, wouldn't work if implemented
- fix reference to non-existent `Bug1234` - > `Bug12345`, wouldn't work if implemented
- fix pre-selected filters in Recommendation list view, `Status` is also pre-selected by defeault
-  fix Hybrid Cloud Console homepage, there's one more page before Advisor appears
- unify some sentences containing numbers

(created one more issue for this because of all the problems found)
Fixes https://issues.redhat.com/browse/CCXDEV-10143 and https://issues.redhat.com/browse/CCXDEV-9924 

## Type of change

Please delete options that are not relevant.

- Bug fix (non-breaking change which fixes an issue)
- New test scenario added into existing feature file
- Non-breaking change in test steps implementation
- Breaking change (fix or feature that would cause existing functionality to not work as expected)
- Refactor (refactoring code, removing useless files)

## Testing steps
n/a

## Checklist
* [x] Pylint passes for Python sources
* [ ] sources has been pre-processed by Black
* [ ] updated documentation wherever necessary
