### PR TITLE
Mock service clusters with rule hits BDD

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,6 +119,10 @@ make notification-service
 ### Insights Results Aggregator Mock service
 
 * [Basic set of smoke tests](features/insights-results-aggregator-mock/smoketests.feature)
+* [REST API endpoints provided by Insights Results Aggregator Mock](features/insights-results-aggregator-mock/basic_rest_api.feature)
+* [Tests for cluster list endpoint](features/insights-results-aggregator-mock/rest_api_clusters.feature)
+* [Checking REST API endpoint that returns list of clusters hitting specified rule](features/insights-results-aggregator-mock/clusters_hitting_rule.feature)
+* [Checking all responses from Insights Results Aggregator Mock service](features/insights-results-aggregator-mock/mock_responses.feature)
 
 
 

--- a/features/README.md
+++ b/features/README.md
@@ -403,6 +403,14 @@ Directory where feature files with scenarios and scenario outlines are stored.
 * Check the groups endpoint
 * Check the organizations endpoint
 
+## `insights-results-aggregator-mock/clusters_hitting_rule.feature`
+
+* Check if Insights Results Aggregator Mock service return correct list of clusters for rule ccx_rules_ocp.external.rules.cluster_wide_proxy_auth_check
+* Check if Insights Results Aggregator Mock service return correct list of clusters for rule minimum requirements
+* Check if Insights Results Aggregator Mock service return correct list of clusters for rule ccx_rules_ocp.external.bug_rules.bug_1766907
+* Check if Insights Results Aggregator Mock service return correct list of clusters for rule ccx_rules_ocp.external.rules.nodes_kubelet_version_check
+* Check if Insights Results Aggregator Mock service return correct list of clusters for rule ccx_rules_ocp.external.rules.samples_op_failed_image_import_check
+
 ## `insights-results-aggregator-mock/mock_responses.feature`
 
 * Check if Insights Results Aggregator Mock service return correct list of organizations

--- a/features/README.md
+++ b/features/README.md
@@ -405,11 +405,11 @@ Directory where feature files with scenarios and scenario outlines are stored.
 
 ## `insights-results-aggregator-mock/clusters_hitting_rule.feature`
 
-* Check if Insights Results Aggregator Mock service return correct list of clusters for rule ccx_rules_ocp.external.rules.cluster_wide_proxy_auth_check
-* Check if Insights Results Aggregator Mock service return correct list of clusters for rule minimum requirements
-* Check if Insights Results Aggregator Mock service return correct list of clusters for rule ccx_rules_ocp.external.bug_rules.bug_1766907
-* Check if Insights Results Aggregator Mock service return correct list of clusters for rule ccx_rules_ocp.external.rules.nodes_kubelet_version_check
-* Check if Insights Results Aggregator Mock service return correct list of clusters for rule ccx_rules_ocp.external.rules.samples_op_failed_image_import_check
+* Check if Insights Results Aggregator Mock service returns correct list of clusters for rule ccx_rules_ocp.external.rules.cluster_wide_proxy_auth_check
+* Check if Insights Results Aggregator Mock service returns correct list of clusters for rule minimum requirements
+* Check if Insights Results Aggregator Mock service returns correct list of clusters for rule ccx_rules_ocp.external.bug_rules.bug_1766907
+* Check if Insights Results Aggregator Mock service returns correct list of clusters for rule ccx_rules_ocp.external.rules.nodes_kubelet_version_check
+* Check if Insights Results Aggregator Mock service returns correct list of clusters for rule ccx_rules_ocp.external.rules.samples_op_failed_image_import_check
 
 ## `insights-results-aggregator-mock/mock_responses.feature`
 

--- a/features/insights-results-aggregator-mock/clusters_hitting_rule.feature
+++ b/features/insights-results-aggregator-mock/clusters_hitting_rule.feature
@@ -2,7 +2,7 @@ Feature: Checking REST API endpoint that returns list of clusters hitting specif
 
 
 
-  Scenario: Check if Insights Results Aggregator Mock service return correct list of clusters for rule ccx_rules_ocp.external.rules.cluster_wide_proxy_auth_check
+  Scenario: Check if Insights Results Aggregator Mock service returns correct list of clusters for rule ccx_rules_ocp.external.rules.cluster_wide_proxy_auth_check
     Given the system is in default state
       And REST API service hostname is localhost
       And REST API service port is 8080
@@ -21,7 +21,7 @@ Feature: Checking REST API endpoint that returns list of clusters hitting specif
 
 
 
-  Scenario: Check if Insights Results Aggregator Mock service return correct list of clusters for rule minimum requirements
+  Scenario: Check if Insights Results Aggregator Mock service returns correct list of clusters for rule minimum requirements
     Given the system is in default state
       And REST API service hostname is localhost
       And REST API service port is 8080
@@ -62,7 +62,7 @@ Feature: Checking REST API endpoint that returns list of clusters hitting specif
 
 
 
-  Scenario: Check if Insights Results Aggregator Mock service return correct list of clusters for rule ccx_rules_ocp.external.bug_rules.bug_1766907
+  Scenario: Check if Insights Results Aggregator Mock service returns correct list of clusters for rule ccx_rules_ocp.external.bug_rules.bug_1766907
     Given the system is in default state
       And REST API service hostname is localhost
       And REST API service port is 8080
@@ -91,7 +91,7 @@ Feature: Checking REST API endpoint that returns list of clusters hitting specif
 
 
 
-  Scenario: Check if Insights Results Aggregator Mock service return correct list of clusters for rule ccx_rules_ocp.external.rules.nodes_kubelet_version_check
+  Scenario: Check if Insights Results Aggregator Mock service returns correct list of clusters for rule ccx_rules_ocp.external.rules.nodes_kubelet_version_check
     Given the system is in default state
       And REST API service hostname is localhost
       And REST API service port is 8080
@@ -114,7 +114,7 @@ Feature: Checking REST API endpoint that returns list of clusters hitting specif
 
 
 
-  Scenario: Check if Insights Results Aggregator Mock service return correct list of clusters for rule ccx_rules_ocp.external.rules.samples_op_failed_image_import_check
+  Scenario: Check if Insights Results Aggregator Mock service returns correct list of clusters for rule ccx_rules_ocp.external.rules.samples_op_failed_image_import_check
     Given the system is in default state
       And REST API service hostname is localhost
       And REST API service port is 8080

--- a/features/insights-results-aggregator-mock/clusters_hitting_rule.feature
+++ b/features/insights-results-aggregator-mock/clusters_hitting_rule.feature
@@ -1,0 +1,133 @@
+Feature: Checking REST API endpoint that returns list of clusters hitting specified rule
+
+
+
+  Scenario: Check if Insights Results Aggregator Mock service return correct list of clusters for rule ccx_rules_ocp.external.rules.cluster_wide_proxy_auth_check
+    Given the system is in default state
+      And REST API service hostname is localhost
+      And REST API service port is 8080
+      And REST API service prefix is /api/insights-results-aggregator/v1
+     When I request list of clusters hitting rule with name ccx_rules_ocp.external.rules.cluster_wide_proxy_auth_check and error key AUTH_OPERATOR_PROXY_ERROR
+     Then The status code of the response is 200
+      And The metadata should contain following attributes
+         | Attribute name | Attribute value                                                   |
+         | count          | 2                                                                 |
+         | component      | ccx_rules_ocp.external.rules.cluster_wide_proxy_auth_check.report |
+         | error_key      | AUTH_OPERATOR_PROXY_ERROR                                         |
+      And I should retrieve following list of clusters stored in attribute data
+         | Cluster name                         |
+         | 00000001-8d6a-43cc-b82c-7007664bdf69 |
+         | 00000001-3333-3333-3333-000000000000 |
+
+
+
+  Scenario: Check if Insights Results Aggregator Mock service return correct list of clusters for rule minimum requirements
+    Given the system is in default state
+      And REST API service hostname is localhost
+      And REST API service port is 8080
+      And REST API service prefix is /api/insights-results-aggregator/v1
+     When I request list of clusters hitting rule with name ccx_rules_ocp.external.rules.nodes_requirements_check and error key NODES_MINIMUM_REQUIREMENTS_NOT_MET
+     Then The status code of the response is 200
+      And The metadata should contain following attributes
+         | Attribute name | Attribute value                                              |
+         | count          | 24                                                           |
+         | component      | ccx_rules_ocp.external.rules.nodes_requirements_check.report |
+         | error_key      | NODES_MINIMUM_REQUIREMENTS_NOT_MET                           |
+      And I should retrieve following list of clusters stored in attribute data
+         | Cluster name                         |
+         | 00000001-624a-49a5-bab8-4fdc5e51a266 |
+         | 00000001-6577-4e80-85e7-697cb646ff37 |
+         | 00000001-8933-4a3a-8634-3328fe806e08 |
+         | 00000001-8d6a-43cc-b82c-7007664bdf69 |
+         | 00000001-0000-0000-0000-000000000000 |
+         | 00000001-1111-1111-1111-000000000000 |
+         | 00000001-2222-2222-2222-000000000000 |
+         | 00000001-3333-3333-3333-000000000000 |
+         | 00000001-4444-4444-4444-000000000000 |
+         | 00000001-5555-5555-5555-000000000000 |
+         | 00000001-6666-6666-6666-000000000000 |
+         | 00000001-7777-7777-7777-000000000000 |
+         | 00000001-8888-8888-8888-000000000000 |
+         | 00000001-9999-9999-9999-000000000000 |
+         | 00000001-aaaa-aaaa-aaaa-000000000000 |
+         | 00000001-bbbb-bbbb-bbbb-000000000000 |
+         | 00000001-cccc-cccc-cccc-000000000000 |
+         | 00000001-dddd-dddd-dddd-000000000000 |
+         | 00000001-ffff-ffff-ffff-000000000000 |
+         | 00000001-ffff-ffff-ffff-000000000000 |
+         | 34c3ecc5-624a-49a5-bab8-4fdc5e51a266 |
+         | 74ae54aa-6577-4e80-85e7-697cb646ff37 |
+         | a7467445-8d6a-43cc-b82c-7007664bdf69 |
+         | ee7d2bf4-8933-4a3a-8634-3328fe806e08 |
+
+
+
+  Scenario: Check if Insights Results Aggregator Mock service return correct list of clusters for rule ccx_rules_ocp.external.bug_rules.bug_1766907
+    Given the system is in default state
+      And REST API service hostname is localhost
+      And REST API service port is 8080
+      And REST API service prefix is /api/insights-results-aggregator/v1
+     When I request list of clusters hitting rule with name ccx_rules_ocp.external.bug_rules.bug_1766907 and error key BUGZILLA_BUG_1766907
+     Then The status code of the response is 200
+      And The metadata should contain following attributes
+         | Attribute name | Attribute value                                     |
+         | count          | 12                                                  |
+         | component      | ccx_rules_ocp.external.bug_rules.bug_1766907.report |
+         | error_key      | BUGZILLA_BUG_1766907                                |
+      And I should retrieve following list of clusters stored in attribute data
+         | Cluster name                         |
+         | 00000001-6577-4e80-85e7-697cb646ff37 |
+         | 00000001-8d6a-43cc-b82c-7007664bdf69 |
+         | 00000001-1111-1111-1111-000000000000 |
+         | 00000001-3333-3333-3333-000000000000 |
+         | 00000001-5555-5555-5555-000000000000 |
+         | 00000001-7777-7777-7777-000000000000 |
+         | 00000001-9999-9999-9999-000000000000 |
+         | 00000001-bbbb-bbbb-bbbb-000000000000 |
+         | 00000001-dddd-dddd-dddd-000000000000 |
+         | 00000001-ffff-ffff-ffff-000000000000 |
+         | 74ae54aa-6577-4e80-85e7-697cb646ff37 |
+         | ee7d2bf4-8933-4a3a-8634-3328fe806e08 |
+
+
+
+  Scenario: Check if Insights Results Aggregator Mock service return correct list of clusters for rule ccx_rules_ocp.external.rules.nodes_kubelet_version_check
+    Given the system is in default state
+      And REST API service hostname is localhost
+      And REST API service port is 8080
+      And REST API service prefix is /api/insights-results-aggregator/v1
+     When I request list of clusters hitting rule with name ccx_rules_ocp.external.rules.nodes_kubelet_version_check and error key NODE_KUBELET_VERSION
+     Then The status code of the response is 200
+      And The metadata should contain following attributes
+         | Attribute name | Attribute value                                                 |
+         | count          | 6                                                               |
+         | component      | ccx_rules_ocp.external.rules.nodes_kubelet_version_check.report |
+         | error_key      | NODE_KUBELET_VERSION                                            |
+      And I should retrieve following list of clusters stored in attribute data
+         | Cluster name                         |
+         | 00000001-8d6a-43cc-b82c-7007664bdf69 |
+         | 00000001-3333-3333-3333-000000000000 |
+         | 00000001-7777-7777-7777-000000000000 |
+         | 00000001-bbbb-bbbb-bbbb-000000000000 |
+         | 00000001-ffff-ffff-ffff-000000000000 |
+         | ee7d2bf4-8933-4a3a-8634-3328fe806e08 |
+
+
+
+  Scenario: Check if Insights Results Aggregator Mock service return correct list of clusters for rule ccx_rules_ocp.external.rules.samples_op_failed_image_import_check
+    Given the system is in default state
+      And REST API service hostname is localhost
+      And REST API service port is 8080
+      And REST API service prefix is /api/insights-results-aggregator/v1
+     When I request list of clusters hitting rule with name ccx_rules_ocp.external.rules.samples_op_failed_image_import_check and error key SAMPLES_FAILED_IMAGE_IMPORT_ERR
+     Then The status code of the response is 200
+      And The metadata should contain following attributes
+         | Attribute name | Attribute value                                                          |
+         | count          | 3                                                                        |
+         | component      | ccx_rules_ocp.external.rules.samples_op_failed_image_import_check.report |
+         | error_key      | SAMPLES_FAILED_IMAGE_IMPORT_ERR                                          |
+      And I should retrieve following list of clusters stored in attribute data
+         | Cluster name                         |
+         | 00000001-8d6a-43cc-b82c-7007664bdf69 |
+         | 00000001-3333-3333-3333-000000000000 |
+         | 00000001-7777-7777-7777-000000000000 |

--- a/features/steps/insights_results_aggregator_mock.py
+++ b/features/steps/insights_results_aggregator_mock.py
@@ -148,7 +148,8 @@ def request_list_of_clusters(context, organization):
 
 
 @then("I should retrieve following list of clusters")
-def check_list_of_clusters(context):
+@then("I should retrieve following list of clusters stored in attribute {selector}")
+def check_list_of_clusters(context, selector="clusters"):
     """Check if Insights Results Aggregator Mock service returned expected list of clusters."""
     # construct set of expected cluster names
     # from a table provided in feature file
@@ -156,7 +157,7 @@ def check_list_of_clusters(context):
 
     # construct set of actually found clusters
     # from JSON payload returned by the service
-    found_clusters = set(get_array_from_json(context, "clusters"))
+    found_clusters = set(get_array_from_json(context, selector))
 
     # compare both sets and display diff (if diff is found)
     assert_sets_equality("cluster list", expected_clusters, found_clusters)

--- a/features/steps/insights_results_aggregator_mock.py
+++ b/features/steps/insights_results_aggregator_mock.py
@@ -272,7 +272,7 @@ def check_all_rule_hits(context):
     assert "data" in report, "Data attribute is missing in report attribute"
     data = report["data"]
 
-    # check if all rule hits definec in scenario is found in returned structure
+    # check if all rule hits defined in scenario is found in returned structure
     for rule_hit in context.table:
         expected_type = rule_hit["Type"]
         expected_rule_id = rule_hit["Rule ID"]

--- a/features/steps/insights_results_aggregator_mock.py
+++ b/features/steps/insights_results_aggregator_mock.py
@@ -163,6 +163,17 @@ def check_list_of_clusters(context, selector="clusters"):
     assert_sets_equality("cluster list", expected_clusters, found_clusters)
 
 
+@when("I request list of clusters hitting rule with name {rule_name} and error key {error_key}")
+def request_clusters_hitting_rule(context, rule_name, error_key):
+    """Check if Insights Results Aggregator Mock service returned expected list of clusters hitting rule."""  # noqa E501
+    url = f"http://{context.hostname}:{context.port}{context.api_prefix}/rule/{rule_name}.report|{error_key}/clusters_detail/"  # noqa E501
+    context.response = requests.get(url)
+
+    # check the response
+    assert context.response is not None
+    assert context.response.status_code == 200
+
+
 @when("I request list of groups")
 def request_list_of_groups(context):
     """Call Insights Results Aggregator Mock service and retrieve list groups."""

--- a/features/steps/insights_results_aggregator_mock.py
+++ b/features/steps/insights_results_aggregator_mock.py
@@ -298,3 +298,26 @@ def check_all_rule_hits(context):
         else:
             # record was not found
             raise KeyError(f"Rule hit {rule_hit} was not returned by the service")
+
+
+@then("The metadata should contain following attributes")
+def check_metadata(context):
+    """Check metadata returned from the service."""
+    json = context.response.json()
+    assert json is not None
+
+    # try to retrieve metadata attribute which should be object containing more attributes
+    assert "meta" in json, "meta attribute is missing"
+    meta = json["meta"]
+
+    # check if all metadata defined in scenario is found in returned structure
+    for expected_metadata in context.table:
+        expected_name = expected_metadata["Attribute name"]
+        expected_value = expected_metadata["Attribute value"]
+
+        # does the attribute exist?
+        assert expected_name in meta, f"Attribute with name {expected_name} is missing"
+
+        # has the attribute expected value?
+        assert str(meta[expected_name]) == expected_value, \
+            f"Attribute with name {expected_name} has unexpected value {meta[expected_name]}"

--- a/test_list/insights_results_aggregator_mock.txt
+++ b/test_list/insights_results_aggregator_mock.txt
@@ -2,3 +2,4 @@
 ../features/insights-results-aggregator-mock/basic_rest_api.feature
 ../features/insights-results-aggregator-mock/rest_api_clusters.feature
 ../features/insights-results-aggregator-mock/mock_responses.feature
+../features/insights-results-aggregator-mock/clusters_hitting_rule.feature


### PR DESCRIPTION
# Description

New BDD feature file + test steps: ability to return list of clusters hitting selected rule

## Type of change

- New test feature file
- Non-breaking change in test steps implementation

## Testing steps

N/A

## Checklist
* [ ] Pylint passes for Python sources
* [ ] sources has been pre-processed by Black
* [ ] updated documentation wherever necessary
