### PR TITLE
Exporter tests update

### DIFF
--- a/features/insights-results-aggregator-exporter/database_access.feature
+++ b/features/insights-results-aggregator-exporter/database_access.feature
@@ -1,3 +1,4 @@
+@aggregator_exporter
 Feature: Ability to access database
 
   Background: System is in default state and database exist

--- a/features/insights-results-aggregator-exporter/file_export.feature
+++ b/features/insights-results-aggregator-exporter/file_export.feature
@@ -1,3 +1,4 @@
+@aggregator_exporter
 Feature: Ability to export tables into file
 
   Background: System is in default state, database exist and is empty

--- a/features/insights-results-aggregator-exporter/file_export_metadata.feature
+++ b/features/insights-results-aggregator-exporter/file_export_metadata.feature
@@ -1,3 +1,4 @@
+@aggregator_exporter
 Feature: Ability to export metadata into file
 
   Background: System is in default state, database exist and is empty

--- a/features/insights-results-aggregator-exporter/s3_export.feature
+++ b/features/insights-results-aggregator-exporter/s3_export.feature
@@ -1,17 +1,19 @@
+@aggregator_exporter
 Feature: Ability to export tables into S3
 
-  Background: System is in default state, database exist and is empty, Minio is accessible
+  Background: System is in default state, database exist and is empty, S3 is accessible
     Given the system is in default state
       And the database is named test
       And database user is set to postgres
       And database password is set to postgres
       And database connection is established
       And the database is empty
-      And Minio endpoint is set to 127.0.0.1
-      And Minio port is set to 9000
-      And Minio access key is set to foobar01
-      And Minio secret access key is set to foobar01
-      And Minio bucket name is set to test
+      And S3 endpoint is set
+      And S3 port is set
+      And S3 access key is set
+      And S3 secret access key is set
+      And S3 bucket name is set to test
+      And S3 connection is established
 
   @database @s3 @export
   Scenario: Check export empty tables into S3/Minio

--- a/features/insights-results-aggregator-exporter/s3_export_metadata.feature
+++ b/features/insights-results-aggregator-exporter/s3_export_metadata.feature
@@ -1,3 +1,4 @@
+@aggregator_exporter
 Feature: Ability to export metadata into S3
 
   Background: System is in default state, database exist and is empty
@@ -7,11 +8,12 @@ Feature: Ability to export metadata into S3
       And database password is set to postgres
       And database connection is established
       And the database is empty
-      And Minio endpoint is set to 127.0.0.1
-      And Minio port is set to 9000
-      And Minio access key is set to foobar01
-      And Minio secret access key is set to foobar01
-      And Minio bucket name is set to test
+      And S3 endpoint is set
+      And S3 port is set
+      And S3 access key is set
+      And S3 secret access key is set
+      And S3 bucket name is set to test
+      And S3 connection is established
 
 
   @database @s3 @export @metadata

--- a/features/insights-results-aggregator-exporter/smoketests.feature
+++ b/features/insights-results-aggregator-exporter/smoketests.feature
@@ -1,3 +1,4 @@
+@aggregator_exporter
 Feature: Basic set of smoke tests
 
   @cli

--- a/features/src/asserts.py
+++ b/features/src/asserts.py
@@ -17,4 +17,6 @@
 
 def assert_sets_equality(what, expected, actual):
     """Compare two sets of values."""
-    assert expected == actual, "Difference found in sets of {}: {}".format(what, expected ^ actual)
+    assert expected == actual, "Difference found in sets of {}: {}".format(
+        what, expected ^ actual
+    )

--- a/features/steps/exporter_csv.py
+++ b/features/steps/exporter_csv.py
@@ -45,8 +45,13 @@ def number_of_records_in_csv(context):
         )
 
 
-@then(u"I should see following records in exported file {filename} placed in column {column:d}")
-@then(u"I should see following records in exported file {filename} placed in columns {column:d} and {column2:d}")   # noqa: E501
+@then(
+    u"I should see following records in exported file {filename} placed in column {column:d}"
+)
+@then(
+    u"I should see following records in exported file {filename} placed in columns "
+    "{column:d} and {column2:d}"
+)  # noqa: E501
 def check_records_in_csv(context, filename, column, column2=None):
     """Check if all records are really stored in given CSV file."""
     with open(filename, "r") as fin:

--- a/features/steps/exporter_main.py
+++ b/features/steps/exporter_main.py
@@ -16,6 +16,7 @@
 
 import subprocess
 from src.process_output import process_generated_output
+from behave import when, then
 
 
 @when(u"I run the exporter with the {flag} command line flag")
@@ -32,7 +33,7 @@ def run_exporter_with_flag(context, flag):
 
 
 @when(u"I run the exporter with the following command line flags: {flags}")
-def run_exporter_with_flag(context, flags):
+def run_exporter_with_flags(context, flags):
     """Start the exporter with given command-line flags."""
     flags = flags.split(" ")
     cli = ["insights-results-aggregator-exporter"] + flags
@@ -55,6 +56,8 @@ Usage of insights-results-aggregator-exporter:
         export rules disabled by more users
   -export-log
         export log
+  -ignore-tables string
+        comma-separated list of tables that will be ignored
   -limit int
         limit number of exported records (default -1)
   -metadata

--- a/features/steps/exporter_s3.py
+++ b/features/steps/exporter_s3.py
@@ -12,95 +12,119 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Implementation of test steps that check or access S3/Minio service."""
+"""Implementation of test steps that check or access S3/S3 service."""
 
-from src.minio import minio_client, bucket_check, read_object_into_buffer
+
 import csv
+from behave import given, then
 from src.csv_checks import check_table_content
+from src.minio import minio_client, bucket_check, read_object_into_buffer
 
 
-@given(u"Minio endpoint is set to {endpoint}")
-def set_minio_endpoing(context, endpoint):
-    """Set Minio endpoint value."""
+@given("S3 endpoint is set")
+def assert_s3_endpoint_is_set(context):
+    """Set S3 endpoint value."""
+    assert context.S3_endpoint is not None, "S3 endpoint not found in context"
+
+
+@given("S3 endpoint is set to {endpoint}")
+def set_s3_endpoint(context, endpoint):
+    """Set S3 endpoint value."""
     assert endpoint is not None, "Endpoint needs to be specified"
-    context.minio_endpoint = endpoint
+    context.S3_endpoint = endpoint
 
 
-@given(u"Minio port is set to {port:d}")
-def set_minio_port(context, port):
-    """Set Minio port value."""
-    context.minio_port = port
+@given("S3 port is set")
+def assert_s3_port_is_set(context):
+    """Set S3 port value."""
+    assert context.S3_port is not None, "S3 port not found in context"
 
 
-@given(u"Minio access key is set to {value}")
-def set_minio_access_key(context, value):
-    """Set Minio access key."""
+@given("S3 port is set to {port:d}")
+def set_s3_port(context, port):
+    """Set S3 port value."""
+    context.S3_port = port
+
+
+@given("S3 access key is set")
+def assert_s3_access_key_is_set(context):
+    """Set S3 access key."""
+    assert context.S3_access_key is not None, "S3 Access key not found in context"
+
+
+@given("S3 access key is set to {value}")
+def set_s3_access_key(context, value):
+    """Set S3 access key."""
     assert value is not None, "Access key needs to be specified"
-    context.minio_access_key = value
+    context.S3_access_key = value
 
 
-@given(u"Minio secret access key is set to {value}")
-def set_minio_secret_access_key(context, value):
-    """Set Minio secret access key."""
+@given("S3 secret access key is set")
+def assert_s3_secret_access_key_is_set(context):
+    """Set S3 secret access key."""
+    assert (
+        context.S3_secret_access_key is not None
+    ), "S3 Secret access key not found in context"
+
+
+@given("S3 secret access key is set to {value}")
+def set_s3_secret_access_key(context, value):
+    """Set S3 secret access key."""
     assert value is not None, "Secret access key needs to be specified"
-    context.minio_secret_access_key = value
+    context.S3_secret_access_key = value
 
 
-@given(u"Minio bucket name is set to {value}")
-def set_minio_bucket_name(context, value):
-    """Set Minio bucket name."""
+@given("S3 bucket name is set to {value}")
+def assert_s3_bucket_name_is_set(context, value):
+    """Set S3 bucket name."""
     assert value is not None, "Bucket name needs to be specified"
-    context.minio_bucket_name = value
+    context.S3_bucket_name = value
 
 
-@then(u"I should see following objects generated in S3")
+@given("S3 connection is established")
+def establish_s3_connection(context):
+    """Establish connection to S3."""
+    minio_client(context)
+
+
+@then("I should see following objects generated in S3")
 def check_objects_in_s3(context):
     """Check that all specified objects was generated."""
-    # construct new Minio client
-    client = minio_client(context)
-
     # check if bucket used by exporter exists
-    bucket_check(context, client)
+    bucket_check(context)
 
     # retrieve all objects stored in bucket
-    objects = client.list_objects(context.minio_bucket_name, recursive=False)
-
+    objects = context.minio_client.list_objects(context.S3_bucket_name, recursive=True)
     # retrieve object names only
     names = [o.object_name for o in objects]
+    print("S3 objects: ", names)
 
     # iterate over all items in feature table
     for row in context.table:
-        object_name = row["File name"]
-        assert object_name in names, \
-            "Can not find object {} in bucket {}".format(object_name, context.minio_bucket_name)
+        object_name = f"{context.S3_bucket_name}/{row['File name']}"
+        assert object_name in names, "Can not find object {} in bucket {}".format(
+            object_name, context.S3_bucket_name
+        )
 
 
-@then(u"I should see following number of records stored in CSV objects in S3")
+@then("I should see following number of records stored in CSV objects in S3")
 def check_csv_content_in_s3(context):
     """Check content of objects stored in S3."""
-    # construct new Minio client
-    client = minio_client(context)
-
     # check if bucket used by exporter exists
-    bucket_check(context, client)
+    bucket_check(context)
 
     # iterate over all items in feature table
     for row in context.table:
-        object_name = row["File name"]
+        object_name = f"{context.S3_bucket_name}/{row['File name']}"
         expected_records = int(row["Records"])
 
         # read object content
-        buff = read_object_into_buffer(context, client, object_name)
+        buff = read_object_into_buffer(context, object_name)
 
         # read CVS from buffer
-        csvFile = csv.reader(buff)
+        csv_file = csv.reader(buff)
 
-        # skip the first row of the CSV file.
-        next(csvFile)
-
-        stored_records = 0
-        for lines in csvFile:
-            stored_records += 1
+        stored_records = len(list(csv_file)) - 1
 
         # now check numbers
         assert (
@@ -110,14 +134,17 @@ def check_csv_content_in_s3(context):
         )
 
 
-@then(u"I should see following records in exported object {object_name} placed in column {column:d}")  # noqa: E501
-@then(u"I should see following records in exported object {object_name} placed in columns {column:d} and {column2:d}")   # noqa: E501
+@then(
+    "I should see following records in exported object {object_name} placed in column {column:d}"
+)  # noqa: E501
+@then(
+    "I should see following records in exported object {object_name} "
+    "placed in columns {column:d} and {column2:d}"
+)  # noqa: E501
 def check_records_in_csv_object(context, object_name, column, column2=None):
-    """Check if all records are really stored in given CSV file/object in S3/Minio."""
-    # construct new Minio client
-    client = minio_client(context)
-
+    """Check if all records are really stored in given CSV file/object in S3/S3."""
     # read object content
-    buff = read_object_into_buffer(context, client, object_name)
+    object_name = f"{context.S3_bucket_name}/{object_name}"
+    buff = read_object_into_buffer(context, object_name)
 
     check_table_content(context, buff, object_name, column, column2)


### PR DESCRIPTION
# Description

Update the steps defined for the insights-aggregator-results-exporter service

The important parts:
- renamed the minio steps to mention s3 instead
- added minio connection in context instead of creating it in the steps that need it
- fixed `check_objects_in_s3 `, `check_csv_content_in_s3` and `check_records_in_csv_object`  functions

## Type of change

- New test scenario added into existing feature file
- Breaking change (fix or feature that would cause existing functionality to not work as expected)
- Refactor (refactoring code, removing useless files)

## Testing steps

Run BDD tests locally and within container

## Checklist
* [x] Pylint passes for Python sources
* [x] sources has been pre-processed by Black
* [ ] updated documentation wherever necessary
