### PR TITLE
Fixed navigation order on GitHub pages

### DIFF
--- a/docs/feature_list.md
+++ b/docs/feature_list.md
@@ -1,6 +1,6 @@
 ---
 layout: page
-nav_order: 1
+nav_order: 2
 ---
 
 # List of existing behavioral specifications (features)

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,5 +1,6 @@
 ---
 layout: default
+nav_order: 1
 ---
 
 # Description

--- a/docs/scenarios_list.md
+++ b/docs/scenarios_list.md
@@ -1,6 +1,6 @@
 ---
 layout: page
-nav_order: 2
+nav_order: 3
 ---
 
 # List of scenarios


### PR DESCRIPTION
# Description

Fixed navigation order on GitHub pages

## Type of change

- Bug fix (non-breaking change which fixes an issue)
- Documentation update

## Testing steps

N/A

## Checklist
* [ ] Pylint passes for Python sources
* [ ] sources has been pre-processed by Black
* [ ] updated documentation wherever necessary
