### PR TITLE
Remove postgres database check from notification writer smoketests

### DIFF
--- a/features/ccx-notification-writer/smoketests.feature
+++ b/features/ccx-notification-writer/smoketests.feature
@@ -21,14 +21,6 @@ Feature: Basic set of smoke tests - checks if all required tools are available a
      Then I should find that file on PATH
 
 
-  Scenario: Check if Postgres database is available
-    Given the system is in default state
-     When I connect to database named test as user postgres with password postgres
-     Then I should be able to connect to such database
-     When I close database connection
-     Then I should be disconnected
-
-
   Scenario: Check if CCX Notification Writer database can be reached
      Given the system is in default state
      When I connect to database named notification as user postgres with password postgres


### PR DESCRIPTION
# Description

This test fails when run within the docker compose environment as the database created for the notification writer is called "notification". Since the database existence is tested by the "Check if CCX Notification database can be reached" scenario, this one can be removed. (No need to update scenario list. The test probably got added again by a bad rebase of mine, as I did remove it in a previous PR)

## Type of change

- Non-breaking change in test steps implementation

## Testing steps

N/A

## Checklist
* [ ] Pylint passes for Python sources
* [ ] sources has been pre-processed by Black
* [ ] updated documentation wherever necessary
