### PR TITLE
Remove drop-table step from notification-writer display/clean old reports scenarios

### DIFF
--- a/features/ccx-notification-writer/cleanup_new_records.feature
+++ b/features/ccx-notification-writer/cleanup_new_records.feature
@@ -22,8 +22,6 @@ Feature: Ability to clean up old records stored in database with new records
      Then I should get 0 rows
      When I close database connection
      Then I should be disconnected
-     When I start the CCX Notification Writer with the --db-drop-tables command line flag
-     Then the process should exit with status code set to 0
 
 
   @cli @database @database-write
@@ -46,8 +44,6 @@ Feature: Ability to clean up old records stored in database with new records
      Then I should get 0 rows
      When I close database connection
      Then I should be disconnected
-     When I start the CCX Notification Writer with the --db-drop-tables command line flag
-     Then the process should exit with status code set to 0
 
 
   @cli @database @database-write
@@ -73,8 +69,6 @@ Feature: Ability to clean up old records stored in database with new records
      Then I should get 1 row
      When I close database connection
      Then I should be disconnected
-     When I start the CCX Notification Writer with the --db-drop-tables command line flag
-     Then the process should exit with status code set to 0
 
 
   @cli @database @database-write
@@ -101,8 +95,6 @@ Feature: Ability to clean up old records stored in database with new records
      Then I should get 2 rows
      When I close database connection
      Then I should be disconnected
-     When I start the CCX Notification Writer with the --db-drop-tables command line flag
-     Then the process should exit with status code set to 0
 
 
   @cli @database @database-write
@@ -129,8 +121,6 @@ Feature: Ability to clean up old records stored in database with new records
      Then I should get 1 row
      When I close database connection
      Then I should be disconnected
-     When I start the CCX Notification Writer with the --db-drop-tables command line flag
-     Then the process should exit with status code set to 0
 
 
   @cli @database @database-write
@@ -156,8 +146,6 @@ Feature: Ability to clean up old records stored in database with new records
      Then I should get 1 row
      When I close database connection
      Then I should be disconnected
-     When I start the CCX Notification Writer with the --db-drop-tables command line flag
-     Then the process should exit with status code set to 0
 
 
   @cli @database @database-write
@@ -184,8 +172,6 @@ Feature: Ability to clean up old records stored in database with new records
      Then I should get 2 rows
      When I close database connection
      Then I should be disconnected
-     When I start the CCX Notification Writer with the --db-drop-tables command line flag
-     Then the process should exit with status code set to 0
 
 
   @cli @database @database-write
@@ -212,5 +198,3 @@ Feature: Ability to clean up old records stored in database with new records
      Then I should get 1 row
      When I close database connection
      Then I should be disconnected
-     When I start the CCX Notification Writer with the --db-drop-tables command line flag
-     Then the process should exit with status code set to 0

--- a/features/ccx-notification-writer/cleanup_old_records.feature
+++ b/features/ccx-notification-writer/cleanup_old_records.feature
@@ -22,8 +22,6 @@ Feature: Ability to clean up old records stored in database
      Then I should get 0 rows
      When I close database connection
      Then I should be disconnected
-     When I start the CCX Notification Writer with the --db-drop-tables command line flag
-     Then the process should exit with status code set to 0
 
 
   @cli @database @database-write
@@ -46,8 +44,6 @@ Feature: Ability to clean up old records stored in database
      Then I should get 0 rows
      When I close database connection
      Then I should be disconnected
-     When I start the CCX Notification Writer with the --db-drop-tables command line flag
-     Then the process should exit with status code set to 0
 
 
   @cli @database @database-write
@@ -73,8 +69,6 @@ Feature: Ability to clean up old records stored in database
      Then I should get 0 rows
      When I close database connection
      Then I should be disconnected
-     When I start the CCX Notification Writer with the --db-drop-tables command line flag
-     Then the process should exit with status code set to 0
 
 
   @cli @database @database-write
@@ -101,8 +95,6 @@ Feature: Ability to clean up old records stored in database
      Then I should get 0 rows
      When I close database connection
      Then I should be disconnected
-     When I start the CCX Notification Writer with the --db-drop-tables command line flag
-     Then the process should exit with status code set to 0
 
 
   @cli @database @database-write
@@ -128,8 +120,6 @@ Feature: Ability to clean up old records stored in database
      Then I should get 0 rows
      When I close database connection
      Then I should be disconnected
-     When I start the CCX Notification Writer with the --db-drop-tables command line flag
-     Then the process should exit with status code set to 0
 
 
   @cli @database @database-write
@@ -156,5 +146,3 @@ Feature: Ability to clean up old records stored in database
      Then I should get 0 rows
      When I close database connection
      Then I should be disconnected
-     When I start the CCX Notification Writer with the --db-drop-tables command line flag
-     Then the process should exit with status code set to 0

--- a/features/ccx-notification-writer/display_old_records.feature
+++ b/features/ccx-notification-writer/display_old_records.feature
@@ -16,8 +16,6 @@ Feature: Ability to display old records stored in database
      Then I should be disconnected
      When I start the CCX Notification Writer with the --print-new-reports-for-cleanup command line flag
      Then the process should exit with status code set to 0
-     When I start the CCX Notification Writer with the --db-drop-tables command line flag
-     Then the process should exit with status code set to 0
 
 
   @cli @database @database-read
@@ -33,8 +31,6 @@ Feature: Ability to display old records stored in database
      When I close database connection
      Then I should be disconnected
      When I start the CCX Notification Writer with the --print-old-reports-for-cleanup command line flag
-     Then the process should exit with status code set to 0
-     When I start the CCX Notification Writer with the --db-drop-tables command line flag
      Then the process should exit with status code set to 0
 
 
@@ -55,8 +51,6 @@ Feature: Ability to display old records stored in database
      Then I should be disconnected
      When I start the CCX Notification Writer with the --print-new-reports-for-cleanup command line flag
      Then the process should exit with status code set to 0
-     When I start the CCX Notification Writer with the --db-drop-tables command line flag
-     Then the process should exit with status code set to 0
 
 
   @cli @database @database-read
@@ -75,8 +69,6 @@ Feature: Ability to display old records stored in database
      When I close database connection
      Then I should be disconnected
      When I start the CCX Notification Writer with the --print-new-reports-for-cleanup command line flag
-     Then the process should exit with status code set to 0
-     When I start the CCX Notification Writer with the --db-drop-tables command line flag
      Then the process should exit with status code set to 0
 
 
@@ -98,8 +90,6 @@ Feature: Ability to display old records stored in database
      Then I should be disconnected
      When I start the CCX Notification Writer with the --print-new-reports-for-cleanup command line flag
      Then the process should exit with status code set to 0
-     When I start the CCX Notification Writer with the --db-drop-tables command line flag
-     Then the process should exit with status code set to 0
 
 
   @cli @database @database-read
@@ -119,8 +109,6 @@ Feature: Ability to display old records stored in database
      When I close database connection
      Then I should be disconnected
      When I start the CCX Notification Writer with the --print-new-reports-for-cleanup command line flag
-     Then the process should exit with status code set to 0
-     When I start the CCX Notification Writer with the --db-drop-tables command line flag
      Then the process should exit with status code set to 0
 
 
@@ -143,8 +131,6 @@ Feature: Ability to display old records stored in database
      Then I should be disconnected
      When I start the CCX Notification Writer with the --print-new-reports-for-cleanup command line flag
      Then the process should exit with status code set to 0
-     When I start the CCX Notification Writer with the --db-drop-tables command line flag
-     Then the process should exit with status code set to 0
 
 
   @cli @database @database-read
@@ -165,8 +151,6 @@ Feature: Ability to display old records stored in database
      Then I should be disconnected
      When I start the CCX Notification Writer with the --print-old-reports-for-cleanup command line flag
      Then the process should exit with status code set to 0
-     When I start the CCX Notification Writer with the --db-drop-tables command line flag
-     Then the process should exit with status code set to 0
 
 
   @cli @database @database-read
@@ -186,8 +170,6 @@ Feature: Ability to display old records stored in database
      When I close database connection
      Then I should be disconnected
      When I start the CCX Notification Writer with the --print-old-reports-for-cleanup command line flag
-     Then the process should exit with status code set to 0
-     When I start the CCX Notification Writer with the --db-drop-tables command line flag
      Then the process should exit with status code set to 0
 
 
@@ -210,8 +192,6 @@ Feature: Ability to display old records stored in database
      Then I should be disconnected
      When I start the CCX Notification Writer with the --print-old-reports-for-cleanup command line flag
      Then the process should exit with status code set to 0
-     When I start the CCX Notification Writer with the --db-drop-tables command line flag
-     Then the process should exit with status code set to 0
 
 
   @cli @database @database-read
@@ -233,8 +213,6 @@ Feature: Ability to display old records stored in database
      Then I should be disconnected
      When I start the CCX Notification Writer with the --print-old-reports-for-cleanup command line flag
      Then the process should exit with status code set to 0
-     When I start the CCX Notification Writer with the --db-drop-tables command line flag
-     Then the process should exit with status code set to 0
 
 
   @cli @database @database-read
@@ -255,6 +233,4 @@ Feature: Ability to display old records stored in database
      When I close database connection
      Then I should be disconnected
      When I start the CCX Notification Writer with the --print-old-reports-for-cleanup command line flag
-     Then the process should exit with status code set to 0
-     When I start the CCX Notification Writer with the --db-drop-tables command line flag
      Then the process should exit with status code set to 0


### PR DESCRIPTION
# Description

These steps fail if the notification DB is migrated to a version higher than v2, as foreign key references are included in the database and the original tables cannot be dropped without first migrating to a lower version. Since the migrations will be tested apart and the `--drop-tables` option is tested on a specific scenario, these steps can be removed.

## Type of change

- Bug fix (non-breaking change which fixes an issue)
- Refactor (refactoring code, removing useless files)

## Testing steps

Ran tests

## Checklist
* [ ] Pylint passes for Python sources
* [ ] sources has been pre-processed by Black
* [ ] updated documentation wherever necessary
