### PR TITLE
[CCXDEV-10303] Check that ccx upgrades inference doesn't return upgrade_recommended

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ coverage.txt
 covcounters.*
 covmeta.*
 ./insights-content-service/
+logs/**/*.log

--- a/features/ccx-upgrades-inference/perform_inference.feature
+++ b/features/ccx-upgrades-inference/perform_inference.feature
@@ -54,15 +54,10 @@ Feature: Upgrade Risks Prediction inference - test well known values
           """
             {
               "required": [
-                "upgrade_recommended",
                 "upgrade_risks_predictors"
               ],
               "type": "object",
               "properties": {
-                "upgrade_recommended": {
-                  "title": "Upgrade Recommended",
-                  "type": "boolean"
-                },
                 "upgrade_risks_predictors": {
                   "title": "Upgrade Risks Predictors",
                   "type": "object",
@@ -83,7 +78,6 @@ Feature: Upgrade Risks Prediction inference - test well known values
       And The body of the response is the following
           """
             {
-              "upgrade_recommended": false,
               "upgrade_risks_predictors": {
                 "alerts": [],
                 "operator_conditions": [

--- a/features/steps/ccx_inference_service.py
+++ b/features/steps/ccx_inference_service.py
@@ -17,6 +17,7 @@
 import os
 import subprocess
 import time
+from behave import given
 
 
 @given("The CCX Inference Service is running on port {port:d}")
@@ -25,8 +26,9 @@ def start_ccx_inference_service(context, port):
     params = ["uvicorn", "ccx_upgrades_inference.main:app", "--port", str(port)]
     env = os.environ.copy()
 
+    f = open(f"logs/ccx-upgrades-inference/{context.scenario}.log", "w")
     popen = subprocess.Popen(
-        params, stdout=subprocess.PIPE, stderr=subprocess.STDOUT, env=env
+        params, stdout=f, stderr=f, env=env
     )
     assert popen is not None
     time.sleep(0.5)


### PR DESCRIPTION
# Description

Checks for https://gitlab.cee.redhat.com/ccx/ccx-upgrades-inference/-/merge_requests/19.

## Type of change

- Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Testing steps

Locally.

## Checklist
* [x] Pylint passes for Python sources
* [ ] sources has been pre-processed by Black
* [ ] updated documentation wherever necessary
