### PR TITLE
Ability to display Makefile targets docs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,45 +6,45 @@ tests:	cleaner-tests exporter-tests aggregator-tests aggregator-mock-tests \
 	notification-service-tests notification-writer-tests insights-content-service-tests \
 	inference-service-tests data-engineering-service-tests
 
-cleaner-tests:
+cleaner-tests: ## Run BDD tests for the CCX Cleaner service
 	./cleaner_tests.sh
 
-aggregator-tests:
+aggregator-tests: ## Run BDD tests for Insights Results Aggregator service
 	./insights_results_aggregator_tests.sh
 
-aggregator-code-coverage:
+aggregator-code-coverage: ## Compute code coverage for Insights Results Aggregator service
 	./insights_results_aggregator_tests.sh coverage
 
-aggregator-mock-tests:
+aggregator-mock-tests: ## Run BDD tests for Insights Results Aggregator Mock service
 	./insights_results_aggregator_mock_tests.sh
 
-exporter-tests:
+exporter-tests: ## Run BDD tests for the CCX Exporter service
 	./exporter_tests.sh
 
-notification-service-tests:
+notification-service-tests: ## Run BDD tests for the CCX Notification Service
 	./notification_service_tests.sh
 
-notification-writer-tests:
+notification-writer-tests: ## Run BDD tests for the CCX Notification Writer
 	./notification_writer_tests.sh
 
-inference-service-tests:
+inference-service-tests: ## Run BDD tests for the Inference Service
 	./ccx_upgrade_risk_inference_tests.sh
 
-data-engineering-service-tests:
+data-engineering-service-tests: ## Run BDD tests for the Data Engineering Service
 	./ccx_upgrade_risk_data_eng_tests.sh
 
-insights-content-service-tests:
+insights-content-service-tests: ## Run BDD tests for the CCX Content Service
 	./insights_content_service_test.sh
 
-code-style:
+code-style: ## Check code style for all Python sources from this repository
 	python3 tools/run_pycodestyle.py
 
-update-scenarios:
+update-scenarios: ## Update list of scenarios for GitHub pages
 	python3 tools/gen_scenario_list.py > docs/scenarios_list.md
 
 before_commit: code-style update-scenarios
 
-docker-build:
+docker-build: ## Build Docker images that can be used for tests
 	docker build -t insights-behavioral-spec:ci .
 
 help: ## Show this help screen
@@ -53,5 +53,5 @@ help: ## Show this help screen
 	@echo 'Available targets are:'
 	@echo ''
 	@grep -E '^[ a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | \
-		awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-20s\033[0m %s\n", $$1, $$2}'
+		awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-30s\033[0m %s\n", $$1, $$2}'
 	@echo ''

--- a/Makefile
+++ b/Makefile
@@ -2,9 +2,9 @@
 
 default: tests
 
-tests:	cleaner-tests exporter-tests aggregator-test aggregator-mock-tests \
-	notification-service notification-writer insights-content-service \
-	inference-service data-engineering-service
+tests:	cleaner-tests exporter-tests aggregator-tests aggregator-mock-tests \
+	notification-service-tests notification-writer-tests insights-content-service-tests \
+	inference-service-tests data-engineering-service-tests
 
 cleaner-tests:
 	./cleaner_tests.sh
@@ -21,19 +21,19 @@ aggregator-mock-tests:
 exporter-tests:
 	./exporter_tests.sh
 
-notification-service:
+notification-service-tests:
 	./notification_service_tests.sh
 
-notification-writer:
+notification-writer-tests:
 	./notification_writer_tests.sh
 
-inference-service:
+inference-service-tests:
 	./ccx_upgrade_risk_inference_tests.sh
 
-data-engineering-service:
+data-engineering-service-tests:
 	./ccx_upgrade_risk_data_eng_tests.sh
 
-insights-content-service:
+insights-content-service-tests:
 	./insights_content_service_test.sh
 
 code-style:

--- a/Makefile
+++ b/Makefile
@@ -46,3 +46,12 @@ before_commit: code-style update-scenarios
 
 docker-build:
 	docker build -t insights-behavioral-spec:ci .
+
+help: ## Show this help screen
+	@echo 'Usage: make <OPTIONS> ... <TARGETS>'
+	@echo ''
+	@echo 'Available targets are:'
+	@echo ''
+	@grep -E '^[ a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | \
+		awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-20s\033[0m %s\n", $$1, $$2}'
+	@echo ''

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: default tests code-style update-scenarios before_commit cleaner-tests exporter-tests notification-service notification-writer inference-service
+.PHONY: default tests code-style update-scenarios before_commit cleaner-tests exporter-tests aggregator-tests aggregator-mock-tests notification-service-tests notification-writer-tests insights-content-service-tests inference-service-tests data-engineering-service-tests
 
 default: tests
 

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,9 @@
 
 default: tests
 
-tests:	cleaner-tests exporter-tests inference-service
+tests:	cleaner-tests exporter-tests aggregator-test aggregator-mock-tests \
+	notification-service notification-writer insights-content-service \
+	inference-service data-engineering-service
 
 cleaner-tests:
 	./cleaner_tests.sh

--- a/README.md
+++ b/README.md
@@ -6,6 +6,15 @@
 
 Behavioral specifications for Insights pipelines and its integration into OCM, OCP, and ACM
 
+<!-- vim-markdown-toc GFM -->
+
+* [How to run the scenarios](#how-to-run-the-scenarios)
+* [List of existing behavioral specifications (features)](#list-of-existing-behavioral-specifications-features)
+* [List of scenarios](#list-of-scenarios)
+* [Makefile targets](#makefile-targets)
+
+<!-- vim-markdown-toc -->
+
 ## How to run the scenarios
 
 Optional: Spin up the docker containers:
@@ -37,3 +46,7 @@ All features are listed [on this page](https://redhatinsights.github.io/insights
 ## List of scenarios
 
 List of scenarios can be seen [there](https://redhatinsights.github.io/insights-behavioral-spec/scenarios_list.html)
+
+## Makefile targets
+
+Please look at [this page](https://redhatinsights.github.io/insights-behavioral-spec/makefile_targets.html)

--- a/docs/makefile_targets.md
+++ b/docs/makefile_targets.md
@@ -1,0 +1,28 @@
+---
+layout: page
+nav_order: 7
+---
+
+## Makefile targets
+
+```
+Usage: make <OPTIONS> ... <TARGETS>
+
+Available targets are:
+
+cleaner-tests                  Run BDD tests for the CCX Cleaner service
+aggregator-tests               Run BDD tests for Insights Results Aggregator service
+aggregator-code-coverage       Compute code coverage for Insights Results Aggregator service
+aggregator-mock-tests          Run BDD tests for Insights Results Aggregator Mock service
+exporter-tests                 Run BDD tests for the CCX Exporter service
+notification-service-tests     Run BDD tests for the CCX Notification Service
+notification-writer-tests      Run BDD tests for the CCX Notification Writer
+inference-service-tests        Run BDD tests for the Inference Service
+data-engineering-service-tests Run BDD tests for the Data Engineering Service
+insights-content-service-tests Run BDD tests for the CCX Content Service
+code-style                     Check code style for all Python sources from this repository
+update-scenarios               Update list of scenarios for GitHub pages
+docker-build                   Build Docker images that can be used for tests
+help                           Show this help screen
+```
+


### PR DESCRIPTION
# Description

Ability to display Makefile targets docs

Fixes https://issues.redhat.com/browse/CCXDEV-10431

## Type of change

- Documentation update

## Testing steps

Just run `make help` and see ;)

## Checklist
* [ ] Pylint passes for Python sources
* [ ] sources has been pre-processed by Black
* [ ] updated documentation wherever necessary
