### PR TITLE
Wait for 5 seconds before initializing database

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -64,7 +64,7 @@ services:
     entrypoint:
       - /bin/sh
       - -c
-      - 'export CCX_NOTIFICATION_WRITER__STORAGE__DB_DRIVER=postgres CCX_NOTIFICATION_WRITER__STORAGE__PG_PARAMS="sslmode=disable" CCX_NOTIFICATION_WRITER__STORAGE__PG_USERNAME=postgres CCX_NOTIFICATION_WRITER__STORAGE__PG_PASSWORD=postgres CCX_NOTIFICATION_WRITER__STORAGE__PG_HOST=database CCX_NOTIFICATION_WRITER__STORAGE__PG_PORT=5432 CCX_NOTIFICATION_WRITER__STORAGE__PG_DB_NAME=notification && ./ccx-notification-writer --db-init-migration && ./ccx-notification-writer --db-init && ./ccx-notification-writer --migrate latest'
+      - 'sleep 5 && export CCX_NOTIFICATION_WRITER__STORAGE__DB_DRIVER=postgres CCX_NOTIFICATION_WRITER__STORAGE__PG_PARAMS="sslmode=disable" CCX_NOTIFICATION_WRITER__STORAGE__PG_USERNAME=postgres CCX_NOTIFICATION_WRITER__STORAGE__PG_PASSWORD=postgres CCX_NOTIFICATION_WRITER__STORAGE__PG_HOST=database CCX_NOTIFICATION_WRITER__STORAGE__PG_PORT=5432 CCX_NOTIFICATION_WRITER__STORAGE__PG_DB_NAME=notification && ./ccx-notification-writer --db-init-migration && ./ccx-notification-writer --db-init && ./ccx-notification-writer --migrate latest'
 
   content-service:
     profiles:


### PR DESCRIPTION
# Description

Database initialisation can fail if the `initnotificationdb` container is created before the `postgres` container 

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Testing steps

Recreated the docker-compose project multiple times

## Checklist
* [ ] Pylint passes for Python sources
* [ ] sources has been pre-processed by Black
* [ ] updated documentation wherever necessary
