### PR TITLE
[CCXDEV-10357] Prepare image for data-eng testing

### DIFF
--- a/features/ccx-upgrades-data-eng/request_prediction.feature
+++ b/features/ccx-upgrades-data-eng/request_prediction.feature
@@ -1,15 +1,18 @@
 Feature: Upgrade Risks Prediction Data Engineering - test well known values
 
+  # You have to add 127.0.0.1   localhost mock-oauth2-server
+  # to your /etc/hosts. This is needed to run these tests in Gitlab CI.
+
   Background: Data eng service is running and well configured to work
     Given The CCX Data Engineering Service is running on port 8000 with envs
-          | variable                    | value                         |
-          | CLIENT_ID                   | test-client-id                |
-          | CLIENT_SECRET               | test-client-secret            |
-          | INFERENCE_URL               | http://localhost:8001         |
-          | SSO_ISSUER                  | http://localhost:8081/default |
-          | ALLOW_INSECURE              | 1                             |
-          | RHOBS_URL                   | http://localhost:8002         |
-          | OAUTHLIB_INSECURE_TRANSPORT | 1                             |
+          | variable                    | value                                  |
+          | CLIENT_ID                   | test-client-id                         |
+          | CLIENT_SECRET               | test-client-secret                     |
+          | INFERENCE_URL               | http://localhost:8001                  |
+          | SSO_ISSUER                  | http://mock-oauth2-server:8081/default |
+          | ALLOW_INSECURE              | 1                                      |
+          | RHOBS_URL                   | http://localhost:8002                  |
+          | OAUTHLIB_INSECURE_TRANSPORT | 1                                      |
 
   Scenario: Check Data Engineering Service response with an invalid cluster ID in the request
      When I request the cluster endpoint in localhost:8000 with path not-an-uuid/upgrade-risks-prediction

--- a/features/ccx-upgrades-data-eng/smoketests.feature
+++ b/features/ccx-upgrades-data-eng/smoketests.feature
@@ -1,5 +1,7 @@
 Feature: Basic set of smoke tests - checks if all required tools are available and all services are running.
 
+  # You have to add 127.0.0.1   localhost mock-oauth2-server
+  # to your /etc/hosts. This is needed to run these tests in Gitlab CI.
 
   Scenario: Check if CCX Upgrade Risk Data Engineering Service application is available
     Given the system is in default state
@@ -8,13 +10,13 @@ Feature: Basic set of smoke tests - checks if all required tools are available a
 
   Scenario: Check if CCX Upgrade Risk Data Engineering Service can be run
     Given The CCX Data Engineering Service is running on port 8000 with envs
-          | variable                    | value                         |
-          | CLIENT_ID                   | test-client-id                |
-          | CLIENT_SECRET               | test-client-secret            |
-          | INFERENCE_URL               | http://localhost:8001         |
-          | SSO_ISSUER                  | http://localhost:8081/default |
-          | ALLOW_INSECURE              | 1                             |
-          | RHOBS_URL                   | http://localhost:8002         |
-          | OAUTHLIB_INSECURE_TRANSPORT | 1                             |
+          | variable                    | value                                  |
+          | CLIENT_ID                   | test-client-id                         |
+          | CLIENT_SECRET               | test-client-secret                     |
+          | INFERENCE_URL               | http://localhost:8001                  |
+          | SSO_ISSUER                  | http://mock-oauth2-server:8081/default |
+          | ALLOW_INSECURE              | 1                                      |
+          | RHOBS_URL                   | http://localhost:8002                  |
+          | OAUTHLIB_INSECURE_TRANSPORT | 1                                      |
      When I request the openapi.json endpoint in localhost:8000
      Then The status code of the response is 200


### PR DESCRIPTION
# Description

In Gitlab CI we need to use [services](https://docs.gitlab.com/ee/ci/services/), which are containers but the ports are not mapped to localhost. We need to put the alias of the service in the `SSO_ISSUER` url, which cannot be `localhost`.

This makes it mandatory to add `mock-oauth2-server` to the `/etc/hosts` file in your PC.

Part of #CCXDEV-10357

## Type of change

- Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Testing steps

Locally.

## Checklist
* [x] Pylint passes for Python sources
* [x] sources has been pre-processed by Black
* [x] updated documentation wherever necessary
