### PR TITLE
[CCXDEV-10357][ccx-upgrades-data-eng] Fix uvicorn exception

### DIFF
--- a/config/ccx-upgrades-data-eng_logging.yaml
+++ b/config/ccx-upgrades-data-eng_logging.yaml
@@ -1,0 +1,43 @@
+version: 1
+formatters:
+  simple:
+    format: '%(asctime)s - %(name)s - %(levelname)s - %(message)s'
+  default:
+    (): uvicorn.logging.DefaultFormatter
+    fmt: '%(levelprefix)s %(message)s'
+    use_colors: None
+  access:
+    (): uvicorn.logging.AccessFormatter
+    fmt: '%(levelprefix)s %(client_addr)s - "%(request_line)s" %(status_code)s'
+handlers:
+  console:
+    class: logging.StreamHandler
+    level: DEBUG
+    formatter: simple
+    stream: ext://sys.stdout
+  default:
+    formatter: default
+    class: logging.StreamHandler
+    stream: ext://sys.stderr
+  access:
+    formatter: access
+    class: logging.StreamHandler
+    stream: ext://sys.stdout
+loggers:
+  ccx_upgrades_data_eng:
+    level: DEBUG
+    handlers: [default]
+    propagate: no
+  uvicorn:
+    handlers: [default]
+    level: DEBUG
+    propagate: no
+  uvicorn.error:
+    level: DEBUG
+  uvicorn.access:
+    handlers: [access]
+    level: DEBUG
+    propagate: no
+root:
+  level: DEBUG
+  handlers: [default]

--- a/features/steps/ccx_data_engineering_service.py
+++ b/features/steps/ccx_data_engineering_service.py
@@ -25,7 +25,7 @@ from behave import given
 def start_ccx_upgrades_data_eng(context, port):
     """Run ccx-upgrades-data-eng for a test and prepare its stop."""
     params = ["uvicorn", "ccx_upgrades_data_eng.main:app", "--port", str(port),
-              "--log-level", "debug"]
+              "--log-config", "config/ccx-upgrades-data-eng_logging.yaml"]
     env = os.environ.copy()
 
     # Update the environment with variables configured by the test
@@ -37,5 +37,5 @@ def start_ccx_upgrades_data_eng(context, port):
 
     popen = subprocess.Popen(params, stdout=f, stderr=f, env=env)
     assert popen is not None
-    time.sleep(0.5)
+    time.sleep(1)
     context.add_cleanup(popen.terminate)


### PR DESCRIPTION
# Description

Wait for 1 second before running the ccx-upgrades-data-eng steps, otherwise it fails.

## Type of change

- Non-breaking change in test steps implementation

## Testing steps

I tagged a debug image and used it in https://gitlab.cee.redhat.com/ccx/ccx-upgrades-data-eng/-/merge_requests/20

## Checklist
* [x] Pylint passes for Python sources
* [x] sources has been pre-processed by Black
* [ ] updated documentation wherever necessary
