### PR TITLE
Wait for the server to be up

### DIFF
--- a/features/steps/ccx_data_engineering_service.py
+++ b/features/steps/ccx_data_engineering_service.py
@@ -37,5 +37,5 @@ def start_ccx_upgrades_data_eng(context, port):
 
     popen = subprocess.Popen(params, stdout=f, stderr=f, env=env)
     assert popen is not None
-    time.sleep(1)
+    time.sleep(2)
     context.add_cleanup(popen.terminate)


### PR DESCRIPTION
# Description

Follow up on https://github.com/RedHatInsights/insights-behavioral-spec/pull/298. It seems like 1 second wasn't enough.

Part of #CCXDEV-10357

## Type of change

- Non-breaking change in test steps implementation

## Testing steps

[This job](https://gitlab.cee.redhat.com/ccx/ccx-upgrades-data-eng/-/jobs/10991957) ran with this change.

## Checklist
* [x] Pylint passes for Python sources
* [x] sources has been pre-processed by Black
* [  ] updated documentation wherever necessary
