### PR TITLE
Try to start insights-results-aggregator-mock server in runner script

### DIFF
--- a/insights_results_aggregator_mock_tests.sh
+++ b/insights_results_aggregator_mock_tests.sh
@@ -28,5 +28,14 @@ case "$NOVENV" in
     "1") prepare_venv;;
 esac
 
+#try to start mock server for the tests that need it
+if [[ -z $PATH_TO_MOCK_SERVER ]]
+then
+    echo "PATH_TO_MOCK_SERVER is not set!"
+    echo "Make sure to start the insights-results-aggregator-mock application before running the tests"
+else
+    pushd $PATH_TO_MOCK_SERVER && insights-results-aggregator-mock &
+fi
+
 PYTHONDONTWRITEBYTECODE=1 python3 -m behave --tags=-skip -D dump_errors=true @test_list/insights_results_aggregator_mock.txt "$@"
 


### PR DESCRIPTION
# Description

Some of the insights-results-aggregator-mock tests depend on the server to be running. This change tries to start the mock server if the PATH_TO_MOCK_SERVER environment variable is provided

## Testing steps

Manual testing

## Checklist
* [ ] Pylint passes for Python sources
* [ ] sources has been pre-processed by Black
* [ ] updated documentation wherever necessary
