### PR TITLE
Do not use Unicode characters in shell script

### DIFF
--- a/cleaner_tests.sh
+++ b/cleaner_tests.sh
@@ -17,7 +17,7 @@
 function prepare_venv() {
     echo "preparing virtual environment for tests execution"
     # shellcheck disable=SC1091
-    python3 -m venv venv && source venv/bin/activate && python3 "$(which pip3)" install -r requirements.txt || exit 1
+    python3 -m venv venv && source venv/bin/activate && python3 "$(which pip3)" install -r requirements.txt || exit 1
     echo "Environment ready"
 }
 


### PR DESCRIPTION
# Description

Do not use Unicode characters in shell script

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Testing steps

N/A

## Checklist
* [ ] Pylint passes for Python sources
* [ ] sources has been pre-processed by Black
* [ ] updated documentation wherever necessary
