### PR TITLE
Modify BDD tests for data eng to break with wrong RHOBS query

### DIFF
--- a/mocks/inference-service/inference_service.py
+++ b/mocks/inference-service/inference_service.py
@@ -39,12 +39,10 @@ async def upgrade_risk_prediction_mock(request: Request):
     }
 
     result = {
-        "upgrade_recommended": False,
         "upgrade_risks_predictors": {"alerts": [], "operator_conditions": []},
     }
     if data == expected_data:
         result = {
-            "upgrade_recommended": True,
             "upgrade_risks_predictors": {
                 "alerts": [],
                 "operator_conditions": [

--- a/mocks/inference-service/inference_service.py
+++ b/mocks/inference-service/inference_service.py
@@ -15,25 +15,45 @@
 """Mock server that can be used instead of fully functional Inference Service."""
 
 
-from fastapi import FastAPI
+from fastapi import Request, FastAPI
 
 
 app = FastAPI()
 
 
 @app.get("/upgrade-risks-prediction")
-def upgrade_risk_prediction_mock():
+async def upgrade_risk_prediction_mock(request: Request):
     """Request handler for REST API endpoint to return upgrade prediction prediction."""
-    return {
-        "upgrade_recommended": False,
-        "upgrade_risks_predictors": {
-            "alerts": [],
-            "operator_conditions": [
-                {
-                    "name": "authentication",
-                    "condition": "Degraded",
-                    "reason": "AsExpected"
-                }
-            ]
-        }
+    data = await request.json()
+    expected_data = {
+        "alerts": [
+            {
+                "name": "SomeCriticalAlert",
+                "namespace": "openshift-kube-apiserver",
+                "severity": "critical",
+            }
+        ],
+        "operator_conditions": [
+            {"name": "authentication", "condition": "Degraded", "reason": "AsExpected"}
+        ],
     }
+
+    result = {
+        "upgrade_recommended": False,
+        "upgrade_risks_predictors": {"alerts": [], "operator_conditions": []},
+    }
+    if data == expected_data:
+        result = {
+            "upgrade_recommended": True,
+            "upgrade_risks_predictors": {
+                "alerts": [],
+                "operator_conditions": [
+                    {
+                        "name": "authentication",
+                        "condition": "Degraded",
+                        "reason": "AsExpected",
+                    }
+                ],
+            },
+        }
+    return result

--- a/mocks/rhobs/rhobs_service.py
+++ b/mocks/rhobs/rhobs_service.py
@@ -21,7 +21,6 @@ from pydantic import BaseModel
 
 app = FastAPI()
 
-
 EXAMPLE_RESULT = [
     {
         "metric": {
@@ -29,6 +28,14 @@ EXAMPLE_RESULT = [
             "alertname": "APIRemovedInNextEUSReleaseInUse",
             "namespace": "openshift-kube-apiserver",
             "severity": "info",
+        },
+    },
+    {
+        "metric": {
+            "__name__": "alerts",
+            "alertname": "SomeCriticalAlert",
+            "namespace": "openshift-kube-apiserver",
+            "severity": "critical",
         },
     },
     {
@@ -49,6 +56,14 @@ class Query(BaseModel):
 
 
 @app.get("/api/metrics/v1/telemeter/api/v1/query")
-def get_random_results():
+def get_random_results(query: str):
     """Request handler for REST API endpoint to return alerts and FOCs."""
+    expected_query_format = \
+        r"""alerts\{_id=.*", namespace=~"openshift-\.\*", severity=~"warning\|critical"\}
+or
+cluster_operator_conditions\{_id=.*, condition="Available"\} == 0
+or
+cluster_operator_conditions\{_id=.*, condition="Degraded"\} == 1"""
+    if re.match(expected_query_format, query):
+        return {"data": {"result": EXAMPLE_RESULT[-2:]}}
     return {"data": {"result": EXAMPLE_RESULT}}


### PR DESCRIPTION
# Description

BDD tests should break when the query sent to the RHOBS is different than expected. PR modifies to tests so they break when different query is received by mocked RHOBS service.

## Type of change

- Non-breaking change in test steps implementation

## Testing steps

Tests have been run locally.

## Checklist
* [ ] Pylint passes for Python sources
* [x] sources has been pre-processed by Black
* [ ] updated documentation wherever necessary
