### PR TITLE
Content service - forward Behave's exit code to make script fail if BDD tests fail

### DIFF
--- a/insights_content_service_test.sh
+++ b/insights_content_service_test.sh
@@ -75,6 +75,8 @@ PYTHONDONTWRITEBYTECODE=1 python3 -m behave --no-capture \
     --tags=-skip --tags=-managed \
     -D dump_errors=true @test_list/insights_content_service.txt "$@"
 
+exitCode=$?
+
 kill -9 $content_service_pid
 $REMOVE_CONTENT_SERVICE_DIRECTORY || rm -rf ./insights-content-service
-
+exit $exitCode


### PR DESCRIPTION
# Description

If the content-service's BDD tests fail, we are not returning the correct exit code

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Testing steps

Make the service fail and run the script

## Checklist
* [ ] Pylint passes for Python sources
* [ ] sources has been pre-processed by Black
* [ ] updated documentation wherever necessary
