### PR TITLE
scenario for archive with workloadinfo and new consumer/producer

### DIFF
--- a/config/insights_sha_extractor.yaml
+++ b/config/insights_sha_extractor.yaml
@@ -13,19 +13,19 @@ service:
   format: insights.formats._json.JsonFormat
   target_components: []
   consumer:
-    name: ccx_messaging.consumers.consumer.AnemicConsumer
+    name: ccx_messaging.consumers.kafka_consumer.KafkaConsumer
     kwargs:
       incoming_topic: platform.upload.announce
-      group_id: ${CDP_GROUP_ID:insights_sha_extractor_app}
-      bootstrap_servers: kafka:9092
+      dead_letter_queue_topic: dead.letter.queue
       platform_service: testareno
       processing_timeout_s: 0
-      max_poll_records: 1
-      max_poll_interval_ms: 3000
-      heartbeat_interval_ms: 5000
-      session_timeout_ms: 10000
-      auto_offset_reset: latest
-      dead_letter_queue_topic: dead.letter.queue
+      group.id: ${CDP_GROUP_ID:insights_sha_extractor_app}
+      bootstrap.servers: kafka:9092
+      security.protocol: PLAINTEXT
+      max.poll.interval.ms: 30000
+      heartbeat.interval.ms: 50000
+      session.timeout.ms: 10000
+      auto.offset.reset: earliest
   downloader:
     name: ccx_messaging.downloaders.http_downloader.HTTPDownloader
     kwargs:
@@ -36,10 +36,10 @@ service:
     kwargs:
       extract_timeout: 10
   publisher:
-    name: ccx_messaging.publishers.sha_publisher.SHAPublisher
+    name: ccx_messaging.publishers.workloads_info_publisher.WorkloadInfoPublisher
     kwargs:
       outgoing_topic: archive-results
-      bootstrap_servers: kafka:9092
+      bootstrap.servers: kafka:9092
   
   logging:
     version: 1
@@ -52,12 +52,6 @@ service:
         formatter: json
         filters:
           - context_filter
-      logstash:
-        level: INFO
-        class: logstash.TCPLogstashHandler
-        host: "127.0.0.1"
-        port: 5000
-        version: 1
     formatters:
       brief:
         format: "%(message)s"
@@ -72,7 +66,6 @@ service:
     root:
       handlers:
         - default
-        - logstash
     loggers:
       insights_messaging:
         level: DEBUG

--- a/features/SHA_Extractor/sha_extractor.feature
+++ b/features/SHA_Extractor/sha_extractor.feature
@@ -67,26 +67,19 @@ Feature: SHA Extractor
      Then the tarball is not further processed
 
 
-#  Scenario: Check if SHA extractor is able to finish the processing of SHA images
-#    Given SHA extractor service is started
-#      And Kafka broker is started
-#      And Kafka topic specified in configuration variable "incoming_topic" is created
-#      And Kafka topic specified in configuration variable "dead_letter_queue_topic" is created
-#      And Kafka topic specified in configuration variable "archive_results" is created
-#     When new event about about new tarball being sent by Insights Operator is produced into "incoming_topic" topic
-#     Then SHA extractor should consume message about this event
-#      And this message should contains following attributes
-#          | Attribute    | Description                | Type         |
-#          | account      | account ID                 | unsigned int |
-#          | principal    | principal ID               | unsigned int |
-#          | size         | tarball size               | unsigned int |
-#          | url          | URL to S3                  | string       |
-#          | b64_identity | identity encoded by BASE64 | string       |
-#          | timestamp    | timestamp of event         | string       |
-#     When SHA extractor consume this message
-#     Then SHA extractor should take the URL attribute
-#      And SHA extractor should download tarball from given URL attribute
-#     When SHA extractor decompress the tarball
-#     Then SHA extractor needs to check if it contains file "config/workload_info.json"
-#     When that file is found
-#     Then the content of this file needs to be sent into topic "archive_results"
+  Scenario: Check if SHA extractor is able to finish the processing of SHA images
+    Given SHA extractor service is started
+     When an archive with workload info is announced in "incoming_topic" topic
+     Then SHA extractor should consume message about this event
+      And this message should contain following attributes
+          | Attribute    | Description                | Type         |
+          | account      | account ID                 | unsigned int |
+          | principal    | principal ID               | unsigned int |
+          | size         | tarball size               | unsigned int |
+          | url          | URL to S3                  | string       |
+          | b64_identity | identity encoded by BASE64 | string       |
+          | timestamp    | timestamp of event         | string       |
+     Then SHA extractor retrieve the "url" attribute from the message
+      And SHA extractor should download tarball from given URL attribute
+     When the file "config/workload_info.json" is found
+     Then the content of this file needs to be sent into topic "archive_results"

--- a/features/environment.py
+++ b/features/environment.py
@@ -79,12 +79,14 @@ def after_scenario(context, scenario):
     """Run after each scenario is run."""
     if "@database" in scenario.effective_tags:
         prepare_db(context, CLEANUP_FILES, context.database_name)
-    if "@sha_extractor" in scenario.effective_tags:
+    if "sha_extractor" in scenario.effective_tags:
         # terminate the subprocess to have
         # one kafka consumer at a time
         context.sha_extractor.terminate()
         context.sha_extractor.kill()
         context.sha_extractor.wait()
+        assert context.sha_extractor.poll() is not None, \
+            f"sha extractor was not closed"
 
 
 def prepare_db(context, setup_files=CLEANUP_FILES, database="test"):

--- a/requirements/insights_sha_extractor.txt
+++ b/requirements/insights_sha_extractor.txt
@@ -1,4 +1,4 @@
 kafka-python
 minio
 fastapi
-uvicorn
+uvicorn[standard]


### PR DESCRIPTION
# Description
changed consumer and producer to a more updated one, and added a scenario (the last one) for when the workload infos are processed and a message is produced in the outgoing topic

Fixes CCXDEV-7543

## Type of change

Please delete options that are not relevant.

- New test feature file
- Bump-up dependent library (no changes in the code)


## Testing steps

`make insights-sha-extractor-test`

## Checklist
* [ ] Pylint passes for Python sources
* [ ] sources has been pre-processed by Black
* [ ] updated documentation wherever necessary
* [ ] new tests can be executed both locally and within docker container 
