### PR TITLE
CCX-Notification-Service tests update

### DIFF
--- a/docs/scenarios_list.md
+++ b/docs/scenarios_list.md
@@ -772,6 +772,11 @@ nav_order: 3
 * Check the ability to display old reports for cleanup with max-age specified
 * Check the ability to perform database cleanup on startup
 
+## `ccx-notification-service/configuration.feature`
+
+* Check that notification service exits with exit code 1 if no destination is configured
+* check that service exits with status 4 if rules content cannot be fetched
+
 ## `ccx-notification-service/customer_notifications.feature`
 
 * Check that notification service does not need kafka if database has no new report
@@ -798,7 +803,10 @@ nav_order: 3
 
 * Check that notification service does not send messages to service log if it is disabled
 * Check that notification service sends messages to service log if it is enabled
+* Check that notification service includes correct service name if set
+* Check that notification service does not send messages to service log if it cannot be rendered
 * Check that notification service doesn't send message to service log if it is not moderate
+* Check that notification service sends log events for the configured total risk threshold
 * Check that notification service doesn't send message that has been sent within cooldown
 * Check that notification service resends message after cooldown has passed
 * Check that notification service produces a single notification event for cluster with multiple new reports

--- a/features/ccx-notification-service/configuration.feature
+++ b/features/ccx-notification-service/configuration.feature
@@ -26,3 +26,15 @@ Feature: Customer Notifications configuration and exit codes
       And the logs should match
           | log                                              | contains   |
           | No known event destination configured. Aborting. | yes        |
+
+
+  Scenario: check that service exits with status 4 if rules content cannot be fetched
+    Given the service is expected to exit with code 4
+     When I start the CCX Notification Service with the --instant-reports command line flag
+          | val                                                    | var                        |
+          | CCX_NOTIFICATION_SERVICE__KAFKA_BROKER__ENABLED        | true                       |
+          | CCX_NOTIFICATION_SERVICE__SERVICE_LOG__ENABLED         | true                       |
+          | CCX_NOTIFICATION_SERVICE__DEPENDENCIES__CONTENT_SERVER | unresolved_url:8082/api/v1 |
+     Then it should have sent 0 notification events to Kafka
+      And it should have sent 0 notification events to Service Log
+      And the process should exit with status code set to 4

--- a/features/ccx-notification-service/configuration.feature
+++ b/features/ccx-notification-service/configuration.feature
@@ -19,7 +19,7 @@ Feature: Customer Notifications configuration and exit codes
      When I start the CCX Notification Service with the --instant-reports command line flag
           | val                                                   | var         |
           | CCX_NOTIFICATION_SERVICE__KAFKA_BROKER__ENABLED       | false       |
-          | CCX_NOTIFICATION_SERVICE__SERVICE_LOG__ENABLED        | false        |
+          | CCX_NOTIFICATION_SERVICE__SERVICE_LOG__ENABLED        | false       |
      Then it should have sent 0 notification events to Kafka
       And it should have sent 0 notification events to Service Log
       And the process should exit with status code set to 1

--- a/features/ccx-notification-service/configuration.feature
+++ b/features/ccx-notification-service/configuration.feature
@@ -1,0 +1,28 @@
+@notification_service
+Feature: Customer Notifications configuration and exit codes
+
+
+  Background: Dependencies are prepared
+    Given Kafka broker is available
+      And Kafka topic "platform.notifications.ingress" is empty
+      And the database is named notification
+      And database user is set to postgres
+      And database password is set to postgres
+      And database connection is established
+      And CCX Notification database is set up
+      And insights-content service is available on localhost:8082
+      And prometheus push gateway is available on localhost:9091
+
+
+  Scenario: Check that notification service exits with exit code 1 if no destination is configured
+    Given the service is expected to exit with code 1
+     When I start the CCX Notification Service with the --instant-reports command line flag
+          | val                                                   | var         |
+          | CCX_NOTIFICATION_SERVICE__KAFKA_BROKER__ENABLED       | false       |
+          | CCX_NOTIFICATION_SERVICE__SERVICE_LOG__ENABLED        | false        |
+     Then it should have sent 0 notification events to Kafka
+      And it should have sent 0 notification events to Service Log
+      And the process should exit with status code set to 1
+      And the logs should match
+          | log                                              | contains   |
+          | No known event destination configured. Aborting. | yes        |

--- a/features/ccx-notification-service/service_log.feature
+++ b/features/ccx-notification-service/service_log.feature
@@ -23,9 +23,9 @@ Feature: Service Log
      Then it should have sent 0 notification events to Service Log
       And the process should exit with status code set to 0
       And the logs should match
-          | log                              | contains   |
-          | Report with high impact detected | yes        |
-          | No new issues to notify          | no         |
+          | log                              | contains |
+          | Report with high impact detected | yes      |
+          | No new issues to notify          | no       |
 
 
   @rest-api
@@ -43,8 +43,8 @@ Feature: Service Log
           | cluster name                         |
           | 5d5892d4-2g85-4ccf-02bg-548dfc9767aa |
      Then I should find the following log events for each cluster
-          | cluster name                         | num logs | service name
-          | 5d5892d4-2g85-4ccf-02bg-548dfc9767aa | 1        | CCX Notification Service
+          | cluster name                         | num logs | service name             |
+          | 5d5892d4-2g85-4ccf-02bg-548dfc9767aa | 1        | CCX Notification Service |
 
 
   @rest-api
@@ -63,8 +63,8 @@ Feature: Service Log
           | cluster name                         |
           | 5d5892d4-2g85-4ccf-02bg-548dfc9767aa |
      Then I should find the following log events for each cluster
-          | cluster name                         | num logs | service name
-          | 5d5892d4-2g85-4ccf-02bg-548dfc9767aa | 1        | test
+          | cluster name                         | num logs | service name |
+          | 5d5892d4-2g85-4ccf-02bg-548dfc9767aa | 1        | test         |
 
 
   @rest-api
@@ -73,14 +73,14 @@ Feature: Service Log
           | org id |  account number | cluster name                         |
           | 1      |  1              | 5d5892d4-2g85-4ccf-02bg-548dfc9767aa |
       And I start the CCX Notification Service with the --instant-reports command line flag
-          | val                                             | var   |
-          | CCX_NOTIFICATION_SERVICE__KAFKA_BROKER__ENABLED | false |
-          | CCX_NOTIFICATION_SERVICE__SERVICE_LOG__ENABLED  | true  |
+          | val                                                               | var         |
+          | CCX_NOTIFICATION_SERVICE__KAFKA_BROKER__ENABLED                   | false       |
+          | CCX_NOTIFICATION_SERVICE__SERVICE_LOG__ENABLED                    | true        |
           | CCX_NOTIFICATION_SERVICE__DEPENDENCIES__TEMPLATE_RENDERER_SERVER  | unknown_url |
      Then it should have sent 0 notification events to Service Log
       And the logs should match
-          | log                                       | contains   |
-          | Rendering reports failed for this cluster | yes        |
+          | log                                       | contains |
+          | Rendering reports failed for this cluster | yes      |
       And the process should exit with status code set to 0
 
 
@@ -177,11 +177,11 @@ Feature: Service Log
   @rest-api
   Scenario: Check that notification service produces a single notification event for cluster with multiple new reports
      When I insert 1 report with important total risk for the following clusters
-          | org id |  account number | cluster name                         |
-          | 1      |  1              | 5d5892d4-2g85-4ccf-02bg-548dfc9767   |
+          | org id |  account number | cluster name                       |
+          | 1      |  1              | 5d5892d4-2g85-4ccf-02bg-548dfc9767 |
     When I insert 1 report with important total risk for the following clusters
-          | org id |  account number | cluster name                         |
-          | 1      |  1              | 5d5892d4-2g85-4ccf-02bg-548dfc9767   |
+          | org id |  account number | cluster name                       |
+          | 1      |  1              | 5d5892d4-2g85-4ccf-02bg-548dfc9767 |
       And I start the CCX Notification Service with the --instant-reports command line flag
           | val                                             | var   |
           | CCX_NOTIFICATION_SERVICE__KAFKA_BROKER__ENABLED | false |

--- a/features/ccx-notification-service/service_log.feature
+++ b/features/ccx-notification-service/service_log.feature
@@ -39,6 +39,49 @@ Feature: Service Log
           | CCX_NOTIFICATION_SERVICE__SERVICE_LOG__ENABLED  | true  |
      Then it should have sent 1 notification events to Service Log
       And the process should exit with status code set to 0
+     When I retrieve the service log events for the following clusters
+          | cluster name                         |
+          | 5d5892d4-2g85-4ccf-02bg-548dfc9767aa |
+     Then I should find the following log events for each cluster
+          | cluster name                         | num logs | service name
+          | 5d5892d4-2g85-4ccf-02bg-548dfc9767aa | 1        | CCX Notification Service
+
+
+  @rest-api
+  Scenario: Check that notification service includes correct service name if set
+     When I insert 1 report with important total risk for the following clusters
+          | org id |  account number | cluster name                         |
+          | 1      |  1              | 5d5892d4-2g85-4ccf-02bg-548dfc9767aa |
+      And I start the CCX Notification Service with the --instant-reports command line flag
+          | val                                                | var   |
+          | CCX_NOTIFICATION_SERVICE__KAFKA_BROKER__ENABLED    | false |
+          | CCX_NOTIFICATION_SERVICE__SERVICE_LOG__ENABLED     | true  |
+          | CCX_NOTIFICATION_SERVICE__SERVICE_LOG__CREATED_BY  | test  |
+     Then it should have sent 1 notification events to Service Log
+      And the process should exit with status code set to 0
+     When I retrieve the service log events for the following clusters
+          | cluster name                         |
+          | 5d5892d4-2g85-4ccf-02bg-548dfc9767aa |
+     Then I should find the following log events for each cluster
+          | cluster name                         | num logs | service name
+          | 5d5892d4-2g85-4ccf-02bg-548dfc9767aa | 1        | test
+
+
+  @rest-api
+  Scenario: Check that notification service does not send messages to service log if it cannot be rendered
+     When I insert 1 report with important total risk for the following clusters
+          | org id |  account number | cluster name                         |
+          | 1      |  1              | 5d5892d4-2g85-4ccf-02bg-548dfc9767aa |
+      And I start the CCX Notification Service with the --instant-reports command line flag
+          | val                                             | var   |
+          | CCX_NOTIFICATION_SERVICE__KAFKA_BROKER__ENABLED | false |
+          | CCX_NOTIFICATION_SERVICE__SERVICE_LOG__ENABLED  | true  |
+          | CCX_NOTIFICATION_SERVICE__DEPENDENCIES__TEMPLATE_RENDERER_SERVER  | unknown_url |
+     Then it should have sent 0 notification events to Service Log
+      And the logs should match
+          | log                                       | contains   |
+          | Rendering reports failed for this cluster | yes        |
+      And the process should exit with status code set to 0
 
 
   @rest-api
@@ -51,6 +94,51 @@ Feature: Service Log
           | CCX_NOTIFICATION_SERVICE__KAFKA_BROKER__ENABLED | false |
           | CCX_NOTIFICATION_SERVICE__SERVICE_LOG__ENABLED  | true  |
      Then it should have sent 0 notification events to Service Log
+      And the process should exit with status code set to 0
+    Given service-log service is empty
+    When I insert 1 report with moderate total risk for the following clusters
+          | org id |  account number | cluster name                         |
+          | 1      |  1              | 5d5892d4-2g85-4ccf-02bg-548dfc9767aa |
+      And I start the CCX Notification Service with the --instant-reports command line flag
+          | val                                             | var   |
+          | CCX_NOTIFICATION_SERVICE__KAFKA_BROKER__ENABLED | false |
+          | CCX_NOTIFICATION_SERVICE__SERVICE_LOG__ENABLED  | true  |
+     Then it should have sent 1 notification events to Service Log
+      And the process should exit with status code set to 0
+    Given service-log service is empty
+    When I insert 1 report with important total risk for the following clusters
+          | org id |  account number | cluster name                         |
+          | 1      |  1              | 5d5892d4-2g85-4ccf-02bg-548dfc9767aa |
+      And I start the CCX Notification Service with the --instant-reports command line flag
+          | val                                             | var   |
+          | CCX_NOTIFICATION_SERVICE__KAFKA_BROKER__ENABLED | false |
+          | CCX_NOTIFICATION_SERVICE__SERVICE_LOG__ENABLED  | true  |
+     Then it should have sent 1 notification events to Service Log
+      And the process should exit with status code set to 0
+    Given service-log service is empty
+    When I insert 1 report with critical total risk for the following clusters
+          | org id |  account number | cluster name                         |
+          | 1      |  1              | 5d5892d4-2g85-4ccf-02bg-548dfc9767aa |
+      And I start the CCX Notification Service with the --instant-reports command line flag
+          | val                                             | var   |
+          | CCX_NOTIFICATION_SERVICE__KAFKA_BROKER__ENABLED | false |
+          | CCX_NOTIFICATION_SERVICE__SERVICE_LOG__ENABLED  | true  |
+     Then it should have sent 1 notification events to Service Log
+      And the process should exit with status code set to 0
+
+
+  @rest-api
+  Scenario: Check that notification service sends log events for the configured total risk threshold
+     When I insert 1 report with low total risk for the following clusters
+          | org id |  account number | cluster name                         |
+          | 1      |  1              | 5d5892d4-2g85-4ccf-02bg-548dfc9767aa |
+      And I start the CCX Notification Service with the --instant-reports command line flag
+          | val                                                         | var   |
+          | CCX_NOTIFICATION_SERVICE__KAFKA_BROKER__ENABLED             | false |
+          | CCX_NOTIFICATION_SERVICE__SERVICE_LOG__ENABLED              | true  |
+          | CCX_NOTIFICATION_SERVICE__SERVICE_LOG__TOTAL_RISK_THRESHOLD | 0     |
+          | CCX_NOTIFICATION_SERVICE__SERVICE_LOG__EVENT_FILTER         | totalRisk >= totalRiskThreshold |
+     Then it should have sent 1 notification events to Service Log
       And the process should exit with status code set to 0
 
 

--- a/features/steps/notification_service.py
+++ b/features/steps/notification_service.py
@@ -86,6 +86,7 @@ def process_ccx_notification_service_output(context, out, allowed_return_codes):
 
 @given("the service is expected to exit with code {exit_code:d}")
 def store_exit_code(context, exit_code):
+    """Store exit code that the service is allowed to return."""
     context.return_codes = [exit_code]
 
 
@@ -468,7 +469,7 @@ def retrieve_notification_events_kafka(context, num_event):
 
 
 def get_service_log_event_by_cluster(cluster_id):
-    """Retrieve the events from service log for a given cluster"""
+    """Retrieve the events from service log for a given cluster."""
     address = "http://localhost:8000"
     response = requests.get(
         address + f"/api/service_logs/v1/clusters/{cluster_id}/cluster_logs",
@@ -495,11 +496,13 @@ def get_events_service_log():
 
 @when("I retrieve the service log events")
 def get_service_log_logs(context):
+    """Retrieve all the events currently stored by the service log database."""
     context.service_logs = get_events_service_log
 
 
 @when("I retrieve the service log events for the following clusters")
 def get_service_log_logs_for_given_clusters(context):
+    """Retrieve all the events currently stored by the service log database for given cluster."""
     context.service_logs_by_cluster = {}
     for row in context.table:
         cluster = row["cluster name"]
@@ -509,6 +512,7 @@ def get_service_log_logs_for_given_clusters(context):
 
 @then("I should find the following log events for each cluster")
 def check_service_log_logs_for_given_clusters(context):
+    """Verify that (part of) the content of the log events for given cluster is the expected."""
     for row in context.table:
         log_event = context.service_logs_by_cluster[row["cluster name"]]
         assert (

--- a/features/steps/notification_service.py
+++ b/features/steps/notification_service.py
@@ -466,6 +466,7 @@ def retrieve_notification_events_kafka(context, num_event):
             total_risk == encoded["events"][0]["payload"]["total_risk"]
         ), f"Expected reported risk in event to be {total_risk}."
 
+
 def get_service_log_event_by_cluster(cluster_id):
     """Retrieve the events from service log for a given cluster"""
     address = "http://localhost:8000"

--- a/mocks/service-log/service_log.py
+++ b/mocks/service-log/service_log.py
@@ -206,6 +206,27 @@ def get_logs(request: Request):
     )
 
 
+@app.get("/api/service_logs/v1/clusters/{cluster}/cluster_logs")
+def get_logs_for_cluster(cluster: str, request: Request):
+    """Return all logs for given cluster."""
+    if request.headers.get("Authorization", None) is None:
+        return noAuthResponse
+    res = []
+    for log in log_storage:
+        if log.cluster_uuid == cluster:
+            res.append(log)
+    return JSONResponse(
+        {
+            "kind": "ClusterLogList",
+            "page": 1,
+            "size": len(res),
+            "total": len(res),
+            "items": [log.dict(exclude_none=True) for log in res],
+        },
+        status_code=200,
+    )
+
+
 # This one has not been properly tested against the real ocm
 @app.delete("/api/service_logs/v1/cluster_logs/{id}")
 def delete_logs(id: str, request: Request):

--- a/test_list/notification_service.txt
+++ b/test_list/notification_service.txt
@@ -1,5 +1,6 @@
 ../features/ccx-notification-service/smoketests.feature
 ../features/ccx-notification-service/cli_flags.feature
+../features/ccx-notification-service/configuration.feature
 ../features/ccx-notification-service/display_records.feature
 ../features/ccx-notification-service/cleanup_records.feature
 ../features/ccx-notification-service/customer_notifications.feature


### PR DESCRIPTION
# Description

Additional tests for notification service for both destinations

Fixes [CCXDEV-7545](https://issues.redhat.com/browse/CCXDEV-7545)

## Type of change

- New test feature file
- New test scenario added into existing feature file

## Testing steps

run `WITHMOCK=1 make notification-service-tests` locally or within docker containers

## Checklist
* [ ] Pylint passes for Python sources
* [ ] sources has been pre-processed by Black
* [x] updated documentation wherever necessary
* [x] new tests can be executed both locally and within docker container 
