### PR TITLE
Refactor notification-related DB cleanup operations

### DIFF
--- a/features/environment.py
+++ b/features/environment.py
@@ -39,9 +39,6 @@ FEATURES_WITH_KAFKA = ("aggregator", "notification_writer", "notification_servic
 # Setup all environment variables needed to work with Minio (local or remote)
 FEATURES_WITH_MINIO = ("aggregator_exporter",)
 
-# Setup for working with notifications
-FEATURES_NOTIFICATION = ("notification_writer", "notification_service", "service_log")
-
 # Mapping between database name and script to cleanup such database.
 CLEANUP_FILES = {
     "test": "setup/clean_aggregator_database.sql",

--- a/setup/clean_notification_database.sql
+++ b/setup/clean_notification_database.sql
@@ -1,4 +1,3 @@
 drop table if exists migration_info;
-truncate table if exists read_errors;
-truncate table if exists reported;
-truncate table if exists new_reports;
+delete from reported;
+delete from new_reports cascade;


### PR DESCRIPTION
# Description

`truncate if exists` does not seem to be supported anymore. Since we are not dealing with huge amounts of data, let's just use `delete from [table]` instead to cleanup the tables between scenarios

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Testing steps

Run tests in docker-compose environment

## Checklist
* [ ] Pylint passes for Python sources
* [ ] sources has been pre-processed by Black
* [ ] updated documentation wherever necessary
* [ ] new tests can be executed both locally and within docker container 
