### PR TITLE
Ensure drop-all-tables test is run with correct migration version

### DIFF
--- a/features/ccx-notification-writer/cli_flags.feature
+++ b/features/ccx-notification-writer/cli_flags.feature
@@ -50,7 +50,11 @@ Feature: Check command line options provided by CCX Notification Writer
 
 
   @cli @database @database-write
-  Scenario: Check the ability to drop all database tables
+  Scenario: Check the ability to drop all database tables when database is migrated to initial version
+    Given CCX Notification database is migrated to version 0
      When I start the CCX Notification Writer with the --db-drop-tables command line flag
      Then the process should exit with status code set to 0
       And the database is empty
+     When I start the CCX Notification Writer with the --db-init command line flag
+     Then the process should exit with status code set to 0
+      And CCX Notification database is set up


### PR DESCRIPTION
# Description

the `--drop-all-tables` option is not prepared to run once the database is migrated to a version that is not the initial one. This updates the test to take that into account (only runs with version 0) and to restore the database's tables after dropping them.

## Type of change

- Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Testing steps

Run the test

## Checklist
* [ ] Pylint passes for Python sources
* [ ] sources has been pre-processed by Black
* [ ] updated documentation wherever necessary
* [ ] new tests can be executed both locally and within docker container 
