### PR TITLE
Content service endpoints test - fix BuildTime check

### DIFF
--- a/features/insights-content-service/endpoints.feature
+++ b/features/insights-content-service/endpoints.feature
@@ -59,7 +59,7 @@ Feature: Test the service endpoints
           }
           """
          And BuildCommit is a proper sha1
-         And BuildTime is a proper date 
+         And BuildTime is a proper date
          And BuildVersion is in the proper format
          And OCPRulesVersion is in the proper format
          And UtilsVersion is in the proper format

--- a/features/steps/insights_content_service.py
+++ b/features/steps/insights_content_service.py
@@ -31,7 +31,7 @@ def check_build_time(context):
     """Check build timestamp taken from service output."""
     buildTime = context.response.json()["info"]["BuildTime"]
     pattern = re.compile(
-        r'.{3} .{3}[ ]{1,2}[0-9]* [0-9]{2}:[0-9]{2}:[0-9]{2} [AP]M [A-Z]{3} [0-9]{4}')
+        r'.{3} .{3}[ ]{1,2}[0-9]{1,2} [0-9]{2}:[0-9]{2}:[0-9]{2} ([AP]M )?[A-Z]{1,5} [0-9]{4}')
     match = re.match(pattern, buildTime)
     assert match.group(0), "BuildTime is not a date time: {}".format(buildTime)
 


### PR DESCRIPTION
# Description

Small fixes to the regex used to check the `BuildTime` field from the JSON:
- Based on https://www.timeanddate.com/time/zones/, timezones' abbreviations can be one to five uppercase letters long
- Make the check for `AM/PM` optional
- Make sure that the current day of the month is a two-digit number

Fixes [CCXDEV-10589](https://issues.redhat.com/browse/CCXDEV-10589)

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Testing steps

Compile the content-server with `./build.sh` and run the BDD test

## Checklist
* [ ] Pylint passes for Python sources
* [ ] sources has been pre-processed by Black
* [ ] updated documentation wherever necessary
* [ ] new tests can be executed both locally and within docker container 
