### PR TITLE
Notification Service code coverage report generation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -27,6 +27,9 @@ exporter-tests: ## Run BDD tests for the CCX Exporter service
 notification-service-tests: ## Run BDD tests for the CCX Notification Service
 	./notification_service_tests.sh
 
+notification-service-code-coverage: ## Compute code coverage for the CCX Notification Service
+	./notification_service_tests.sh coverage
+
 notification-writer-tests: ## Run BDD tests for the CCX Notification Writer
 	./notification_writer_tests.sh
 

--- a/docs/makefile_targets.md
+++ b/docs/makefile_targets.md
@@ -17,6 +17,7 @@ aggregator-mock-tests               Run BDD tests for Insights Results Aggregato
 aggregator-mock-code-coverage       Compute code coverage for Insights Results Aggregator Mock service
 exporter-tests                      Run BDD tests for the CCX Exporter service
 notification-service-tests          Run BDD tests for the CCX Notification Service
+notification-service-code-coverage  Compute code coverage for the CCX Notification Service
 notification-writer-tests           Run BDD tests for the CCX Notification Writer
 notification-writer-code-coverage   Compute code coverage for the CCX Notification Writer
 inference-service-tests             Run BDD tests for the Inference Service

--- a/notification_service_tests.sh
+++ b/notification_service_tests.sh
@@ -126,8 +126,9 @@ function code_coverage_report() {
     cat << EOF
     +--------------------------------------------------------------+
     | Coverage report is stored in file named 'coverage.txt'.      |
-    | Copy that file into Aggregator project directory and run the |
-    | following command to get report in readable form:            |
+    | Copy that file into CCX Notification Service project         |
+    | directory and run the following command to get report        |
+    | in readable form:                                            |
     |                                                              |
     | go tool cover -func=coverage.txt                             |
     |                                                              |

--- a/notification_writer_tests.sh
+++ b/notification_writer_tests.sh
@@ -85,3 +85,8 @@ fi
 
 PYTHONDONTWRITEBYTECODE=1 python3 -m behave --tags=-skip -D dump_errors=true @test_list/notification_writer.txt "$@"
 
+
+if [[ "${flag}" == "coverage" ]]
+then
+    code_coverage_report
+fi

--- a/notification_writer_tests.sh
+++ b/notification_writer_tests.sh
@@ -52,8 +52,9 @@ function code_coverage_report() {
     cat << EOF
     +--------------------------------------------------------------+
     | Coverage report is stored in file named 'coverage.txt'.      |
-    | Copy that file into Aggregator project directory and run the |
-    | following command to get report in readable form:            |
+    | Copy that file into CCX Notification Writer project          |
+    | directory and run the following command to get report        |
+    | in readable form:                                            |
     |                                                              |
     | go tool cover -func=coverage.txt                             |
     |                                                              |


### PR DESCRIPTION
# Description

Notification Service code coverage report generation

Fixes CCXDEV-10428

## Type of change

Please delete options that are not relevant.

- New feature
- Documentation update

## Testing steps

It is possible to use the new Makefile target to run tests with code coverage report.

## Checklist
* [ ] Pylint passes for Python sources
* [ ] sources has been pre-processed by Black
* [ ] updated documentation wherever necessary
* [ ] new tests can be executed both locally and within docker container 
