### PR TITLE
Insights Results Exporter tool code coverage

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -27,6 +27,9 @@ aggregator-mock-code-coverage: ## Compute code coverage for Insights Results Agg
 exporter-tests: ## Run BDD tests for the CCX Exporter service
 	./exporter_tests.sh
 
+exporter-code-coverage: ## Compute code coverage for Insights Results exporter service
+	./insights_results_exporter_tests.sh coverage
+
 notification-service-tests: ## Run BDD tests for the CCX Notification Service
 	./notification_service_tests.sh
 

--- a/Makefile
+++ b/Makefile
@@ -27,7 +27,7 @@ aggregator-mock-code-coverage: ## Compute code coverage for Insights Results Agg
 exporter-tests: ## Run BDD tests for the CCX Exporter service
 	./exporter_tests.sh
 
-exporter-code-coverage: ## Compute code coverage for Insights Results exporter service
+exporter-code-coverage: ## Compute code coverage for Insights Results Exporter service
 	./insights_results_exporter_tests.sh coverage
 
 notification-service-tests: ## Run BDD tests for the CCX Notification Service

--- a/docs/makefile_targets.md
+++ b/docs/makefile_targets.md
@@ -17,6 +17,7 @@ aggregator-code-coverage            Compute code coverage for Insights Results A
 aggregator-mock-tests               Run BDD tests for Insights Results Aggregator Mock service
 aggregator-mock-code-coverage       Compute code coverage for Insights Results Aggregator Mock service
 exporter-tests                      Run BDD tests for the CCX Exporter service
+exporter-code-coverage              Compute code coverage for Insights Results Exporter service
 notification-service-tests          Run BDD tests for the CCX Notification Service
 notification-service-code-coverage  Compute code coverage for the CCX Notification Service
 notification-writer-tests           Run BDD tests for the CCX Notification Writer

--- a/exporter_tests.sh
+++ b/exporter_tests.sh
@@ -39,12 +39,44 @@ function set_env_vars(){
 	   INSIGHTS_RESULTS_AGGREGATOR_EXPORTER__S3__PREFIX=$DB_NAME
 }
 
+function prepare_code_coverage() {
+    echo "Preparing code coverage environment"
+    rm -rf coverage
+    mkdir coverage
+    export GOCOVERDIR=coverage/
+}
+
+function code_coverage_report() {
+    echo "Preparing code coverage report"
+    go tool covdata merge -i=coverage/ -o=.
+    go tool covdata textfmt -i=. -o=coverage.txt
+    cat << EOF
+    +--------------------------------------------------------------+
+    | Coverage report is stored in file named 'coverage.txt'.      |
+    | Copy that file into Exporter project directory and run the   |
+    | following command to get report in readable form:            |
+    |                                                              |
+    | go tool cover -func=coverage.txt                             |
+    |                                                              |
+    +--------------------------------------------------------------+
+EOF
+}
+
+flag=${1:-""}
+
+if [[ "${flag}" = "coverage" ]]
+then
+    shift
+    prepare_code_coverage
+fi
+
 # prepare virtual environment if necessary
 [ "$VIRTUAL_ENV" != "" ] || NOVENV=1
 case "$NOVENV" in
     "") echo "using existing virtual env";;
     "1") prepare_venv;;
 esac
+
 
 if [[ -n $ENV_DOCKER ]]
 then
@@ -62,3 +94,7 @@ then
     rm _logs.txt
 fi
 
+if [[ "${flag}" == "coverage" ]]
+then
+    code_coverage_report
+fi


### PR DESCRIPTION
# Description

Insights Results Exporter tool code coverage

Fixes #10427

## Type of change

- New feature file
- Documentation update

## Testing steps

It would be possible to use the new Makefile target to retrieve code coverage report.

## Checklist
* [ ] Pylint passes for Python sources
* [ ] sources has been pre-processed by Black
* [ ] updated documentation wherever necessary
* [ ] new tests can be executed both locally and within docker container 
