### PR TITLE
Build image in quay.io/cloudservices instead of ccxdev

### DIFF
--- a/build_deploy.sh
+++ b/build_deploy.sh
@@ -15,7 +15,7 @@
 
 set -exv
 
-IMAGE="quay.io/ccxdev/insights-behavioral-spec"
+IMAGE="quay.io/cloudservices/insights-behavioral-spec"
 IMAGE_TAG=$(git rev-parse --short=7 HEAD)
 
 if [[ -z "$QUAY_USER" || -z "$QUAY_TOKEN" ]]; then


### PR DESCRIPTION
# Description

This repository's image was historically built in the ccx-dev quay organization. With this change it will be moved to the cloudservices quay organization, which is where we store images for the services onboarded within App SRE.

## Type of change

- Refactor (refactoring code, removing useless files)
- Configuration update

## Testing steps

N/A

## Checklist
* [ ] Pylint passes for Python sources
* [ ] sources has been pre-processed by Black
* [ ] updated documentation wherever necessary
* [ ] new tests can be executed both locally and within docker container 
