### PR TITLE
Make file content comparison order agnostic

### DIFF
--- a/features/steps/common_file.py
+++ b/features/steps/common_file.py
@@ -26,5 +26,5 @@ def check_file_content(context, filename):
     with open(filename, "r") as fin:
         actual_content = fin.read().strip()
 
-    assert expected_content == actual_content, \
+    assert sorted(list(expected_content)) == sorted(list(actual_content)), \
         f"Content does not match:\nexpected:\n{expected_content}\n---\nactual:\n{actual_content}"


### PR DESCRIPTION
# Description

Avoid test failure due to comparing multiline strings that have the same content but with different order

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Testing steps

`make exporter-tests`

## Checklist
* [x] Pylint passes for Python sources
* [x] sources has been pre-processed by Black
* [ ] updated documentation wherever necessary
* [ ] new tests can be executed both locally and within docker container 
