### PR TITLE
Get kafkakat from ccx-dev quay repository

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -42,7 +42,7 @@ RUN dnf clean all
 RUN chmod -R g=u $HOME $VIRTUAL_ENV /etc/passwd
 RUN chgrp -R 0 $HOME $VIRTUAL_ENV
 
-COPY --from=confluentinc/cp-kafkacat:7.1.5-1-ubi8 /usr/local/bin/kafkacat $VIRTUAL_ENV_BIN/kcat
+COPY --from=quay.io/ccxdev/cp-kafkacat:7.1.7-1-ubi8 /usr/local/bin/kafkacat $VIRTUAL_ENV_BIN/kcat
 
 USER 1001
 


### PR DESCRIPTION
# Description

To build this image automatically in our CI/CD tools, it seems like we need to get the dependencies from within our own registry. This change copies the kafkacat binary from an image within our quay repository instead of getting it from an image stored in docker hub.

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Testing steps

Image builds correctly locally, but the actual test will be to see if https://ci.int.devshift.net/job/RedHatInsights-insights-behavioral-spec-gh-build-main/ is able to build the image.

## Checklist
* [ ] Pylint passes for Python sources
* [ ] sources has been pre-processed by Black
* [ ] updated documentation wherever necessary
* [ ] new tests can be executed both locally and within docker container 
