### PR TITLE
[CCXDEV-10314][template-renderer] Create a BDD test for the CCXDEV-10314 bug

### DIFF
--- a/docs/scenarios_list.md
+++ b/docs/scenarios_list.md
@@ -297,6 +297,16 @@ nav_order: 3
 * Check if /status endpoint is working
 * Check if /info endpoint is working
 
+## `insights-content-template-renderer/endpoints.feature`
+
+* check /v1/rendered_reports endpoint response
+
+## `insights-content-template-renderer/smoketests.feature`
+
+* Check if /v1/rendered_reports endpoint is working
+* Check if /docs endpoint is working
+* Check if /metrics endpoint is working
+
 ## `insights-results-aggregator/basic_rest_api.feature`
 
 * Check if the main endpoint is reachable (w/o using auth. token)

--- a/features/insights-content-template-renderer/endpoints.feature
+++ b/features/insights-content-template-renderer/endpoints.feature
@@ -1,0 +1,101 @@
+@insights_content_template_renderer
+
+Feature: Test the service endpoints
+
+  Background:
+    Given REST API service hostname is localhost
+      And REST API service port is 8000
+      And REST API service prefix is /v1/
+      And The Template Renderer is running
+
+    @rest-api @json-schema-check
+    Scenario: check /v1/rendered_reports endpoint response
+        When I access endpoint rendered_reports using HTTP POST method
+        """
+        {
+          "content": [
+            {
+              "plugin": {
+                "name": "",
+                "node_id": "",
+                "product_code": "",
+                "python_module": "ccx_rules_ocp.external.rules.1"
+              },
+              "error_keys": {
+                "RULE_1": {
+                  "metadata": {
+                    "description": "{{?pydata.options == 1\n}}Option 1{{?? pydata.options == 2\n}}Option 2{{??\n}}Other option{{?}}:\n\n More text",
+                    "impact": 2,
+                    "likelihood": 3,
+                    "publish_date": "2019-10-29 15:00:00",
+                    "status": "active",
+                    "tags": [
+                      "openshift",
+                      "configuration",
+                      "performance"
+                    ]
+                  },
+                  "total_risk": 2,
+                  "generic": "",
+                  "summary": "",
+                  "resolution": "This is a test resolution",
+                  "more_info": "",
+                  "reason": "This is a test",
+                  "HasReason": true
+                }
+              },
+              "generic": "",
+              "summary": "",
+              "resolution": "Red Hat recommends you to fix the issue with {{~ pydata.options :option }}",
+              "more_info": "For more information about this, refer to the [Documentation](https://docs.openshift.com)",
+              "reason": "Option{{?pydata.options.length>1}}s{{?}} not working",
+              "HasReason": true
+            }
+          ],
+          "report_data": {
+            "clusters": [
+              "5d5892d3-1f74-4ccf-91af-548dfc9767aa"
+            ],
+            "errors": null,
+            "reports": {
+              "5d5892d3-1f74-4ccf-91af-548dfc9767aa": {
+                "fingerprints": [],
+                "info": [],
+                "pass": [],
+                "reports": [
+                  {
+                    "rule_id": "1|RULE_1",
+                    "component": "ccx_rules_ocp.external.rules.1.report",
+                    "type": "rule",
+                    "key": "RULE_1",
+                    "details": {
+                      "options": [
+                        {
+                          "name": "foo"
+                        }
+                      ],
+                      "link": "https://docs.openshift.com/",
+                      "type": "rule",
+                      "error_key": "RULE_1"
+                    },
+                    "tags": [],
+                    "links": {
+                      "docs": [
+                        "https://docs.openshift.com"
+                      ]
+                    }
+                  }
+                ],
+                "skips": [],
+                "system": {
+                  "metadata": {},
+                  "hostname": null
+                }
+              }
+            },
+            "generated_at": "",
+            "status": "ok"
+          }
+        }
+        """
+         Then The status code of the response is 200

--- a/features/steps/common_http.py
+++ b/features/steps/common_http.py
@@ -166,6 +166,17 @@ def access_rest_api_endpoint_get(context, endpoint):
     context.response = requests.get(url)
 
 
+@when("I access endpoint {endpoint} using HTTP POST method")
+def access_rest_api_endpoint_post(context, endpoint):
+    """Send GET HTTP request to tested service."""
+    base = f"http://{context.hostname}:{context.port}"
+    path = f"{context.api_prefix}/{endpoint}".replace("//", "/")
+    url = base + path
+
+    data = json.loads(context.text)
+    context.response = requests.post(url, json=data)
+
+
 @then("The status message of the response is \"{expected_message}\"")
 def check_status_of_response(context, expected_message):
     """Check the actual message/value in status attribute."""

--- a/features/steps/insights_content_template_renderer.py
+++ b/features/steps/insights_content_template_renderer.py
@@ -33,9 +33,11 @@ def start_template_renderer(context):
 
     curpath = os.path.abspath(os.curdir)
     scenario = str(context.scenario).replace("/", "")
+    log_filename = f"{scenario.translate({ord(i): None for i in '<>/'})}.log"
+
     f = open(
         os.path.join(
-            curpath, "logs", "insights-content-template-renderer", f"{scenario}.log"
+            curpath, "logs", "insights-content-template-renderer", log_filename
         ),
         "w",
     )

--- a/test_list/insights_content_template_renderer.txt
+++ b/test_list/insights_content_template_renderer.txt
@@ -1,1 +1,2 @@
 ../features/insights-content-template-renderer/smoketests.feature
+../features/insights-content-template-renderer/endpoints.feature

--- a/tools/gen_scenario_list.py
+++ b/tools/gen_scenario_list.py
@@ -38,6 +38,7 @@ SUBDIRECTORIES = (
     "SHA_Extractor",
     "smart-proxy",
     "insights-content-service",
+    "insights-content-template-renderer",
     "insights-results-aggregator",
     "insights-results-aggregator-cleaner",
     "insights-results-aggregator-exporter",


### PR DESCRIPTION
# Description

Create a BDD test checking that for an input containing newlines inside the curly braces of the template, the renderer returns a 200 status code. For now, the template renderer returns a 500 (as reported in [CCXDEV-10314](https://issues.redhat.com/browse/CCXDEV-10314)). The idea is to have this merged so that the CI in the template-renderer repo doesn't pass until we fix the issue.

## Type of change

- New test feature file
- New test scenario added into existing feature file

## Testing steps

Locally.

## Checklist
* [x] Pylint passes for Python sources
* [ ] sources has been pre-processed by Black
* [x] updated documentation wherever necessary
* [x] new tests can be executed both locally and within docker container 
