### PR TITLE
[CCXDEV-10956][data-eng] Check the last_checked_at item exists

### DIFF
--- a/features/ccx-upgrades-data-eng/request_prediction.feature
+++ b/features/ccx-upgrades-data-eng/request_prediction.feature
@@ -26,7 +26,8 @@ Feature: Upgrade Risks Prediction Data Engineering - test well known values
           {
             "required": [
               "upgrade_recommended",
-              "upgrade_risks_predictors"
+              "upgrade_risks_predictors",
+              "last_checked_at"
             ],
             "type": "object",
             "properties": {
@@ -76,11 +77,15 @@ Feature: Upgrade Risks Prediction Data Engineering - test well known values
                     }
                   }
                 }
+              },
+              "last_checked_at": {
+                "title": "Last checked at",
+                "type": "string"
               }
             }
           }
           """
-      And The body of the response is the following
+      And The body of the response, ignoring the "last_checked_at" field, is the following
           """
           {
               "upgrade_recommended": false,
@@ -114,7 +119,8 @@ Feature: Upgrade Risks Prediction Data Engineering - test well known values
           {
             "required": [
               "upgrade_recommended",
-              "upgrade_risks_predictors"
+              "upgrade_risks_predictors",
+              "last_checked_at"
             ],
             "type": "object",
             "properties": {
@@ -164,11 +170,15 @@ Feature: Upgrade Risks Prediction Data Engineering - test well known values
                     }
                   }
                 }
+              },
+              "last_checked_at": {
+                "title": "Last checked at",
+                "type": "string"
               }
             }
           }
           """
-      And The body of the response is the following
+      And The body of the response, ignoring the "last_checked_at" field, is the following
           """
           {
               "upgrade_recommended": false,
@@ -202,7 +212,8 @@ Feature: Upgrade Risks Prediction Data Engineering - test well known values
           {
             "required": [
               "upgrade_recommended",
-              "upgrade_risks_predictors"
+              "upgrade_risks_predictors",
+              "last_checked_at"
             ],
             "type": "object",
             "properties": {
@@ -252,11 +263,15 @@ Feature: Upgrade Risks Prediction Data Engineering - test well known values
                     }
                   }
                 }
+              },
+              "last_checked_at": {
+                "title": "Last checked at",
+                "type": "string"
               }
             }
           }
           """
-      And The body of the response is the following
+      And The body of the response, ignoring the "last_checked_at" field, is the following
           """
           {
               "upgrade_recommended": false,

--- a/features/steps/common_http.py
+++ b/features/steps/common_http.py
@@ -136,6 +136,19 @@ def check_prediction_result(context):
     assert result == expected_body, f"got:\n{result}\nwant:\n{expected_body}"
 
 
+@then('The body of the response, ignoring the "{field}" is the following')
+def check_prediction_result_ignoring_field(context, field: str):
+    """Check the content of the response to be exactly the same."""
+    expected_body = json.loads(context.text).copy()
+    result = context.response.json().copy()
+
+    del expected_body[field]
+    del result[field]
+
+    # compare both JSONs and print actual result in case of any difference
+    assert result == expected_body, f"got:\n{result}\nwant:\n{expected_body}"
+
+
 @given("REST API service hostname is {hostname:w}")
 @when("REST API service hostname is {hostname:w}")
 def set_service_hostname(context, hostname):


### PR DESCRIPTION
# Description

Check that the `last_checked_at` field added in #CCXDEV-10956 exists in the data-eng response.

## Type of change

- Scenario update

## Testing steps

Locally.

## Checklist
* [ ] Pylint passes for Python sources
* [ ] sources has been pre-processed by Black
* [ ] updated documentation wherever necessary
* [ ] new tests can be executed both locally and within docker container 
