### PR TITLE
Fix check_prediction_result_ignoring_field step

### DIFF
--- a/features/steps/common_http.py
+++ b/features/steps/common_http.py
@@ -136,14 +136,14 @@ def check_prediction_result(context):
     assert result == expected_body, f"got:\n{result}\nwant:\n{expected_body}"
 
 
-@then('The body of the response, ignoring the "{field}" is the following')
+@then('The body of the response, ignoring the "{field}" field, is the following')
 def check_prediction_result_ignoring_field(context, field: str):
     """Check the content of the response to be exactly the same."""
     expected_body = json.loads(context.text).copy()
     result = context.response.json().copy()
 
-    del expected_body[field]
-    del result[field]
+    expected_body.pop(field, None)
+    result.pop(field, None)
 
     # compare both JSONs and print actual result in case of any difference
     assert result == expected_body, f"got:\n{result}\nwant:\n{expected_body}"


### PR DESCRIPTION
# Description

This step wasn't well defined. Fixing a couple of bugs in it: name and deleting keys that may not exist.

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Testing steps

Locally.

## Checklist
* [x] Pylint passes for Python sources
* [x] sources has been pre-processed by Black
* [ ] updated documentation wherever necessary
* [ ] new tests can be executed both locally and within docker container 
