### PR TITLE
Do not use Python 3.6 on CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 language: python
 python:
-  - "3.6"      # current default Python on Travis CI
   - "3.7"
   - "3.8"
   - "3.9"

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
+dist: jammy
 language: python
 python:
   - "3.7"

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,8 @@ python:
   - "3.7"
   - "3.8"
   - "3.9"
-  - "3.10-dev" # 3.10 development branch
+  - "3.10"
+  - "3.11"
   - "nightly"  # nightly build
 addons:
   apt:

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,8 +3,8 @@ python:
   - "3.7"
   - "3.8"
   - "3.9"
-  - "3.10"
-  - "3.11"
+  - "3.10-dev"
+  - "3.11-dev"
   - "nightly"  # nightly build
 addons:
   apt:


### PR DESCRIPTION
# Description

- Do not use Python 3.6 on CI
- Added Python 3.11-dev
- Had to switch distro

## Type of change

- Configuration update

## Testing steps

Let's check on CI.

## Checklist
* [ ] Pylint passes for Python sources
* [ ] sources has been pre-processed by Black
* [ ] updated documentation wherever necessary
* [ ] new tests can be executed both locally and within docker container 
