### PR TITLE
Docker compose update

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ If you don't want to spin up the containers, you'll need to locally run the requ
 
 > **_NOTE:_**  Don't forget to set up `PATH` environment variable correctly when tests are run outside containers. That environment variable needs to also contain directory with tested executable files (for example `insights-results-aggregator-cleaner` etc.)
 
-If you want to run the real dependencies (content-service and service log), run `docker-compose --profile no-mock up -d` instead and `export WITHMOCK=0`.
+If you want to run the real dependencies (content-service and service log), run `POSTGRES_DB_NAME=notification docker-compose --profile no-mock up -d` instead and `export WITHMOCK=0`.
 
 Run the tests for your repository, for example:
 

--- a/README.md
+++ b/README.md
@@ -27,13 +27,13 @@ POSTGRES_DB_NAME=test docker-compose --profile test-exporter up -d
 POSTGRES_DB_NAME=notification docker-compose --profile test-notification-services up -d
 ```
 
-The `POSTGRES_DB_NAME` environment variable is mandatory, as the different services expect different database names.
+The `POSTGRES_DB_NAME` environment variable is mandatory, as the different services expect different database names: `notification` is used by services related with notification service, and `test` for the rest.
 
 If you don't want to spin up the containers, you'll need to locally run the required services (database, Kafka, etc.). You may need to add or remove the `managed` tag in the `${SERVICE}_tests.sh`.
 
 > **_NOTE:_**  Don't forget to set up `PATH` environment variable correctly when tests are run outside containers. That environment variable needs to also contain directory with tested executable files (for example `insights-results-aggregator-cleaner` etc.)
 
-If you want to run the real dependencies (content-service and service log), run `POSTGRES_DB_NAME=notification docker-compose --profile no-mock up -d` instead and `export WITHMOCK=0`.
+If you want to run the real dependencies (content-service and service log), run `POSTGRES_DB_NAME=<test|notification> docker-compose --profile no-mock up -d` instead and `export WITHMOCK=0`.
 
 Run the tests for your repository, for example:
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,4 @@
-version: "3"
+version: "3.9"
 services:
   # "pod" with the tests
   bddtests:
@@ -15,6 +15,13 @@ services:
       - POSTGRES_USER=postgres
       - POSTGRES_PASSWORD=postgres
       - POSTGRES_DB=${POSTGRES_DB_NAME}
+    healthcheck:
+      test: ["CMD", "pg_isready"]
+      interval: 2s
+      timeout: 2s
+      retries: 4
+      start_period: 2s
+
   kafka:
     profiles:
       - test-notification-services
@@ -37,16 +44,24 @@ services:
     environment:
       - MINIO_ACCESS_KEY=test_access_key
       - MINIO_SECRET_KEY=test_secret_access_key
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://127.0.0.1:9000/minio/health/live"]
+      interval: 2s
+      timeout: 2s
+      retries: 4
+      start_period: 2s
+
   createbuckets:
     profiles:
       - test-exporter
     image: minio/mc
     depends_on:
-      - minio
+      minio:
+        condition: service_healthy
     entrypoint:
       - /bin/sh
       - -c
-      - "sleep 5;
+      - "
       /usr/bin/mc config host add myminio http://minio:9000 test_access_key test_secret_access_key;
       /usr/bin/mc mb myminio/test;"
   pushgateway:
@@ -62,10 +77,13 @@ services:
     profiles:
       - test-notification-services
     image: quay.io/cloudservices/ccx-notification-writer:latest
+    depends_on:
+      database:
+        condition: service_healthy
     entrypoint:
       - /bin/sh
       - -c
-      - 'sleep 5 && export CCX_NOTIFICATION_WRITER__STORAGE__DB_DRIVER=postgres CCX_NOTIFICATION_WRITER__STORAGE__PG_PARAMS="sslmode=disable" CCX_NOTIFICATION_WRITER__STORAGE__PG_USERNAME=postgres CCX_NOTIFICATION_WRITER__STORAGE__PG_PASSWORD=postgres CCX_NOTIFICATION_WRITER__STORAGE__PG_HOST=database CCX_NOTIFICATION_WRITER__STORAGE__PG_PORT=5432 CCX_NOTIFICATION_WRITER__STORAGE__PG_DB_NAME=notification && ./ccx-notification-writer --db-init-migration && ./ccx-notification-writer --db-init && ./ccx-notification-writer --migrate latest'
+      - 'export CCX_NOTIFICATION_WRITER__STORAGE__DB_DRIVER=postgres CCX_NOTIFICATION_WRITER__STORAGE__PG_PARAMS="sslmode=disable" CCX_NOTIFICATION_WRITER__STORAGE__PG_USERNAME=postgres CCX_NOTIFICATION_WRITER__STORAGE__PG_PASSWORD=postgres CCX_NOTIFICATION_WRITER__STORAGE__PG_HOST=database CCX_NOTIFICATION_WRITER__STORAGE__PG_PORT=5432 CCX_NOTIFICATION_WRITER__STORAGE__PG_DB_NAME=notification && ./ccx-notification-writer --db-init-migration && ./ccx-notification-writer --db-init && ./ccx-notification-writer --migrate latest'
 
   content-service:
     profiles:
@@ -84,17 +102,26 @@ services:
     image: postgres:13.9
     volumes:
       - ./setup/:/tmp/setup-scripts
-    entrypoint: sh
+    depends_on:
+      database:
+        condition: service_healthy
     environment:
       - PGPASSWORD=postgres
-    command: >
-      psql 
-        --username=postgres --host=db --port=5432 --dbname notification
+    entrypoint:
+      - /bin/sh
+      - -c
+      - "PGPASSWORD=postgres psql \
+        --username=postgres \
+        --host=database \
+        --port=5432 \
+        --dbname notification \
         -f /tmp/setup-scripts/ocm_service_log.sql
+        "
 
   service-log:
     depends_on:
-      - init-service-log-db
+      init-service-log-db:
+        condition: service_completed_successfully
     profiles:
       - no-mock
     image: quay.io/ccxdev/ocm-service-log
@@ -103,7 +130,7 @@ services:
       - 8083:8083 # Healthcheck
       - 8080:8080 # Metrics
     command: >
-      sh -c "echo db > secrets/db.host
+      sh -c "echo database > secrets/db.host
         ./ocm-service-log serve \
         --api-server-bindaddress "localhost:8000" \
         --health-check-server-bindaddress "localhost:8083" \

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -32,6 +32,7 @@ services:
     environment:
       - KAFKA_ADVERTISED_HOST_NAME=kafka
       - KAFKA_CREATE_TOPICS="platform.notifications.ingress:1:1"
+
   minio:
     profiles:
       - test-exporter
@@ -64,6 +65,7 @@ services:
       - "
       /usr/bin/mc config host add myminio http://minio:9000 test_access_key test_secret_access_key;
       /usr/bin/mc mb myminio/test;"
+
   pushgateway:
     profiles:
       - no-mock
@@ -96,6 +98,7 @@ services:
       - INSIGHTS_CONTENT_SERVICE__SERVER__API_PREFIX=/api/v1/
       - INSIGHTS_CONTENT_SERVICE__SERVER__API_SPEC_FILE=/openapi/openapi.json
       - INSIGHTS_CONTENT_SERVICE__GROUPS__PATH=/groups/groups_config.yaml
+
   init-service-log-db:
     profiles:
       - no-mock
@@ -129,14 +132,16 @@ services:
       - 8000:8000 # API server
       - 8083:8083 # Healthcheck
       - 8080:8080 # Metrics
-    command: >
-      sh -c "echo database > secrets/db.host
+    entrypoint:
+      - /bin/sh
+      - -c
+      - "echo database > secrets/db.host
         ./ocm-service-log serve \
-        --api-server-bindaddress "localhost:8000" \
-        --health-check-server-bindaddress "localhost:8083" \
-        --metrics-server-bindaddress "localhost:8080" \
+        --api-server-bindaddress 'localhost:8000' \
+        --health-check-server-bindaddress 'localhost:8083' \
+        --metrics-server-bindaddress 'localhost:8080' \
         --enable-ocm-mock
-      "
+        "
 
   mock-oauth2-server:
     profiles:


### PR DESCRIPTION
# Description

- Use docker-compose `v3.9` instead of `v3` as it reintroduces conditional dependencies between containers
- Add healthchecks to `database` and `minio` containers so dependent containers know when to start using them
- Remove `sleep` operations when starting containers with dependencies
- Refactor the docker-compose file to unify it (line breaks, quotes, `entrypoint` instead of `command` )

## Type of change

- Refactor (refactoring code, removing useless files)

## Testing steps

Run `docker-compose down -v` then `docker-compose up` with the different profiles, e.g:
- `POSTGRES_DB_NAME=notification docker-compose --profile no-mock --profile test-notification-services up -d`
- `WITHMOCK=1 POSTGRES_DB_NAME=test docker-compose --profile test-upgrades-data-eng up -d`

Use `docker-compose down -v before each `up` to start from 0.

## Checklist
* [x] Pylint passes for Python sources
* [ ] sources has been pre-processed by Black
* [x] updated documentation wherever necessary
* [ ] new tests can be executed both locally and within docker container 
