### PR TITLE
[CCXDEV-11246] Improve steps used in data engineering tests and refactor caching scenarios

### DIFF
--- a/ccx_upgrade_risk_data_eng_tests.sh
+++ b/ccx_upgrade_risk_data_eng_tests.sh
@@ -45,7 +45,7 @@ function start_mocked_dependencies() {
     pushd "$dir_path"/mocks/rhobs && uvicorn rhobs_service:app --port 8002 &
 
     # shellcheck disable=SC2016
-    add_exit_trap 'kill $(lsof -ti:8001); kill $(lsof -ti:8002);'
+    add_exit_trap 'kill $(lsof -ti:8001); kill $(lsof -ti:8002); kill $(lsof -ti:9090); kill $(lsof -ti:9091);'
     pushd "$dir_path" || exit
     sleep 2  # wait for the mocks to be up
 }

--- a/features/ccx-upgrades-data-eng/caching.feature
+++ b/features/ccx-upgrades-data-eng/caching.feature
@@ -68,13 +68,13 @@ Feature: Upgrade Risks Prediction Data Engineering - test correct behavior of th
       | CACHE_TTL                   | 10                                     |
       | CACHE_SIZE                  | 0                                      |
     When I request the cluster endpoint in localhost:8000 with path aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee/upgrade-risks-prediction
-    And I store the response for aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee for comparison
+     And I store the response for aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee for comparison
     Then The status code of the response is 200
     When I stop the mock CCX Inference Service
-    And I stop the mock RHOBS Service
+     And I stop the mock RHOBS Service
     When I request the cluster endpoint in localhost:8000 with path aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee/upgrade-risks-prediction
     Then The status code of the response is 500
-    And The response is different from the previous response for aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee
+     And The response is different from the previous response for aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee
 
 
   Scenario: Check Data Engineering Service response with a valid cluster ID is properly cached
@@ -112,30 +112,18 @@ Feature: Upgrade Risks Prediction Data Engineering - test correct behavior of th
       | OAUTHLIB_INSECURE_TRANSPORT | 1                                      |
       | CACHE_ENABLED               | 1                                      |
       | CACHE_TTL                   | 60                                     |
-      | CACHE_SIZE                  | 3                                      |
+      | CACHE_SIZE                  | 1                                      |
     When I request the cluster endpoint in localhost:8000 with path aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee/upgrade-risks-prediction
     And I store the response for aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee for comparison
     Then The status code of the response is 200
     When I request the cluster endpoint in localhost:8000 with path aaaaaaaa-bbbb-cccc-dddd-000000000000/upgrade-risks-prediction
     And I store the response for aaaaaaaa-bbbb-cccc-dddd-000000000000 for comparison
     Then The status code of the response is 200
-    When I request the cluster endpoint in localhost:8000 with path 44444444-3333-2222-1111-111111111111/upgrade-risks-prediction
-    And I store the response for 44444444-3333-2222-1111-111111111111 for comparison
-    Then The status code of the response is 200
-    When I request the cluster endpoint in localhost:8000 with path 00000000-1111-2222-3333-444444444444/upgrade-risks-prediction
-    And I store the response for 00000000-1111-2222-3333-444444444444 for comparison
-    Then The status code of the response is 404
     When I stop the mock CCX Inference Service
     And I stop the mock RHOBS Service
     And I request the cluster endpoint in localhost:8000 with path aaaaaaaa-bbbb-cccc-dddd-000000000000/upgrade-risks-prediction
     Then The status code of the response is 200
     And The response is identical to the previous response for aaaaaaaa-bbbb-cccc-dddd-000000000000
-    When I request the cluster endpoint in localhost:8000 with path 44444444-3333-2222-1111-111111111111/upgrade-risks-prediction
-    Then The status code of the response is 200
-    And The response is identical to the previous response for 44444444-3333-2222-1111-111111111111
-    When I request the cluster endpoint in localhost:8000 with path 00000000-1111-2222-3333-444444444444/upgrade-risks-prediction
-    Then The status code of the response is 404
-    And The response is identical to the previous response for 00000000-1111-2222-3333-444444444444
     # Item for aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee is not in the cache anymore, so this fails as RHOBS / inference are not available
     When I request the cluster endpoint in localhost:8000 with path aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee/upgrade-risks-prediction
     Then The status code of the response is 500
@@ -154,31 +142,36 @@ Feature: Upgrade Risks Prediction Data Engineering - test correct behavior of th
       | OAUTHLIB_INSECURE_TRANSPORT | 1                                      |
       | CACHE_ENABLED               | 1                                      |
       | CACHE_TTL                   | 60                                     |
-      | CACHE_SIZE                  | 3                                      |
+      | CACHE_SIZE                  | 2                                      |
     When I request the cluster endpoint in localhost:8000 with path aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee/upgrade-risks-prediction
     And I store the response for aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee for comparison
     Then The status code of the response is 200
     When I request the cluster endpoint in localhost:8000 with path aaaaaaaa-bbbb-cccc-dddd-000000000000/upgrade-risks-prediction
     And I store the response for aaaaaaaa-bbbb-cccc-dddd-000000000000 for comparison
     Then The status code of the response is 200
-    When I request the cluster endpoint in localhost:8000 with path 44444444-3333-2222-1111-111111111111/upgrade-risks-prediction
-    And I store the response for 44444444-3333-2222-1111-111111111111 for comparison
+    When I request the cluster endpoint in localhost:8000 with path 00000000-1111-2222-3333-444444444444/upgrade-risks-prediction
+     And I store the response for 00000000-1111-2222-3333-444444444444 for comparison
+    Then The status code of the response is 404
+    # repeat the requests so the cache is used and LRU item is evicted
+    When I request the cluster endpoint in localhost:8000 with path aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee/upgrade-risks-prediction
+     And I store the response for aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee for comparison
+    Then The status code of the response is 200
+    When I request the cluster endpoint in localhost:8000 with path aaaaaaaa-bbbb-cccc-dddd-000000000000/upgrade-risks-prediction
+     And I store the response for aaaaaaaa-bbbb-cccc-dddd-000000000000 for comparison
     Then The status code of the response is 200
     When I request the cluster endpoint in localhost:8000 with path 00000000-1111-2222-3333-444444444444/upgrade-risks-prediction
-    And I store the response for 00000000-1111-2222-3333-444444444444 for comparison
+     And I store the response for 00000000-1111-2222-3333-444444444444 for comparison
     Then The status code of the response is 404
+    # stop the dependencies to only get responses from cache
     When I stop the mock CCX Inference Service
-    And I stop the mock RHOBS Service
-    And I request the cluster endpoint in localhost:8000 with path aaaaaaaa-bbbb-cccc-dddd-000000000000/upgrade-risks-prediction
+     And I stop the mock RHOBS Service
+     And I request the cluster endpoint in localhost:8000 with path aaaaaaaa-bbbb-cccc-dddd-000000000000/upgrade-risks-prediction
     Then The status code of the response is 200
     And The response is identical to the previous response for aaaaaaaa-bbbb-cccc-dddd-000000000000
-    When I request the cluster endpoint in localhost:8000 with path 44444444-3333-2222-1111-111111111111/upgrade-risks-prediction
-    Then The status code of the response is 200
-    And The response is identical to the previous response for 44444444-3333-2222-1111-111111111111
     When I request the cluster endpoint in localhost:8000 with path 00000000-1111-2222-3333-444444444444/upgrade-risks-prediction
     Then The status code of the response is 404
     And The response is identical to the previous response for 00000000-1111-2222-3333-444444444444
-    # Item for aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee is not in the cache anymore, so this fails as RHOBS / inference are not available
+    # Item for aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee has been evicted, so this fails as RHOBS / inference are not available
     When I request the cluster endpoint in localhost:8000 with path aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee/upgrade-risks-prediction
     Then The status code of the response is 500
     And The response is different from the previous response for aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee
@@ -195,25 +188,18 @@ Feature: Upgrade Risks Prediction Data Engineering - test correct behavior of th
       | RHOBS_URL                   | http://localhost:9091                  |
       | OAUTHLIB_INSECURE_TRANSPORT | 1                                      |
       | CACHE_ENABLED               | 1                                      |
-      | CACHE_TTL                   | 5                                      |
+      | CACHE_TTL                   | 3                                      |
       | CACHE_SIZE                  | 50                                     |
     When I request the cluster endpoint in localhost:8000 with path aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee/upgrade-risks-prediction
-    And I store the response for aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee for comparison
-    When I wait 4 seconds
+     And I store the response for aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee for comparison
+    Then The status code of the response is 200
+    When I stop the mock CCX Inference Service
+     And I stop the mock RHOBS Service
      And I request the cluster endpoint in localhost:8000 with path aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee/upgrade-risks-prediction
     Then The status code of the response is 200
-    And The response is identical to the previous response for aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee
-    When I request the cluster endpoint in localhost:8000 with path 00000000-1111-2222-3333-444444444444/upgrade-risks-prediction
-    And I store the response for 00000000-1111-2222-3333-444444444444 for comparison
-    Then The status code of the response is 404
-    When I stop the mock CCX Inference Service
-    And I stop the mock RHOBS Service
-    And I wait 1 seconds
-    # cached results for 00000000-1111-2222-3333-444444444444 are still in the cache
-    When I request the cluster endpoint in localhost:8000 with path 00000000-1111-2222-3333-444444444444/upgrade-risks-prediction
-    Then The status code of the response is 404
-    And The response is identical to the previous response for 00000000-1111-2222-3333-444444444444
-    # cached results for aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee were evicted after 5 seconds
-    When I request the cluster endpoint in localhost:8000 with path aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee/upgrade-risks-prediction
+     And The response is identical to the previous response for aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee
+    # cached results for aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee were evicted after 3 seconds
+    When I wait 3 seconds
+     And I request the cluster endpoint in localhost:8000 with path aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee/upgrade-risks-prediction
     Then The status code of the response is 500
     And The response is different from the previous response for aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee

--- a/features/steps/ccx_data_engineering_service.py
+++ b/features/steps/ccx_data_engineering_service.py
@@ -19,6 +19,7 @@ import os
 import subprocess
 import time
 from behave import given, when
+from common_http import check_service_started
 
 
 @given("The CCX Data Engineering Service is running on port {port:d} with envs")
@@ -43,7 +44,7 @@ def start_ccx_upgrades_data_eng(context, port):
 
     popen = subprocess.Popen(params, stdout=f, stderr=f, env=env)
     assert popen is not None
-    time.sleep(2)
+    check_service_started(context, "localhost", port, attempts=10)
     context.add_cleanup(popen.terminate)
 
 
@@ -55,7 +56,8 @@ def start_RHOBS_mock_service(context, port):
     f = open(f"logs/ccx-upgrades-data-eng/{context.scenario}.log", "w")
     popen = subprocess.Popen(params, stdout=f, stderr=f)
     assert popen is not None
-    time.sleep(0.5)
+    # time.sleep(0.5)
+    check_service_started(context, "localhost", port)
     context.add_cleanup(popen.terminate)
     context.mock_rhobs = popen
 

--- a/features/steps/ccx_data_engineering_service.py
+++ b/features/steps/ccx_data_engineering_service.py
@@ -61,10 +61,10 @@ def start_RHOBS_mock_service(context, port):
 
 
 @when("I stop the mock RHOBS Service")
-def start_ccx_inference_mock_service(context):
+def stop_RHOBS_mock_service(context):
     """Stop mocked RHOBS service."""
     context.mock_rhobs.terminate()
     time.sleep(0.5)
     poll = context.mock_rhobs.poll()
     if poll is None:
-        raise Exception("mock inference subprocess is still alive!")
+        raise Exception("mock RHOBS subprocess is still alive!")

--- a/features/steps/ccx_data_engineering_service.py
+++ b/features/steps/ccx_data_engineering_service.py
@@ -64,7 +64,6 @@ def start_RHOBS_mock_service(context, port):
 def stop_RHOBS_mock_service(context):
     """Stop mocked RHOBS service."""
     context.mock_rhobs.terminate()
-    time.sleep(0.5)
-    poll = context.mock_rhobs.poll()
-    if poll is None:
-        raise Exception("mock RHOBS subprocess is still alive!")
+    while context.mock_rhobs.poll() is None:
+        # subprocess is still alive
+        time.sleep(0.1)

--- a/features/steps/ccx_inference_service.py
+++ b/features/steps/ccx_inference_service.py
@@ -51,7 +51,6 @@ def start_ccx_inference_mock_service(context, port):
 def stop_ccx_inference_mock_service(context):
     """Stop mocked inference service."""
     context.mock_inference.terminate()
-    time.sleep(0.5)
-    poll = context.mock_inference.poll()
-    if poll is None:
-        raise Exception("mock inference subprocess is still alive!")
+    while context.mock_inference.poll() is None:
+        # subprocess is still alive
+        time.sleep(0.1)

--- a/features/steps/ccx_inference_service.py
+++ b/features/steps/ccx_inference_service.py
@@ -48,7 +48,7 @@ def start_ccx_inference_mock_service(context, port):
 
 
 @when("I stop the mock CCX Inference Service")
-def start_ccx_inference_mock_service(context):
+def stop_ccx_inference_mock_service(context):
     """Stop mocked inference service."""
     context.mock_inference.terminate()
     time.sleep(0.5)

--- a/features/steps/ccx_inference_service.py
+++ b/features/steps/ccx_inference_service.py
@@ -19,6 +19,7 @@ import subprocess
 import time
 
 from behave import given, when
+from common_http import check_service_started
 
 
 @given("The CCX Inference Service is running on port {port:d}")
@@ -30,7 +31,7 @@ def start_ccx_inference_service(context, port):
     f = open(f"logs/ccx-upgrades-inference/{context.scenario}.log", "w")
     popen = subprocess.Popen(params, stdout=f, stderr=f, env=env)
     assert popen is not None
-    time.sleep(0.5)
+    check_service_started(context, "localhost", port)
     context.add_cleanup(popen.terminate)
 
 
@@ -42,7 +43,8 @@ def start_ccx_inference_mock_service(context, port):
     f = open(f"logs/ccx-upgrades-inference/{context.scenario}.log", "w")
     popen = subprocess.Popen(params, stdout=f, stderr=f)
     assert popen is not None
-    time.sleep(0.5)
+    check_service_started(context, "localhost", port)
+
     context.add_cleanup(popen.terminate)
     context.mock_inference = popen
 

--- a/features/steps/common_http.py
+++ b/features/steps/common_http.py
@@ -25,7 +25,8 @@ from behave import given, then, when
 def check_service_started(context, hostname, port, attempts=5):
     """Try to query http://<hostname>:<port>/openapi.json.
 
-    Any response is valid as it means the service started"""
+    Any response is valid as it means the service started
+    """
     while attempts > 0:
         time.sleep(0.1)
         try:

--- a/features/steps/common_http.py
+++ b/features/steps/common_http.py
@@ -15,10 +15,29 @@
 """Common steps for HTTP related operations."""
 
 import json
+import time
 
 import jsonschema
 import requests
 from behave import given, then, when
+
+
+def check_service_started(context, hostname, port, attempts=5):
+    """Try to query http://<hostname>:<port>/openapi.json.
+
+    Any response is valid as it means the service started"""
+    while attempts > 0:
+        time.sleep(0.1)
+        try:
+            request_endpoint(context, "openapi.json", hostname, port)
+            if context.response is not None:
+                # service started
+                return
+            else:
+                attempts -= 1
+        except requests.ConnectionError:
+            attempts -= 1
+    raise Exception(f"No service seem to be available at http://{hostname}:{port}")
 
 
 @when("I request the {endpoint} endpoint in {hostname:w}:{port:d} with {body} in the body")

--- a/features/steps/common_http.py
+++ b/features/steps/common_http.py
@@ -22,13 +22,13 @@ import requests
 from behave import given, then, when
 
 
-def check_service_started(context, hostname, port, attempts=5):
+def check_service_started(context, hostname, port, attempts=5, seconds_between_attempts=0.1):
     """Try to query http://<hostname>:<port>/openapi.json.
 
     Any response is valid as it means the service started
     """
     while attempts > 0:
-        time.sleep(0.1)
+        time.sleep(seconds_between_attempts)
         try:
             request_endpoint(context, "openapi.json", hostname, port)
             if context.response is not None:


### PR DESCRIPTION
# Description

- Refactor steps implementations in `ccx_inference_service.py` and `ccx_data_engineering_service.py`, mainly to remove long `time.sleep` calls.

  **Previous execution time:**
  
  ```
  3 features passed, 0 failed, 0 skipped
  14 scenarios passed, 0 failed, 0 skipped
  150 steps passed, 0 failed, 0 skipped, 0 undefined
  Took 0m46.650s
  ```
  
  **Now:**
  
  ```
  3 features passed, 0 failed, 0 skipped
  14 scenarios passed, 0 failed, 0 skipped
  150 steps passed, 0 failed, 0 skipped, 0 undefined
  Took 0m24.585s
  ```

- Reduce data-engineering caching scenarios' steps

Fixes CCXDEV-11246

## Type of change

- Refactor (refactoring code, removing useless files)

## Testing steps

`WITHMOCK=1 ./ccx_upgrade_risk_data_eng_tests.sh` for example.

## Checklist
* [x] Pylint passes for Python sources
* [x] sources has been pre-processed by Black
* [ ] updated documentation wherever necessary
* [ ] new tests can be executed both locally and within docker container 
