### PR TITLE
Make mock template renderer work when rule does not contain .report

### DIFF
--- a/mocks/content-template-renderer/content_template_renderer.py
+++ b/mocks/content-template-renderer/content_template_renderer.py
@@ -67,11 +67,14 @@ async def render_reports(request: Request):
     data = await request.json()
 
     reports = []
+
     for cluster_id, cluster_data in data["report_data"]["reports"].items():
         for report in cluster_data["reports"]:
+            if report["component"].endswith('.report'):
+                report["component"] = report["component"][:-7]
             reports.append(
                 {
-                    "rule_id": report["component"][0: report["component"].rfind(".")],
+                    "rule_id": report["component"],
                     "error_key": report["key"],
                     "description": "detailed description",
                     "reason": "detailed report",


### PR DESCRIPTION
# Description

Render properly reports where the `component` field does not contain `.report` at the end.
For example, the test rules added to the content-service have `test_rule` as component.

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Testing steps

tested locally

## Checklist
* [x] Pylint passes for Python sources
* [ ] sources has been pre-processed by Black
* [ ] updated documentation wherever necessary
* [ ] new tests can be executed both locally and within docker container 
