### PR TITLE
Always exit test runners with Behave's return code

### DIFF
--- a/ccx_upgrade_risk_data_eng_tests.sh
+++ b/ccx_upgrade_risk_data_eng_tests.sh
@@ -80,3 +80,7 @@ PYTHONDONTWRITEBYTECODE=1 python3 "$(which behave)" \
     --format=progress2 \
     --tags=-skip --tags=-managed \
     -D dump_errors=true @test_list/upgrades_data_eng_service.txt "$@"
+
+bddExecutionExitCode=$?
+
+exit $bddExecutionExitCode

--- a/ccx_upgrade_risk_inference_tests.sh
+++ b/ccx_upgrade_risk_inference_tests.sh
@@ -68,3 +68,7 @@ PYTHONDONTWRITEBYTECODE=1 python3 "$(which behave)" \
     --format=progress2 \
     --tags=-skip --tags=-managed \
     -D dump_errors=true @test_list/upgrades_inference_service.txt "$@"
+
+bddExecutionExitCode=$?
+
+exit $bddExecutionExitCode

--- a/cleaner_tests.sh
+++ b/cleaner_tests.sh
@@ -78,7 +78,11 @@ fi
 
 PYTHONDONTWRITEBYTECODE=1 python3 -m behave --tags=-skip -D dump_errors=true @test_list/cleaner.txt "$@"
 
+bddExecutionExitCode=$?
+
 if [[ "${flag}" == "coverage" ]]
 then
     code_coverage_report
 fi
+
+exit $bddExecutionExitCode

--- a/exporter_tests.sh
+++ b/exporter_tests.sh
@@ -86,9 +86,11 @@ fi
 
 PYTHONDONTWRITEBYTECODE=1 python3 -m behave --tags=-skip -D dump_errors=true @test_list/exporter.txt "$@"
 
+bddExecutionExitCode=$?
+
 # post-run clean up
 # shellcheck disable=SC2181
-if [ $? -eq 0 ]
+if [ $bddExecutionExitCode -eq 0 ]
 then
     rm -- *.csv
     rm _logs.txt
@@ -98,3 +100,5 @@ if [[ "${flag}" == "coverage" ]]
 then
     code_coverage_report
 fi
+
+exit $bddExecutionExitCode

--- a/insights_content_template_renderer_tests.sh
+++ b/insights_content_template_renderer_tests.sh
@@ -69,3 +69,7 @@ PYTHONDONTWRITEBYTECODE=1 python3 "$(which behave)" \
     --format=progress2 \
     --tags=-skip --tags=-managed \
     -D dump_errors=true @test_list/insights_content_template_renderer.txt "$@"
+
+bddExecutionExitCode=$?
+
+exit $bddExecutionExitCode

--- a/insights_results_aggregator_mock_tests.sh
+++ b/insights_results_aggregator_mock_tests.sh
@@ -70,6 +70,8 @@ fi
 
 PYTHONDONTWRITEBYTECODE=1 python3 -m behave --tags=-skip -D dump_errors=true @test_list/insights_results_aggregator_mock.txt "$@"
 
+bddExecutionExitCode=$?
+
 # stop the Insights Results Aggregator Mock
 killall insights-results-aggregator-mock
 
@@ -77,3 +79,5 @@ if [[ "${flag}" == "coverage" ]]
 then
     code_coverage_report
 fi
+
+exit $bddExecutionExitCode

--- a/insights_results_aggregator_tests.sh
+++ b/insights_results_aggregator_tests.sh
@@ -72,6 +72,8 @@ fi
 
 PYTHONDONTWRITEBYTECODE=1 python3 -m behave --tags=-skip -D dump_errors=true @test_list/insights_results_aggregator.txt "$@"
 
+bddExecutionExitCode=$?
+
 # stop the Insights Results Aggregator
 killall insights-results-aggregator
 
@@ -82,3 +84,5 @@ if [[ "${flag}" == "coverage" ]]
 then
     code_coverage_report
 fi
+
+exit $bddExecutionExitCode

--- a/notification_service_tests.sh
+++ b/notification_service_tests.sh
@@ -187,7 +187,11 @@ PYTHONDONTWRITEBYTECODE=1 python3 -m behave \
     --tags=-skip --tags=-managed \
     -D dump_errors=true @test_list/notification_service.txt "$@"
 
+bddExecutionExitCode=$?
+
 if [[ "${flag}" == "coverage" ]]
 then
     code_coverage_report
 fi
+
+exit $bddExecutionExitCode

--- a/notification_writer_tests.sh
+++ b/notification_writer_tests.sh
@@ -86,8 +86,11 @@ fi
 
 PYTHONDONTWRITEBYTECODE=1 python3 -m behave --tags=-skip -D dump_errors=true @test_list/notification_writer.txt "$@"
 
+bddExecutionExitCode=$?
 
 if [[ "${flag}" == "coverage" ]]
 then
     code_coverage_report
 fi
+
+exit $bddExecutionExitCode

--- a/smart_proxy_tests.sh
+++ b/smart_proxy_tests.sh
@@ -79,7 +79,11 @@ fi
 
 PYTHONDONTWRITEBYTECODE=1 python3 -m behave --tags=-skip -D dump_errors=true @test_list/smart_proxy.txt "$@"
 
+bddExecutionExitCode=$?
+
 if [[ "${flag}" == "coverage" ]]
 then
     code_coverage_report
 fi
+
+exit $bddExecutionExitCode


### PR DESCRIPTION
# Description

When exiting the test runners, always use Behave's return code as exit code so we can know if the tests passed or failed in CI.

e.g after adding the lines for running coverage check, https://app.travis-ci.com/github/RedHatInsights/ccx-notification-service/jobs/605744767 passed despite the tests failing

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Testing steps

Make the tests fail by changing anything in the steps and run them. Exit code should not be 0 anymore

## Checklist
* [ ] Pylint passes for Python sources
* [ ] sources has been pre-processed by Black
* [ ] updated documentation wherever necessary
* [ ] new tests can be executed both locally and within docker container 
