### PR TITLE
Notification service - actively wait for dependencies to be up

### DIFF
--- a/features/steps/notification_service_dependencies.py
+++ b/features/steps/notification_service_dependencies.py
@@ -20,6 +20,8 @@ import requests
 
 from behave import given, then, when
 
+from common_http import check_service_started
+
 CONTENT_SERVICE_OPENAPI_ENDPOINT = "/api/v1/openapi.json"
 SERVICE_LOG_CLUSTER_LOGS_ENDPOINT = "/api/service_logs/v1/cluster_logs"
 PUSH_GATEWAY_METRICS_ENDPOINT = "/metrics"
@@ -45,14 +47,13 @@ def check_content_service_availability(context, host=None, port=None):
         host is not None and port is not None
     ), "host and port of content service has not been set"
 
-    url = create_url(host, port, CONTENT_SERVICE_OPENAPI_ENDPOINT)
-    response = requests.get(url)
-    assert response.status_code == 200
+    check_service_started(context, host, port)
 
 
 @given("service-log service is available on {host}:{port:d}")
 def check_service_log_availability(context, host, port):
     """Check if service-log is available at given address."""
+    check_service_started(context, host, port)
     url = create_url(host, port, SERVICE_LOG_CLUSTER_LOGS_ENDPOINT)
     response = requests.get(url, headers={"Authorization": "TEST_TOKEN"})
     assert response.status_code == 200, "service log is not up"
@@ -61,6 +62,7 @@ def check_service_log_availability(context, host, port):
 @given("token refreshment server is available on {host}:{port:d}")
 def check_token_refreshment_availability(context, host, port):
     """Check if token refreshment server is available at given address."""
+    check_service_started(context, host, port)
     url = create_url(host, port, TOKEN_REFRESHMENT_ENDPOINT)
     body = {
         "grant_type": "client_credentials",
@@ -87,9 +89,7 @@ def check_push_gateway_availability(context, host=None, port=None):
         host is not None and port is not None
     ), "host and port of gateway has not been set"
 
-    url = create_url(host, port, PUSH_GATEWAY_METRICS_ENDPOINT)
-    response = requests.get(url)
-    assert response.status_code == 200
+    check_service_started(context, host, port)
 
 
 def create_url(host, port, endpoint):


### PR DESCRIPTION
# Description

Use active wait when checking if dependencies are up, as in ccx-data-upgrades tests, as the smoke tests can randomly fail due to a dependency not being up yet when they are run

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Testing steps

- `POSTGRES_DB_NAME=notification docker-compose --profile test-notification-services up -d`
- Run `WITHMOCK=1 ./notification_service_tests.sh` within the `insights-behavioral-spec` container

## Checklist
* [ ] Pylint passes for Python sources
* [ ] sources has been pre-processed by Black
* [ ] updated documentation wherever necessary
* [ ] new tests can be executed both locally and within docker container 
