### PR TITLE
Give more waiting time to notification dependencies for uvicorn mocks

### DIFF
--- a/features/steps/notification_service_dependencies.py
+++ b/features/steps/notification_service_dependencies.py
@@ -47,7 +47,7 @@ def check_content_service_availability(context, host=None, port=None):
         host is not None and port is not None
     ), "host and port of content service has not been set"
 
-    check_service_started(context, host, port)
+    check_service_started(context, host, port, seconds_between_attempts=1)
 
 
 @given("service-log service is available on {host}:{port:d}")
@@ -62,7 +62,7 @@ def check_service_log_availability(context, host, port):
 @given("token refreshment server is available on {host}:{port:d}")
 def check_token_refreshment_availability(context, host, port):
     """Check if token refreshment server is available at given address."""
-    check_service_started(context, host, port)
+    check_service_started(context, host, port, seconds_between_attempts=1)
     url = create_url(host, port, TOKEN_REFRESHMENT_ENDPOINT)
     body = {
         "grant_type": "client_credentials",
@@ -89,7 +89,7 @@ def check_push_gateway_availability(context, host=None, port=None):
         host is not None and port is not None
     ), "host and port of gateway has not been set"
 
-    check_service_started(context, host, port)
+    check_service_started(context, host, port, seconds_between_attempts=1)
 
 
 def create_url(host, port, endpoint):


### PR DESCRIPTION
# Description

Starting the mocks is taking more time in the CI environment than locally. This is a quick fix to take that into account.

## Type of change

- Non-breaking change in test steps implementation

## Testing steps

- `POSTGRES_DB_NAME=notification docker-compose --profile test-notification-services up -d`
- Run `WITHMOCK=1 ./notification_service_tests.sh` within the `insights-behavioral-spec` container
 
## Checklist
* [ ] Pylint passes for Python sources
* [ ] sources has been pre-processed by Black
* [ ] updated documentation wherever necessary
* [ ] new tests can be executed both locally and within docker container 
