### PR TITLE
Prolong timeout for checking that inference service is running

### DIFF
--- a/features/steps/ccx_inference_service.py
+++ b/features/steps/ccx_inference_service.py
@@ -31,7 +31,7 @@ def start_ccx_inference_service(context, port):
     f = open(f"logs/ccx-upgrades-inference/{context.scenario}.log", "w")
     popen = subprocess.Popen(params, stdout=f, stderr=f, env=env)
     assert popen is not None
-    check_service_started(context, "localhost", port)
+    check_service_started(context, "localhost", port, seconds_between_attempts=1)
     context.add_cleanup(popen.terminate)
 
 


### PR DESCRIPTION
# Description

Prolong time for checking that inference service is running (since it failed in CI).

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Testing steps

Run `make inference-service-tests` locally.

## Checklist
* [ ] Pylint passes for Python sources
* [ ] sources has been pre-processed by Black
* [ ] updated documentation wherever necessary
* [ ] new tests can be executed both locally and within docker container 
