### PR TITLE
Remove killall from runner scripts

### DIFF
--- a/features/steps/cleaner_main.py
+++ b/features/steps/cleaner_main.py
@@ -42,6 +42,8 @@ def run_cleaner_for_older_records(context, age):
     # check if subprocess has been started and its output caught
     assert out is not None
 
+    context.add_cleanup(out.terminate)
+
     # it is expected that exit code will be 0
     process_generated_output(context, out, 0)
 
@@ -57,6 +59,8 @@ def run_cleaner_with_flag(context, flag):
 
     # check if subprocess has been started and its output caught
     assert out is not None
+
+    context.add_cleanup(out.terminate)
 
     # it is expected that exit code will be 0 or 2
     process_generated_output(context, out, 2)
@@ -74,6 +78,8 @@ def run_cleaner_to_cleanup_cluster(context, cluster):
     # check if subprocess has been started and its output caught
     assert out is not None
 
+    context.add_cleanup(out.terminate)
+
     # it is expected that exit code will be 0
     process_generated_output(context, out, 0)
 
@@ -89,6 +95,8 @@ def start_db_vacuum(context):
 
     # check if subprocess has been started and its output caught
     assert out is not None
+
+    context.add_cleanup(out.terminate)
 
     # it is expected that exit code will be 0
     process_generated_output(context, out, 0)

--- a/features/steps/exporter_main.py
+++ b/features/steps/exporter_main.py
@@ -37,7 +37,6 @@ def run_exporter_with_flag(context, flag):
     process_generated_output(context, out, 2)
 
 
-
 @when(u"I run the exporter with the following command line flags: {flags}")
 def run_exporter_with_flags(context, flags):
     """Start the exporter with given command-line flags."""
@@ -47,6 +46,8 @@ def run_exporter_with_flags(context, flags):
 
     # check if subprocess has been started and its output caught
     assert out is not None
+
+    context.add_cleanup(out.terminate)
 
     # it is expected that exit code will be 0 or 2
     process_generated_output(context, out, 2)

--- a/features/steps/exporter_main.py
+++ b/features/steps/exporter_main.py
@@ -31,8 +31,11 @@ def run_exporter_with_flag(context, flag):
     # check if subprocess has been started and its output caught
     assert out is not None
 
+    context.add_cleanup(out.terminate)
+
     # it is expected that exit code will be 0 or 2
     process_generated_output(context, out, 2)
+
 
 
 @when(u"I run the exporter with the following command line flags: {flags}")

--- a/features/steps/insights_results_aggregator.py
+++ b/features/steps/insights_results_aggregator.py
@@ -210,6 +210,8 @@ def start_insights_results_aggregator_in_background(context):
     # check if process has been created
     assert process is not None, "Process was not created!"
 
+    context.add_cleanup(process.terminate)
+
     # check if process has been started
     assert process.poll() is None, "Insights Results Aggregator immediatelly finished!"
 

--- a/features/steps/insights_results_aggregator.py
+++ b/features/steps/insights_results_aggregator.py
@@ -79,6 +79,7 @@ def start_aggregator(context, flag, environment):
 
     # check if subprocess has been started and its output caught
     assert out is not None
+    context.add_cleanup(out.terminate)
 
     # don't check exit code at this stage
     process_generated_output(context, out)

--- a/features/steps/insights_results_aggregator_mock.py
+++ b/features/steps/insights_results_aggregator_mock.py
@@ -38,6 +38,7 @@ def run_insights_results_aggregator_mock_with_flag(context, flag):
 
     # check if subprocess has been started and its output caught
     assert out is not None
+    context.add_cleanup(out.terminate)
 
     # it is expected that exit code will be 0 or 2
     process_generated_output(context, out, 2)
@@ -389,7 +390,7 @@ def request_results_for_list_of_clusters(context, org=None, account=None, user=N
 
 
 @then("I should see empty list of reports")
-def step_impl(context):
+def check_list_of_reports_is_empty(context):
     """Check that list of reports returned from the service is empty."""
     json = context.response.json()
     assert json is not None

--- a/features/steps/insights_sha_extractor.py
+++ b/features/steps/insights_sha_extractor.py
@@ -82,6 +82,8 @@ def start_sha_extractor(context, group_id=None):
         encoding="utf-8",
         env=os.environ.copy(),
     )
+    assert sha_extractor is not None, "Process was not created"
+    context.add_cleanup(sha_extractor.terminate)
     context.sha_extractor = sha_extractor
 
 

--- a/features/steps/notification_service.py
+++ b/features/steps/notification_service.py
@@ -135,6 +135,8 @@ def start_ccx_notification_service_with_flag(context, flag):
         params, stdout=subprocess.PIPE, stderr=subprocess.STDOUT, env=env
     )
     assert out is not None
+    context.add_cleanup(out.terminate)
+
     process_ccx_notification_service_output(context, out, context.return_codes)
 
 

--- a/features/steps/notification_writer.py
+++ b/features/steps/notification_writer.py
@@ -60,6 +60,8 @@ def start_ccx_notification_writer_with_flag(context, flag):
     )
 
     assert out is not None
+    context.add_cleanup(out.terminate)
+
     process_ccx_notification_writer_output(context, out, 2)
 
 
@@ -153,11 +155,6 @@ def notification_writer_db_empty(context):
     # first step - drop all tables, together with theirs content
     # TODO: --drop-tables does not delete the tables created by migrations, so --migrate fails
 
-    # out = subprocess.Popen(
-    #    ["ccx-notification-writer", "--db-drop-tables"],
-    #    stdout=subprocess.PIPE,
-    #    stderr=subprocess.STDOUT,
-    # )
     from steps.notification_database import ensure_database_emptiness
 
     ensure_database_emptiness(context)

--- a/features/steps/smart_proxy.py
+++ b/features/steps/smart_proxy.py
@@ -33,6 +33,8 @@ def run_insights_results_aggregator_with_flag(context, flag):
     # check if subprocess has been started and its output caught
     assert out is not None
 
+    context.add_cleanup(out.terminate)
+
     # it is expected that exit code will be 0 or 2
     process_generated_output(context, out, 2)
 

--- a/insights_results_aggregator_mock_tests.sh
+++ b/insights_results_aggregator_mock_tests.sh
@@ -72,9 +72,6 @@ PYTHONDONTWRITEBYTECODE=1 python3 -m behave --tags=-skip -D dump_errors=true @te
 
 bddExecutionExitCode=$?
 
-# stop the Insights Results Aggregator Mock
-killall insights-results-aggregator-mock
-
 if [[ "${flag}" == "coverage" ]]
 then
     code_coverage_report

--- a/insights_results_aggregator_tests.sh
+++ b/insights_results_aggregator_tests.sh
@@ -74,9 +74,6 @@ PYTHONDONTWRITEBYTECODE=1 python3 -m behave --tags=-skip -D dump_errors=true @te
 
 bddExecutionExitCode=$?
 
-# stop the Insights Results Aggregator
-killall insights-results-aggregator
-
 # time to disconnect from Kafka and from PostgreSQL
 sleep 2
 


### PR DESCRIPTION
# Description

We use minimalistic images as base image on our services, and `killall` is not a utility we can expect to have in all of them.

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Testing steps

Run all the tests in container

## Checklist
* [ ] Pylint passes for Python sources
* [ ] sources has been pre-processed by Black
* [ ] updated documentation wherever necessary
* [ ] new tests can be executed both locally and within docker container 
