### PR TITLE
Use proper formating for array items in JSON schema

### DIFF
--- a/features/insights-results-aggregator/cluster_reports.feature
+++ b/features/insights-results-aggregator/cluster_reports.feature
@@ -73,7 +73,7 @@ Feature: Checks for cluster reports provided by Insights Results Aggregator
                 },
                 "errors": {
                   "type": "array",
-                  "items": [
+                  "prefixItems": [
                     {
                       "type": "string"
                     }
@@ -121,7 +121,7 @@ Feature: Checks for cluster reports provided by Insights Results Aggregator
                 },
                 "errors": {
                   "type": "array",
-                  "items": [
+                  "prefixItems": [
                     {
                       "type": "string"
                     }
@@ -192,7 +192,7 @@ Feature: Checks for cluster reports provided by Insights Results Aggregator
                 },
                 "errors": {
                   "type": "array",
-                  "items": [
+                  "prefixItems": [
                     {
                       "type": "string"
                     }


### PR DESCRIPTION
# Description

Json schema validator fails if array items are not defined with "prefixItems"

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Testing steps

Run the tests =)

## Checklist
* [ ] Pylint passes for Python sources
* [ ] sources has been pre-processed by Black
* [ ] updated documentation wherever necessary
* [ ] new tests can be executed both locally and within docker container 
