### PR TITLE
Fix build version check for Content Service

### DIFF
--- a/features/steps/insights_content_service.py
+++ b/features/steps/insights_content_service.py
@@ -40,7 +40,7 @@ def check_build_time(context):
 @then("BuildVersion is in the proper format")
 def check_build_version(context):
     """Check build version taken from service output."""
-    pattern = re.compile(r"[0-9].[0-9]*")
+    pattern = re.compile(r"v[0-9].[0-9]*")
     match = re.match(pattern, context.response.json()["info"]["BuildVersion"])
     assert match.group(0), "BuildVersion is in the wrong format"
 


### PR DESCRIPTION
# Description

Fix build version check for Content Service
Context: we start to use semantic versioning and to be compatible with Go packaging rules, the version info starts with "v", for example "v1.0.0". Previously the Content Service version was set in stone to "0.1" :)

## Type of change

- Bug fix (non-breaking change which fixes an issue)
- Non-breaking change in test steps implementation

## Testing steps

N/A

## Checklist
* [ ] Pylint passes for Python sources
* [ ] sources has been pre-processed by Black
* [ ] updated documentation wherever necessary
* [ ] new tests can be executed both locally and within docker container 
