### PR TITLE
Mark aggregator version info test as local

### DIFF
--- a/features/insights-results-aggregator/smoketests.feature
+++ b/features/insights-results-aggregator/smoketests.feature
@@ -24,7 +24,7 @@ Feature: Basic set of smoke tests
       And The process should finish with exit code 0
 
 
-  @cli
+  @cli @local
   Scenario: Check if Insights Results Aggregator displays version info
     Given the system is in default state
      When I run the Insights Results Aggregator with the print-version-info command line flag


### PR DESCRIPTION
# Description

The way we are using to retrieve the git version does not work within Travis.

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Testing steps

Run `make aggregator-tests` in docker container and this test is skipped

## Checklist
* [ ] Pylint passes for Python sources
* [ ] sources has been pre-processed by Black
* [ ] updated documentation wherever necessary
* [ ] new tests can be executed both locally and within docker container 
