### PR TITLE
[CCXDEV-11000] Create more detailed tests for inference service

### DIFF
--- a/features/ccx-upgrades-inference/perform_inference.feature
+++ b/features/ccx-upgrades-inference/perform_inference.feature
@@ -28,7 +28,7 @@ Feature: Upgrade Risks Prediction inference - test well known values
       """
      Then The status code of the response is 422
 
-  Scenario: Check Inference Service response with a valid body with valid data is used in the request
+  Scenario: Check Inference Service predicts risk for degraded operator condition
     Given The CCX Inference Service is running on port 8000
      When I request the upgrade-risks-prediction endpoint in localhost:8000 with JSON
           """
@@ -85,6 +85,339 @@ Feature: Upgrade Risks Prediction inference - test well known values
                     "name": "authentication", 
                     "condition": "Degraded", 
                     "reason": "AsExpected"
+                  }
+                ]
+              }
+            }
+          """
+
+  Scenario: Check Inference Service does not predict risk for available operator conditions
+    Given The CCX Inference Service is running on port 8000
+     When I request the upgrade-risks-prediction endpoint in localhost:8000 with JSON
+          """
+            {
+              "alerts": [],
+              "operator_conditions": [
+                {
+                  "name": "authentication", 
+                  "condition": "Available", 
+                  "reason": "AsExpected"
+                }
+              ]
+            }
+          """
+     Then The status code of the response is 200
+      And The body of the response has the following schema
+          """
+            {
+              "required": [
+                "upgrade_risks_predictors"
+              ],
+              "type": "object",
+              "properties": {
+                "upgrade_risks_predictors": {
+                  "title": "Upgrade Risks Predictors",
+                  "type": "object",
+                  "properties": {
+                    "alerts": {
+                      "title": "Alerts",
+                      "type": "array"
+                    },
+                    "operator_conditions": {
+                      "title": "Degraded Operator Condition",
+                      "type": "array"
+                    }
+                  }
+                }
+              }
+            }
+          """
+      And The body of the response is the following
+          """
+            {
+              "upgrade_risks_predictors": {
+                "alerts":[],
+                "operator_conditions":[]
+              }
+            }
+          """
+
+  Scenario: Check Inference Service does not predict risk for less than 2 alerts
+    Given The CCX Inference Service is running on port 8000
+     When I request the upgrade-risks-prediction endpoint in localhost:8000 with JSON
+          """
+            {
+              "alerts": [
+                {
+                  "name": "APIRemovedInNextEUSReleaseInUse",
+                  "namespace": "openshift-kube-apiserver",
+                  "severity": "info"
+                }
+              ],
+              "operator_conditions": []
+            }
+          """
+     Then The status code of the response is 200
+      And The body of the response has the following schema
+          """
+            {
+              "required": [
+                "upgrade_risks_predictors"
+              ],
+              "type": "object",
+              "properties": {
+                "upgrade_risks_predictors": {
+                  "title": "Upgrade Risks Predictors",
+                  "type": "object",
+                  "properties": {
+                    "alerts": {
+                      "title": "Alerts",
+                      "type": "array"
+                    },
+                    "operator_conditions": {
+                      "title": "Degraded Operator Condition",
+                      "type": "array"
+                    }
+                  }
+                }
+              }
+            }
+          """
+      And The body of the response is the following
+          """
+            {
+              "upgrade_risks_predictors": {
+                "alerts":[],
+                "operator_conditions":[]
+              }
+            }
+          """
+
+  Scenario: Check Inference Service predicts risk for 2 alerts with critical severity
+    Given The CCX Inference Service is running on port 8000
+     When I request the upgrade-risks-prediction endpoint in localhost:8000 with JSON
+          """
+            {
+              "alerts": [
+                {
+                  "name": "APIRemovedInNextEUSReleaseInUse",
+                  "namespace": "openshift-kube-apiserver",
+                  "severity": "critical"
+                },
+                {
+                  "name": "OtherAlert",
+                  "namespace": "openshift-kube-apiserver",
+                  "severity": "critical"
+                }
+              ],
+              "operator_conditions": []
+            }
+          """
+     Then The status code of the response is 200
+      And The body of the response has the following schema
+          """
+            {
+              "required": [
+                "upgrade_risks_predictors"
+              ],
+              "type": "object",
+              "properties": {
+                "upgrade_risks_predictors": {
+                  "title": "Upgrade Risks Predictors",
+                  "type": "object",
+                  "properties": {
+                    "alerts": {
+                      "title": "Alerts",
+                      "type": "array"
+                    },
+                    "operator_conditions": {
+                      "title": "Degraded Operator Condition",
+                      "type": "array"
+                    }
+                  }
+                }
+              }
+            }
+          """
+      And The body of the response is the following
+          """
+            {
+              "upgrade_risks_predictors": {
+                "alerts":[
+                  {
+                    "name": "APIRemovedInNextEUSReleaseInUse",
+                    "namespace": "openshift-kube-apiserver",
+                    "severity": "critical"
+                  },
+                  {
+                    "name": "OtherAlert",
+                    "namespace": "openshift-kube-apiserver",
+                    "severity": "critical"
+                  }
+                ],
+                "operator_conditions":[]
+              }
+            }
+          """
+
+Scenario: Check Inference Service does not predict risk for 2 alerts with info severity
+    Given The CCX Inference Service is running on port 8000
+     When I request the upgrade-risks-prediction endpoint in localhost:8000 with JSON
+          """
+            {
+              "alerts": [
+                {
+                  "name": "APIRemovedInNextEUSReleaseInUse",
+                  "namespace": "openshift-kube-apiserver",
+                  "severity": "info"
+                },
+                {
+                  "name": "OtherAlert",
+                  "namespace": "openshift-kube-apiserver",
+                  "severity": "info"
+                }
+              ],
+              "operator_conditions": []
+            }
+          """
+     Then The status code of the response is 200
+      And The body of the response has the following schema
+          """
+            {
+              "required": [
+                "upgrade_risks_predictors"
+              ],
+              "type": "object",
+              "properties": {
+                "upgrade_risks_predictors": {
+                  "title": "Upgrade Risks Predictors",
+                  "type": "object",
+                  "properties": {
+                    "alerts": {
+                      "title": "Alerts",
+                      "type": "array"
+                    },
+                    "operator_conditions": {
+                      "title": "Degraded Operator Condition",
+                      "type": "array"
+                    }
+                  }
+                }
+              }
+            }
+          """
+      And The body of the response is the following
+          """
+            {
+              "upgrade_risks_predictors": {
+                "alerts":[],
+                "operator_conditions":[]
+              }
+            }
+          """
+
+  Scenario: Check Inference Service does not predict risk for 1 alert with critical severity
+    Given The CCX Inference Service is running on port 8000
+     When I request the upgrade-risks-prediction endpoint in localhost:8000 with JSON
+          """
+            {
+              "alerts": [
+                {
+                  "name": "APIRemovedInNextEUSReleaseInUse",
+                  "namespace": "openshift-kube-apiserver",
+                  "severity": "critical"
+                }
+              ],
+              "operator_conditions": []
+            }
+          """
+     Then The status code of the response is 200
+      And The body of the response has the following schema
+          """
+            {
+              "required": [
+                "upgrade_risks_predictors"
+              ],
+              "type": "object",
+              "properties": {
+                "upgrade_risks_predictors": {
+                  "title": "Upgrade Risks Predictors",
+                  "type": "object",
+                  "properties": {
+                    "alerts": {
+                      "title": "Alerts",
+                      "type": "array"
+                    },
+                    "operator_conditions": {
+                      "title": "Degraded Operator Condition",
+                      "type": "array"
+                    }
+                  }
+                }
+              }
+            }
+          """
+      And The body of the response is the following
+          """
+            {
+              "upgrade_risks_predictors": {
+                "alerts": [],
+                "operator_conditions":[]
+              }
+            }
+          """
+
+  Scenario: Check Inference Service predicts risk for not available operator condition
+    Given The CCX Inference Service is running on port 8000
+     When I request the upgrade-risks-prediction endpoint in localhost:8000 with JSON
+          """
+            {
+              "alerts": [],
+              "operator_conditions": [
+                {
+                  "name": "authentication", 
+                  "condition": "Not Available", 
+                  "reason": "AsExpected"
+                }
+              ]
+            }
+          """
+     Then The status code of the response is 200
+      And The body of the response has the following schema
+          """
+            {
+              "required": [
+                "upgrade_risks_predictors"
+              ],
+              "type": "object",
+              "properties": {
+                "upgrade_risks_predictors": {
+                  "title": "Upgrade Risks Predictors",
+                  "type": "object",
+                  "properties": {
+                    "alerts": {
+                      "title": "Alerts",
+                      "type": "array"
+                    },
+                    "operator_conditions": {
+                      "title": "Degraded Operator Condition",
+                      "type": "array"
+                    }
+                  }
+                }
+              }
+            }
+          """
+      And The body of the response is the following
+          """
+            {
+              "upgrade_risks_predictors": {
+                "alerts":[],
+                "operator_conditions": [
+                  {
+                    "name":"authentication",
+                    "condition":"Not Available",
+                    "reason":"AsExpected"
                   }
                 ]
               }

--- a/features/ccx-upgrades-inference/perform_inference.feature
+++ b/features/ccx-upgrades-inference/perform_inference.feature
@@ -1,17 +1,17 @@
 Feature: Upgrade Risks Prediction inference - test well known values
 
-  Scenario: Check Inference Service response with no body is sent in the request
+  Background: Inference service is running and well configured to work
     Given The CCX Inference Service is running on port 8000
+
+  Scenario: Check Inference Service response with no body is sent in the request
      When I request the upgrade-risks-prediction endpoint in localhost:8000
      Then The status code of the response is 422
 
   Scenario: Check Inference Service response with an invalid body is used in the request
-    Given The CCX Inference Service is running on port 8000
      When I request the upgrade-risks-prediction endpoint in localhost:8000 with junk in the body
      Then The status code of the response is 422
     
   Scenario: Check Inference Service response with a valid body with invalid data is used in the request
-    Given The CCX Inference Service is running on port 8000
      When I request the upgrade-risks-prediction endpoint in localhost:8000 with JSON
       """
         {
@@ -29,7 +29,6 @@ Feature: Upgrade Risks Prediction inference - test well known values
      Then The status code of the response is 422
 
   Scenario: Check Inference Service predicts risk for degraded operator condition
-    Given The CCX Inference Service is running on port 8000
      When I request the upgrade-risks-prediction endpoint in localhost:8000 with JSON
           """
             {
@@ -92,7 +91,6 @@ Feature: Upgrade Risks Prediction inference - test well known values
           """
 
   Scenario: Check Inference Service does not predict risk for available operator conditions
-    Given The CCX Inference Service is running on port 8000
      When I request the upgrade-risks-prediction endpoint in localhost:8000 with JSON
           """
             {
@@ -143,7 +141,6 @@ Feature: Upgrade Risks Prediction inference - test well known values
           """
 
   Scenario: Check Inference Service predicts risk for 2 alerts with critical severity
-    Given The CCX Inference Service is running on port 8000
      When I request the upgrade-risks-prediction endpoint in localhost:8000 with JSON
           """
             {
@@ -210,7 +207,6 @@ Feature: Upgrade Risks Prediction inference - test well known values
           """
 
 Scenario: Check Inference Service does not predict risk for 2 alerts with info severity
-    Given The CCX Inference Service is running on port 8000
      When I request the upgrade-risks-prediction endpoint in localhost:8000 with JSON
           """
             {
@@ -266,7 +262,6 @@ Scenario: Check Inference Service does not predict risk for 2 alerts with info s
           """
 
   Scenario: Check Inference Service does not predict risk for 1 alert with critical severity
-    Given The CCX Inference Service is running on port 8000
      When I request the upgrade-risks-prediction endpoint in localhost:8000 with JSON
           """
             {
@@ -317,7 +312,6 @@ Scenario: Check Inference Service does not predict risk for 2 alerts with info s
           """
 
   Scenario: Check Inference Service predicts risk for not available operator condition
-    Given The CCX Inference Service is running on port 8000
      When I request the upgrade-risks-prediction endpoint in localhost:8000 with JSON
           """
             {

--- a/features/ccx-upgrades-inference/perform_inference.feature
+++ b/features/ccx-upgrades-inference/perform_inference.feature
@@ -142,57 +142,6 @@ Feature: Upgrade Risks Prediction inference - test well known values
             }
           """
 
-  Scenario: Check Inference Service does not predict risk for less than 2 alerts
-    Given The CCX Inference Service is running on port 8000
-     When I request the upgrade-risks-prediction endpoint in localhost:8000 with JSON
-          """
-            {
-              "alerts": [
-                {
-                  "name": "APIRemovedInNextEUSReleaseInUse",
-                  "namespace": "openshift-kube-apiserver",
-                  "severity": "info"
-                }
-              ],
-              "operator_conditions": []
-            }
-          """
-     Then The status code of the response is 200
-      And The body of the response has the following schema
-          """
-            {
-              "required": [
-                "upgrade_risks_predictors"
-              ],
-              "type": "object",
-              "properties": {
-                "upgrade_risks_predictors": {
-                  "title": "Upgrade Risks Predictors",
-                  "type": "object",
-                  "properties": {
-                    "alerts": {
-                      "title": "Alerts",
-                      "type": "array"
-                    },
-                    "operator_conditions": {
-                      "title": "Degraded Operator Condition",
-                      "type": "array"
-                    }
-                  }
-                }
-              }
-            }
-          """
-      And The body of the response is the following
-          """
-            {
-              "upgrade_risks_predictors": {
-                "alerts":[],
-                "operator_conditions":[]
-              }
-            }
-          """
-
   Scenario: Check Inference Service predicts risk for 2 alerts with critical severity
     Given The CCX Inference Service is running on port 8000
      When I request the upgrade-risks-prediction endpoint in localhost:8000 with JSON


### PR DESCRIPTION
# Description

Add tests checking behavior of inference service for different combinations of input alerts and operator conditions.

Fixes [CCXDEV-11000](https://issues.redhat.com/browse/CCXDEV-11000)

## Type of change

- New test scenario added into existing feature file

## Testing steps

Tests have been locally run with `make inference-service-tests`

## Checklist
* [ ] Pylint passes for Python sources
* [ ] sources has been pre-processed by Black
* [ ] updated documentation wherever necessary
* [x] new tests can be executed both locally and within docker container 
