### PR TITLE
Alternate URL to retrieve namespaces for cluster + other minor enhancements

### DIFF
--- a/docs/scenarios_list.md
+++ b/docs/scenarios_list.md
@@ -276,6 +276,11 @@ nav_order: 3
 * Accessing Smart Proxy REST API endpoint to retrieve DVO namespaces for known cluster without DVO namespaces
 * Accessing Smart Proxy REST API endpoint to retrieve DVO namespaces for improper cluster UUID
 * Accessing Smart Proxy REST API endpoint to retrieve DVO namespaces for improper organization
+* Accessing Smart Proxy REST API endpoint to retrieve DVO namespaces when cluster is not specified
+* Accessing Smart Proxy REST API endpoint to retrieve DVO namespaces for not known cluster
+* Accessing Smart Proxy REST API endpoint to retrieve DVO namespaces for known cluster without DVO namespaces
+* Accessing Smart Proxy REST API endpoint to retrieve DVO namespaces for improper cluster UUID
+* Accessing Smart Proxy REST API endpoint to retrieve DVO namespaces for improper organization
 
 ## [`DVO_Recommendations/namespace_disable.feature`](https://github.com/RedHatInsights/insights-behavioral-spec/blob/main/features/DVO_Recommendations/namespace_disable.feature)
 

--- a/features/DVO_Recommendations/Smart_Proxy_REST_API.feature
+++ b/features/DVO_Recommendations/Smart_Proxy_REST_API.feature
@@ -200,3 +200,18 @@ Feature: Behaviour specification for new REST API endpoints that will be impleme
               "status": "forbidden"
           }
           """
+
+
+  Scenario: Accessing Smart Proxy REST API endpoint to retrieve DVO namespaces when cluster is not specified
+    Given REST API for Smart Proxy is available
+      And REST API service prefix is /api/v2
+      And organization TEST_ORG is registered
+      And user TEST_USER is member of TEST_USER organization
+      And access token is generated to TEST_USER
+     When TEST_USER make HTTP GET request to REST API endpoint namespaces/dvo/cluster using their access token
+     Then The status of the response is 400
+      And The body of the response is the following
+          """
+          {
+              "status": "cluster UUID is not provided"
+          }

--- a/features/DVO_Recommendations/Smart_Proxy_REST_API.feature
+++ b/features/DVO_Recommendations/Smart_Proxy_REST_API.feature
@@ -215,3 +215,75 @@ Feature: Behaviour specification for new REST API endpoints that will be impleme
           {
               "status": "cluster UUID is not provided"
           }
+          """
+
+
+  Scenario: Accessing Smart Proxy REST API endpoint to retrieve DVO namespaces for not known cluster
+    Given REST API for Smart Proxy is available
+      And REST API service prefix is /api/v2
+      And organization TEST_ORG is registered
+      And user TEST_USER is member of TEST_USER organization
+      And access token is generated to TEST_USER
+      And CCX data pipeline has DVO results stored in its database for following cluster
+          | Organization ID | Cluster name                         |
+          | TEST_ORG        | 00000001-0000-0000-0000-000000000000 |
+     When TEST_USER make HTTP GET request to REST API endpoint cluster/ffffffff-ffff-ffff-ffff-000000000000/namespaces/dvo using their access token
+     Then The status of the response is 404
+      And The body of the response is the following
+          """
+          {
+              "status": "cluster not found"
+          }
+          """
+
+
+  Scenario: Accessing Smart Proxy REST API endpoint to retrieve DVO namespaces for known cluster without DVO namespaces
+    Given REST API for Smart Proxy is available
+      And REST API service prefix is /api/v2
+      And organization TEST_ORG is registered
+      And user TEST_USER is member of TEST_USER organization
+      And access token is generated to TEST_USER
+     When TEST_USER make HTTP GET request to REST API endpoint cluster/00000001-0000-0000-0000-000000000000/namespaces/dvo/ using their access token
+     Then The status of the response is 404
+      And The body of the response is the following
+          """
+          {
+              "status": "namespace not found"
+          }
+          """
+
+
+  Scenario: Accessing Smart Proxy REST API endpoint to retrieve DVO namespaces for improper cluster UUID
+    Given REST API for Smart Proxy is available
+      And REST API service prefix is /api/v2
+      And organization TEST_ORG is registered
+      And user TEST_USER is member of TEST_USER organization
+      And access token is generated to TEST_USER
+      And CCX data pipeline has DVO results stored in its database for following cluster
+          | Organization ID | Cluster name                         |
+          | TEST_ORG        | 00000001-0000-0000-0000-000000000000 |
+     When TEST_USER make HTTP GET request to REST API endpoint cluster/foo-bar-baz/namespaces/dvo/ using their access token
+     Then The status of the response is 400
+      And The body of the response is the following
+          """
+          {
+              "status": "improper cluster name"
+          }
+          """
+
+
+  Scenario: Accessing Smart Proxy REST API endpoint to retrieve DVO namespaces for improper organization
+    Given REST API for Smart Proxy is available
+      And REST API service prefix is /api/v2
+      And organization TEST_ORG is NOT registered
+      And user TEST_USER is member of TEST_USER organization
+      And access token is generated to TEST_USER
+     When TEST_USER make HTTP GET request to REST API endpoint cluster/ffffffff-ffff-ffff-ffff-000000000000/namespaces/dvo/ using their access token
+     Then The status of the response is 403
+      And The body of the response is the following
+          """
+          {
+              "status": "forbidden"
+          }
+          """
+

--- a/features/DVO_Recommendations/Smart_Proxy_REST_API.feature
+++ b/features/DVO_Recommendations/Smart_Proxy_REST_API.feature
@@ -14,6 +14,7 @@ Feature: Behaviour specification for new REST API endpoints that will be impleme
         the namespace ID, the namespace display name if available, the cluster ID under
         which this namespace is created (repeated input), and the number of affecting
         recommendations for this namespace as well.
+        Both GETers have the same meaning, just the order of selectors is different.
 
         GET /namespace/dvo/{namespace_id}/info
         Returns information about the requested namespace. Contains the display name,


### PR DESCRIPTION
# Description

Alternate URL to retrieve namespaces for cluster + other minor enhancements

## Type of change

- New test scenario added into existing feature file

## Testing steps

N/A

## Checklist
* [ ] Pylint passes for Python sources
* [ ] sources has been pre-processed by Black
* [ ] updated documentation wherever necessary
* [ ] new tests can be executed both locally and within docker container 
