### PR TITLE
Linter settings: don't ignore E402

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.ruff]
 select = ["E", "F", "W", "C", "D"]
-ignore = ["F601", "D211", "D213", "C401", "E402"]
+ignore = ["F601", "D211", "D213", "C401"]
 
 line-length = 100
 


### PR DESCRIPTION
# Description

Linter settings: don't ignore `E402`

## Type of change

- Configuration update

## Testing steps

To be checked on CI.

## Checklist
* [ ] Pylint passes for Python sources
* [ ] sources has been pre-processed by Black
* [ ] updated documentation wherever necessary
* [ ] new tests can be executed both locally and within docker container 
