### PR TITLE
Notification service - remove obsolte option from displayed help

### DIFF
--- a/features/steps/notification_service.py
+++ b/features/steps/notification_service.py
@@ -151,7 +151,6 @@ def check_help_from_ccx_notification_service(context):
         "  -show-authors",
         "  -show-configuration",
         "  -show-version",
-        "  -weekly-reports",
     ]
 
     # preliminary checks


### PR DESCRIPTION
# Description

This option is being removed in https://github.com/RedHatInsights/ccx-notification-service/pull/597.

Fixes CCXDEV-6961 partially

## Type of change

- Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Testing steps

CI of https://github.com/RedHatInsights/ccx-notification-service/pull/597

## Checklist
* [x] Pylint passes for Python sources
* [x] sources has been pre-processed by Black
* [ ] updated documentation wherever necessary
* [ ] new tests can be executed both locally and within docker container 
