### PR TITLE
[ccx-notification-service] configure only one destination

### DIFF
--- a/docs/scenarios_list.md
+++ b/docs/scenarios_list.md
@@ -160,6 +160,14 @@ nav_order: 3
 * Ability to search for issues on Advanced Cluster Management for one local cluster
 * Ability to search for issues on Advanced Cluster Management for one managed cluster
 
+## [`ACM/upgrade_risks.feature`](https://github.com/RedHatInsights/insights-behavioral-spec/blob/main/features/ACM/upgrade_risks.feature)
+
+* Displaying 1 cluster with high upgrade risk
+* Displaying 1 cluster with low upgrade risk
+* Displaying the overview of the clusters at risk
+* Displaying the upgrade risk for 100 clusters or less
+* Displaying the upgrade risk for more than 100 clusters
+
 ## [`Insights_Advisor/affected_clusters_filtering.feature`](https://github.com/RedHatInsights/insights-behavioral-spec/blob/main/features/Insights_Advisor/affected_clusters_filtering.feature)
 
 * Default filtering on Advisor's "Recommendations" page on Hybrid Cloud Console with five recommendations and four clusters
@@ -838,7 +846,8 @@ nav_order: 3
 ## [`ccx-notification-service/configuration.feature`](https://github.com/RedHatInsights/insights-behavioral-spec/blob/main/features/ccx-notification-service/configuration.feature)
 
 * Check that notification service exits with exit code 1 if no destination is configured
-* check that service exits with status 4 if rules content cannot be fetched
+* Check that notification-to-notification-backend is not started and exits with status 4 if rules cannot be fetched
+* Check that notification-to-service-log is not started and exits with status 4 if rules cannot be fetched
 
 ## [`ccx-notification-service/customer_notifications.feature`](https://github.com/RedHatInsights/insights-behavioral-spec/blob/main/features/ccx-notification-service/customer_notifications.feature)
 

--- a/features/ACM/upgrade_risks.feature
+++ b/features/ACM/upgrade_risks.feature
@@ -37,13 +37,13 @@ Feature: Upgrade risks
 
   Scenario: Displaying the upgrade risk for 100 clusters or less
     Given user USER1 owns a maximum of 100 managed clusters
-     When the ACM control plane requests the upgrade risk from console.redhat.com  
+     When the ACM control plane requests the upgrade risk from console.redhat.com
       And all the clusters are requested in a single call
      Then console.redhat.com returns the upgrade risk for all the requested clusters
 
 
   Scenario: Displaying the upgrade risk for more than 100 clusters
     Given user USER1 owns 101 or more managed clusters
-     When the ACM control plane requests the upgrade risk from console.redhat.com 
+     When the ACM control plane requests the upgrade risk from console.redhat.com
       And all the clusters are requested in a single call
      Then console.redhat.com returns an error

--- a/features/ccx-notification-service/configuration.feature
+++ b/features/ccx-notification-service/configuration.feature
@@ -28,7 +28,7 @@ Feature: Customer Notifications configuration and exit codes
           | No known event destination configured. Aborting. | yes        |
 
 
-  Scenario: check that service exits with status 4 if rules content cannot be fetched
+  Scenario: Check that notification-to-notification-backend is not started and exits with status 4 if rules cannot be fetched
     Given the service is expected to exit with code 4
      When I start the CCX Notification Service with the --instant-reports command line flag
           | val                                                    | var                        |
@@ -38,6 +38,9 @@ Feature: Customer Notifications configuration and exit codes
      Then it should have sent 0 notification events to Kafka
       And it should have sent 0 notification events to Service Log
       And the process should exit with status code set to 4
+
+  Scenario: Check that notification-to-service-log is not started and exits with status 4 if rules cannot be fetched
+    Given the service is expected to exit with code 4
      When I start the CCX Notification Service with the --instant-reports command line flag
           | val                                                    | var                        |
           | CCX_NOTIFICATION_SERVICE__KAFKA_BROKER__ENABLED        | false                      |

--- a/features/ccx-notification-service/configuration.feature
+++ b/features/ccx-notification-service/configuration.feature
@@ -33,6 +33,14 @@ Feature: Customer Notifications configuration and exit codes
      When I start the CCX Notification Service with the --instant-reports command line flag
           | val                                                    | var                        |
           | CCX_NOTIFICATION_SERVICE__KAFKA_BROKER__ENABLED        | true                       |
+          | CCX_NOTIFICATION_SERVICE__SERVICE_LOG__ENABLED         | false                      |
+          | CCX_NOTIFICATION_SERVICE__DEPENDENCIES__CONTENT_SERVER | unresolved_url:8082/api/v1 |
+     Then it should have sent 0 notification events to Kafka
+      And it should have sent 0 notification events to Service Log
+      And the process should exit with status code set to 4
+     When I start the CCX Notification Service with the --instant-reports command line flag
+          | val                                                    | var                        |
+          | CCX_NOTIFICATION_SERVICE__KAFKA_BROKER__ENABLED        | false                      |
           | CCX_NOTIFICATION_SERVICE__SERVICE_LOG__ENABLED         | true                       |
           | CCX_NOTIFICATION_SERVICE__DEPENDENCIES__CONTENT_SERVER | unresolved_url:8082/api/v1 |
      Then it should have sent 0 notification events to Kafka


### PR DESCRIPTION
# Description

After https://github.com/RedHatInsights/ccx-notification-service/pull/599, the notification service will only allow one integration to be enabled.

## Type of change

- Non-breaking change in test steps implementation

## Testing steps

Test was run locally

## Checklist
* [ ] Pylint passes for Python sources
* [ ] sources has been pre-processed by Black
* [ ] updated documentation wherever necessary
* [ ] new tests can be executed both locally and within docker container 
