### PR TITLE
[CCXDEV-11815] Run aggregator consumer tests in non-local env too

### DIFF
--- a/features/insights-results-aggregator/consumer.feature
+++ b/features/insights-results-aggregator/consumer.feature
@@ -10,23 +10,23 @@ Feature: Consuming and processing results from Kafka broker
       And database user is set to postgres
       And database password is set to postgres
       And aggregator database is in initial state
+      And Kafka broker is available
+      And Kafka topic "ccx.ocp.results" is empty
      When database connection is established
       And I migrate aggregator database to latest version
       And I read current migration number from database
      Then I should see that migration #31 is returned
-     When I retrieve a list of all applications running under JVM
-     Then I should find the following application kafka.Kafka
     Given Insights Results Aggregator service is started in background
      When I wait 5 seconds
 
 
-  @managed @local
+  @managed
   Scenario: Check if Insights Results Aggregator is able to consume messages and store results into database
      When I access endpoint /organizations/123/clusters using HTTP GET method using token for organization 123 account number 456, and user 789
      Then The status code of the response is 200
       And The status message of the response is "ok"
       And I should retrieve empty list of clusters
-     When I send rules results 'tutorial_only.json' into topic 'ccx.ocp.results' to local broker
+     When I send rules results 'tutorial_only.json' into topic 'ccx.ocp.results'
       And I wait 5 seconds
      When I access endpoint /organizations/123/clusters using HTTP GET method using token for organization 123 account number 456, and user 789
      Then The status code of the response is 200
@@ -38,15 +38,15 @@ Feature: Consuming and processing results from Kafka broker
      Then Insights Results Aggregator process should terminate
 
 
-  @managed @local
+  @managed
   Scenario: Check if Insights Results Aggregator is able to consume messages and store results into database for multiple results
      When I access endpoint /organizations/123/clusters using HTTP GET method using token for organization 123 account number 456, and user 789
      Then The status code of the response is 200
       And The status message of the response is "ok"
       And I should retrieve empty list of clusters
-     When I send rules results 'tutorial_only.json' into topic 'ccx.ocp.results' to local broker
+     When I send rules results 'tutorial_only.json' into topic 'ccx.ocp.results'
       And I wait 5 seconds
-      And I send rules results '05_rules_hits.json' into topic 'ccx.ocp.results' to local broker
+      And I send rules results '05_rules_hits.json' into topic 'ccx.ocp.results'
       And I wait 5 seconds
      When I access endpoint /organizations/123/clusters using HTTP GET method using token for organization 123 account number 456, and user 789
      Then The status code of the response is 200
@@ -58,15 +58,15 @@ Feature: Consuming and processing results from Kafka broker
      Then Insights Results Aggregator process should terminate
 
 
-  @managed @local
+  @managed
   Scenario: Check if Insights Results Aggregator is able to consume messages and store results into database for multiple clusters
      When I access endpoint /organizations/123/clusters using HTTP GET method using token for organization 123 account number 456, and user 789
      Then The status code of the response is 200
       And The status message of the response is "ok"
       And I should retrieve empty list of clusters
-     When I send rules results '05_rules_hits.json' into topic 'ccx.ocp.results' to local broker
+     When I send rules results '05_rules_hits.json' into topic 'ccx.ocp.results'
       And I wait 5 seconds
-      And I send rules results '05_rules_hits_different_cluster.json' into topic 'ccx.ocp.results' to local broker
+      And I send rules results '05_rules_hits_different_cluster.json' into topic 'ccx.ocp.results'
       And I wait 5 seconds
      When I access endpoint /organizations/123/clusters using HTTP GET method using token for organization 123 account number 456, and user 789
      Then The status code of the response is 200
@@ -79,13 +79,13 @@ Feature: Consuming and processing results from Kafka broker
      Then Insights Results Aggregator process should terminate
 
 
-  @managed @local
+  @managed
   Scenario: Check rule hits after Insights Results Aggregator consumes messages and stores results into database
      When I access endpoint /organizations/123/clusters using HTTP GET method using token for organization 123 account number 456, and user 789
      Then The status code of the response is 200
       And The status message of the response is "ok"
       And I should retrieve empty list of clusters
-     When I send rules results 'tutorial_only.json' into topic 'ccx.ocp.results' to local broker
+     When I send rules results 'tutorial_only.json' into topic 'ccx.ocp.results'
       And I wait 5 seconds
      When I access endpoint /organizations/123/clusters using HTTP GET method using token for organization 123 account number 456, and user 789
      Then The status code of the response is 200
@@ -104,13 +104,13 @@ Feature: Consuming and processing results from Kafka broker
      Then Insights Results Aggregator process should terminate
 
 
-  @managed @local
+  @managed
   Scenario: Check rule hits after Insights Results Aggregator consumes message and stores results into database for multiple results
      When I access endpoint /organizations/123/clusters using HTTP GET method using token for organization 123 account number 456, and user 789
      Then The status code of the response is 200
       And The status message of the response is "ok"
       And I should retrieve empty list of clusters
-     When I send rules results '05_rules_hits.json' into topic 'ccx.ocp.results' to local broker
+     When I send rules results '05_rules_hits.json' into topic 'ccx.ocp.results'
       And I wait 5 seconds
      When I access endpoint /organizations/123/clusters using HTTP GET method using token for organization 123 account number 456, and user 789
      Then The status code of the response is 200
@@ -133,15 +133,15 @@ Feature: Consuming and processing results from Kafka broker
      Then Insights Results Aggregator process should terminate
 
 
-  @managed @local
+  @managed
   Scenario: Check rule hits after Insights Results Aggregator consumes two messages when the second is older then the first one
      When I access endpoint /organizations/123/clusters using HTTP GET method using token for organization 123 account number 456, and user 789
      Then The status code of the response is 200
       And The status message of the response is "ok"
       And I should retrieve empty list of clusters
-     When I send rules results 'tutorial_only.json' into topic 'ccx.ocp.results' to local broker
+     When I send rules results 'tutorial_only.json' into topic 'ccx.ocp.results'
       And I wait 5 seconds
-     When I send rules results '05_rules_hits.json' into topic 'ccx.ocp.results' to local broker
+     When I send rules results '05_rules_hits.json' into topic 'ccx.ocp.results'
       And I wait 5 seconds
      When I access endpoint /organizations/123/clusters using HTTP GET method using token for organization 123 account number 456, and user 789
      Then The status code of the response is 200
@@ -160,15 +160,15 @@ Feature: Consuming and processing results from Kafka broker
      Then Insights Results Aggregator process should terminate
 
 
-  @managed @local
+  @managed
   Scenario: Check rule hits after Insights Results Aggregator consumes two messages when the second is newer then the first one
      When I access endpoint /organizations/123/clusters using HTTP GET method using token for organization 123 account number 456, and user 789
      Then The status code of the response is 200
       And The status message of the response is "ok"
       And I should retrieve empty list of clusters
-     When I send rules results '05_rules_hits.json' into topic 'ccx.ocp.results' to local broker
+     When I send rules results '05_rules_hits.json' into topic 'ccx.ocp.results'
       And I wait 5 seconds
-     When I send rules results 'tutorial_only.json' into topic 'ccx.ocp.results' to local broker
+     When I send rules results 'tutorial_only.json' into topic 'ccx.ocp.results'
       And I wait 5 seconds
      When I access endpoint /organizations/123/clusters using HTTP GET method using token for organization 123 account number 456, and user 789
      Then The status code of the response is 200
@@ -187,15 +187,15 @@ Feature: Consuming and processing results from Kafka broker
      Then Insights Results Aggregator process should terminate
 
 
-  @managed @local
+  @managed
   Scenario: Check rule hits after Insights Results Aggregator consumes message and stores results into database for multiple clusters
      When I access endpoint /organizations/123/clusters using HTTP GET method using token for organization 123 account number 456, and user 789
      Then The status code of the response is 200
       And The status message of the response is "ok"
       And I should retrieve empty list of clusters
-     When I send rules results '05_rules_hits.json' into topic 'ccx.ocp.results' to local broker
+     When I send rules results '05_rules_hits.json' into topic 'ccx.ocp.results'
       And I wait 5 seconds
-     When I send rules results '05_rules_hits_different_cluster.json' into topic 'ccx.ocp.results' to local broker
+     When I send rules results '05_rules_hits_different_cluster.json' into topic 'ccx.ocp.results'
       And I wait 5 seconds
      When I access endpoint /organizations/123/clusters using HTTP GET method using token for organization 123 account number 456, and user 789
      Then The status code of the response is 200
@@ -230,13 +230,13 @@ Feature: Consuming and processing results from Kafka broker
      Then Insights Results Aggregator process should terminate
 
 
-  @managed @local
+  @managed
   Scenario: Check rule hits after Insights Results Aggregator consumes message with no results
      When I access endpoint /organizations/123/clusters using HTTP GET method using token for organization 123 account number 456, and user 789
      Then The status code of the response is 200
       And The status message of the response is "ok"
       And I should retrieve empty list of clusters
-     When I send rules results 'no_hits.json' into topic 'ccx.ocp.results' to local broker
+     When I send rules results 'no_hits.json' into topic 'ccx.ocp.results'
       And I wait 5 seconds
      When I access endpoint /organizations/123/clusters using HTTP GET method using token for organization 123 account number 456, and user 789
      Then The status code of the response is 200

--- a/features/insights-results-aggregator/smoketests.feature
+++ b/features/insights-results-aggregator/smoketests.feature
@@ -24,7 +24,7 @@ Feature: Basic set of smoke tests
       And The process should finish with exit code 0
 
 
-  @cli @local
+  @cli
   Scenario: Check if Insights Results Aggregator displays version info
     Given the system is in default state
      When I run the Insights Results Aggregator with the print-version-info command line flag

--- a/features/steps/insights_results_aggregator.py
+++ b/features/steps/insights_results_aggregator.py
@@ -419,13 +419,16 @@ def check_disabled_rules_list(context):
             raise KeyError(f"Rule {expected_rule} was not returned by the service")
 
 
-@when("I send rules results '{filename}' into topic '{topic}' to {broker_type} broker")
-def send_rules_results_to_kafka(context, filename, topic, broker_type):
+@when("I send rules results '{filename}' into topic '{topic}'")
+def send_rules_results_to_kafka(context, filename, topic):
     """Send rule results into seleted topic on selected broker."""
     full_path = f"{DATA_DIRECTORY}/{filename}"
     with open(full_path, "r") as fin:
         payload = fin.read().encode("utf-8")
-        if broker_type == "local":
+        if hasattr(context, 'kafka_hostname') and hasattr(context, 'kafka_port'):
+            kafka_util.send_event(f"{context.kafka_hostname}:{context.kafka_port}", topic, payload)
+        else:
+            # try localhost or raise exception
             kafka_util.send_event("localhost:9092", topic, payload)
 
 


### PR DESCRIPTION
# Description

- Remove `@local` tag from aggregator consumer tests so they also run in docker/CI
- Prepare tests to run either with given kafka environment variables, or against local kafka running on `localhost:9092` (to keep previous behaviour)

Fixes CCXDEV-11815

## Type of change

- Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Testing steps

Executed the aggregator tests locally and within container

```
12 features passed, 0 failed, 0 skipped
128 scenarios passed, 0 failed, 3 skipped
2420 steps passed, 0 failed, 6 skipped, 0 undefined
```

## Checklist
* [ ] Pylint passes for Python sources
* [ ] sources has been pre-processed by Black
* [ ] updated documentation wherever necessary
* [x] new tests can be executed both locally and within docker container
* [ ] new tests have been included in scenario list (make update-scenarios)
