### PR TITLE
Make print-version-info a local test

### DIFF
--- a/features/insights-results-aggregator/smoketests.feature
+++ b/features/insights-results-aggregator/smoketests.feature
@@ -24,7 +24,8 @@ Feature: Basic set of smoke tests
       And The process should finish with exit code 0
 
 
-  @cli
+  # Marked as local as it cannot be run properly in Travis
+  @cli @local
   Scenario: Check if Insights Results Aggregator displays version info
     Given the system is in default state
      When I run the Insights Results Aggregator with the print-version-info command line flag


### PR DESCRIPTION
# Description

This test runs properly in docker container but not in travis, as the Git command used to retrieve the version (`git describe`) for the build is not working there.

## Type of change

- Configuration update

## Testing steps

None

## Checklist
* [ ] Pylint passes for Python sources
* [ ] sources has been pre-processed by Black
* [ ] updated documentation wherever necessary
* [ ] new tests can be executed both locally and within docker container
* [ ] new tests have been included in scenario list (make update-scenarios)
