### PR TITLE
Refactor version info check for aggregator

### DIFF
--- a/requirements/insights_results_aggregator.txt
+++ b/requirements/insights_results_aggregator.txt
@@ -1,0 +1,4 @@
+behave
+pytest
+requests
+semver

--- a/requirements/requirements_docker.txt
+++ b/requirements/requirements_docker.txt
@@ -8,5 +8,5 @@ requests
 minio
 jsonschema
 kafka-python
-
 virtualenv
+semver


### PR DESCRIPTION
# Description

version info is not obtained with `git describe --always --tags --abbrev=0`. So it can either be a tag or a full commit SHA, but not an empty string.

## Type of change

- Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Testing steps

Run tests against aggregator after https://github.com/RedHatInsights/insights-results-aggregator/pull/1845 is merged (for now, tested locally)

## Checklist
* [ ] Pylint passes for Python sources
* [ ] sources has been pre-processed by Black
* [ ] updated documentation wherever necessary
* [ ] new tests can be executed both locally and within docker container
* [ ] new tests have been included in scenario list (make update-scenarios)
