### PR TITLE
[CCXDEV-11745] cover read-errors-cleanup functionality of notification writer

### DIFF
--- a/docs/scenarios_list.md
+++ b/docs/scenarios_list.md
@@ -920,6 +920,12 @@ nav_order: 3
 * Check the ability to clean up old records from `reported` table if the table contains one old report.
 * Check the ability to clean up old records from `reported` table if the table contains two old reports.
 
+## [`ccx-notification-writer/cleanup_read_errors.feature`](https://github.com/RedHatInsights/insights-behavioral-spec/blob/main/features/ccx-notification-writer/cleanup_read_errors.feature)
+
+* Check the ability to clean up old records from `read_errors` table if the table is empty.
+* Check the ability to clean up old records from `read_errors` table if the table contains one old report.
+* Check the ability to clean up old records from `read_errors` table if the table contains two old reports.
+
 ## [`ccx-notification-writer/cli_flags.feature`](https://github.com/RedHatInsights/insights-behavioral-spec/blob/main/features/ccx-notification-writer/cli_flags.feature)
 
 * Check if CCX Notification Writer displays help message

--- a/features/ccx-notification-writer/cleanup_read_errors.feature
+++ b/features/ccx-notification-writer/cleanup_read_errors.feature
@@ -1,0 +1,75 @@
+@notification_writer
+Feature: Ability to clean up records stored in read_errors table
+
+
+  Background: Dependencies are prepared
+  Given the system is in default state
+    And the database is named notification
+    And database user is set to postgres
+    And database password is set to postgres
+    And database connection is established
+    And CCX Notification database is empty
+    And CCX Notification database is migrated to version latest
+
+
+  @cli @database @database-write
+  Scenario: Check the ability to clean up old records from `read_errors` table if the table is empty.
+     When I select all rows from table read_errors
+     Then I should get 0 rows
+     When I close database connection
+     Then I should be disconnected
+     When I start the CCX Notification Writer with the --read-errors-cleanup command line flag
+     Then the process should exit with status code set to 0
+     When database connection is established
+      And I select all rows from table read_errors
+     Then I should get 0 rows
+     When I close database connection
+     Then I should be disconnected
+
+
+  @cli @database @database-write
+  Scenario: Check the ability to clean up old records from `read_errors` table if the table contains one old report.
+     When I insert following row into table new_reports
+          | org id |  account number | cluster name                         | updated at  | kafka offset |
+          | 1      |  10             | 5d5892d4-1f74-4ccf-91af-548dfc9767aa | 1990-01-01  | 1            |
+      And I select all rows from table new_reports
+     Then I should get 1 row
+     When I insert following row into table read_errors
+          | org id | cluster name                         | updated at | error           |
+          | 1      | 5d5892d4-1f74-4ccf-91af-548dfc9767aa | 1990-01-01 | some error text |
+      And I select all rows from table read_errors
+     Then I should get 1 row
+     When I close database connection
+     Then I should be disconnected
+     When I start the CCX Notification Writer with the --read-errors-cleanup command line flag
+     Then the process should exit with status code set to 0
+     When database connection is established
+      And I select all rows from table read_errors
+     Then I should get 0 rows
+     When I close database connection
+     Then I should be disconnected
+
+
+  @cli @database @database-write
+  Scenario: Check the ability to clean up old records from `read_errors` table if the table contains two old reports.
+     When I insert following rows into table new_reports
+          | org id |  account number | cluster name                         | updated at  | kafka offset |
+          | 1      |  10             | 5d5892d4-1f74-4ccf-91af-548dfc9767aa | 1990-01-01  | 1            |
+          | 2      |  20             | aaaaaaaa-1f74-4ccf-91af-548dfc9767aa | 1990-01-01  | 2            |
+      And I select all rows from table new_reports
+     Then I should get 2 rows
+     When I insert following row into table read_errors
+          | org id | cluster name                         | updated at | error                 |
+          | 1      | 5d5892d4-1f74-4ccf-91af-548dfc9767aa | 1990-01-01 | some error text       |
+          | 2      | aaaaaaaa-1f74-4ccf-91af-548dfc9767aa | 1990-01-01 | some other error text |
+      And I select all rows from table read_errors
+     Then I should get 2 rows
+     When I close database connection
+     Then I should be disconnected
+     When I start the CCX Notification Writer with the --read-errors-cleanup command line flag
+     Then the process should exit with status code set to 0
+     When database connection is established
+      And I select all rows from table read_errors
+     Then I should get 0 rows
+     When I close database connection
+     Then I should be disconnected

--- a/features/steps/notification_database.py
+++ b/features/steps/notification_database.py
@@ -257,6 +257,42 @@ def insert_rows_into_reported_table(context, report="", default_notified_at=None
         raise e
 
 
+@when("I insert following row into table read_errors")
+@when("I insert following rows into table read_errors")
+def insert_rows_into_read_errors_table(context):
+    """Insert rows into table read_errors."""
+    cursor = context.connection.cursor()
+
+    try:
+        # retrieve table data from feature file
+        for row in context.table:
+            org_id = int(row["org id"])
+            cluster_name = row["cluster name"]
+            updated_at = row["updated at"]
+            error_text = row["error"]
+
+            # check the input table
+            assert org_id is not None, "Organization ID should be set"
+            assert cluster_name is not None, "Cluster name should be set"
+            assert updated_at is not None, "Timestamp updated_at should be set"
+            if not error_text:
+                error_text = "some default error text"
+
+            # try to perform insert statement
+            insertStatement = """INSERT INTO read_errors
+                                 (org_id, cluster, updated_at, created_at, error_text)
+                                 VALUES(%s, %s, %s, %s, %s);"""
+            cursor.execute(
+                insertStatement,
+                (org_id, cluster_name, updated_at, datetime.now(), error_text),
+            )
+
+        context.connection.commit()
+    except Exception as e:
+        context.connection.rollback()
+        raise e
+
+
 @when("I insert 1 report with {risk:w} total risk for the following clusters")
 def insert_report_with_risk_in_new_reports_table(context, risk, updated_at=None):
     """Insert rows into table new_reports."""

--- a/features/steps/notification_writer.py
+++ b/features/steps/notification_writer.py
@@ -95,6 +95,10 @@ Usage of ccx-notification-writer:
         print new reports to be cleaned up
   -print-old-reports-for-cleanup
         print old reports to be cleaned up
+  -print-read-errors-for-cleanup
+        print records from read_errors table to be cleaned up
+  -read-errors-cleanup
+        perform clean up of read_errors table
   -show-configuration
         show configuration
   -version

--- a/test_list/notification_writer.txt
+++ b/test_list/notification_writer.txt
@@ -3,3 +3,4 @@
 ../features/ccx-notification-writer/display_old_records.feature
 ../features/ccx-notification-writer/cleanup_old_records.feature
 ../features/ccx-notification-writer/cleanup_new_records.feature
+../features/ccx-notification-writer/cleanup_read_errors.feature


### PR DESCRIPTION
# Description

New BDD specifications + steps to cover the `--read-errors-cleanup` parameter of ccx-notification-writer

## Type of change

- New test feature file
- New test scenario added into existing feature file
- Non-breaking change in test steps implementation

## Testing steps

Please describe how the change was tested locally. If, for some reason, the testing was not done or not done fully, please describe what are the testing steps.

## Checklist
* [x] Pylint passes for Python sources
* [x] sources has been pre-processed by Black
* [x] updated documentation wherever necessary
* [x] new tests can be executed both locally and within docker container
* [x] new tests have been included in scenario list (make update-scenarios)
