### PR TITLE
[CCXDEV-10937] Add runner script to launch tests in docker container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi8/ubi:latest
+FROM registry.access.redhat.com/ubi9/ubi:latest
 
 ENV VIRTUAL_ENV=/insights-behavioral-spec-venv \
     VIRTUAL_ENV_BIN=/insights-behavioral-spec-venv/bin \
@@ -27,10 +27,9 @@ COPY . $HOME
 
 ENV PATH="$VIRTUAL_ENV/bin:$PATH"
 
+RUN dnf install --nodocs -y unzip make lsof git libpq-devel gcc
 
-RUN dnf install --nodocs -y python39 python39-devel unzip make lsof git libpq-devel gcc
-
-RUN python3 -m venv $VIRTUAL_ENV
+RUN python3 -m venv $VIRTUAL_ENV && source $VIRTUAL_ENV/bin/activate
 
 RUN curl -ksL https://certs.corp.redhat.com/certs/2015-IT-Root-CA.pem -o /etc/pki/ca-trust/source/anchors/RH-IT-Root-CA.crt
 RUN curl -ksL https://certs.corp.redhat.com/certs/2022-IT-Root-CA.pem -o /etc/pki/ca-trust/source/anchors/2022-IT-Root-CA.pem

--- a/ccx_upgrade_risk_data_eng_tests.sh
+++ b/ccx_upgrade_risk_data_eng_tests.sh
@@ -34,7 +34,7 @@ function prepare_venv() {
 }
 
 function install_data_eng_service() {
-    python3 "$(which pip3)" install "$PATH_TO_LOCAL_DATA_ENG_SERVICE"
+    python3 "$(which pip3)" install "$PATH_TO_LOCAL_DATA_ENG_SERVICE" || exit 1
     # shellcheck disable=SC2016
     add_exit_trap 'python3 "$(which pip3)" uninstall -y ccx-upgrades-data-eng'
 }
@@ -67,7 +67,11 @@ function add_exit_trap {
     fi
 }
 
-[ "$NOVENV" != "1" ] && install_reqs || prepare_venv || exit 1
+# prepare virtual environment if necessary
+case "$NOVENV" in
+    "") echo "using existing virtual env";;
+    "1") install_reqs && prepare_venv ;;
+esac
 
 # Copy the binary and configuration to this folder
 install_data_eng_service

--- a/ccx_upgrade_risk_data_eng_tests.sh
+++ b/ccx_upgrade_risk_data_eng_tests.sh
@@ -34,7 +34,7 @@ function prepare_venv() {
 }
 
 function install_data_eng_service() {
-    python3 "$(which pip3)" install "$PATH_TO_LOCAL_DATA_ENG_SERVICE" || exit 1
+    python3 "$(which pip3)" install "$PATH_TO_LOCAL_DATA_ENG_SERVICE" || exit 1
     # shellcheck disable=SC2016
     add_exit_trap 'python3 "$(which pip3)" uninstall -y ccx-upgrades-data-eng'
 }

--- a/ccx_upgrade_risk_inference_tests.sh
+++ b/ccx_upgrade_risk_inference_tests.sh
@@ -34,8 +34,8 @@ function prepare_venv() {
 }
 
 function install_inference_service() {
-    python3 "$(which pip3)" install -r "$PATH_TO_LOCAL_INFERENCE_SERVICE"/requirements.txt
-    python3 "$(which pip3)" install "$PATH_TO_LOCAL_INFERENCE_SERVICE"/.
+    python3 "$(which pip3)" install -r "$PATH_TO_LOCAL_INFERENCE_SERVICE"/requirements.txt || exit 1
+    python3 "$(which pip3)" install "$PATH_TO_LOCAL_INFERENCE_SERVICE"/. || exit 1
     # shellcheck disable=SC2016
     add_exit_trap 'python3 "$(which pip3)" uninstall -y ccx-upgrades-inference'
 }
@@ -57,7 +57,11 @@ function add_exit_trap {
     fi
 }
 
-[ "$NOVENV" != "1" ] && install_reqs || prepare_venv || exit 1
+# prepare virtual environment if necessary
+case "$NOVENV" in
+    "") echo "using existing virtual env";;
+    "1") install_reqs && prepare_venv ;;
+esac
 
 # Copy the binary and configuration to this folder
 install_inference_service

--- a/ccx_upgrade_risk_inference_tests.sh
+++ b/ccx_upgrade_risk_inference_tests.sh
@@ -34,8 +34,8 @@ function prepare_venv() {
 }
 
 function install_inference_service() {
-    python3 "$(which pip3)" install -r "$PATH_TO_LOCAL_INFERENCE_SERVICE"/requirements.txt || exit 1
-    python3 "$(which pip3)" install "$PATH_TO_LOCAL_INFERENCE_SERVICE"/. || exit 1
+    python3 "$(which pip3)" install -r "$PATH_TO_LOCAL_INFERENCE_SERVICE"/requirements.txt || exit 1
+    python3 "$(which pip3)" install "$PATH_TO_LOCAL_INFERENCE_SERVICE"/. || exit 1
     # shellcheck disable=SC2016
     add_exit_trap 'python3 "$(which pip3)" uninstall -y ccx-upgrades-inference'
 }

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -149,6 +149,7 @@ services:
     image: ghcr.io/navikt/mock-oauth2-server:0.5.8
     environment:
       - LOG_LEVEL=DEBUG
+      - SERVER_PORT=8081
     ports:
-      - 8081:8080
+      - 8081:8081
 

--- a/insights_results_aggregator_mock_tests.sh
+++ b/insights_results_aggregator_mock_tests.sh
@@ -55,7 +55,18 @@ esac
 if [[ -z $PATH_TO_MOCK_SERVER ]]
 then
     echo "PATH_TO_MOCK_SERVER is not set!"
-    echo "Make sure to start the insights-results-aggregator-mock application before running the tests"
+    if [[ -n $ENV_DOCKER ]]
+    then
+        echo "Test in running in docker environment. Trying $HOME/mock_server path"
+	if [ -d "$HOME/mock_server" ]; then
+            PATH_TO_MOCK_SERVER="$HOME/mock_server"
+	    echo "mock_server directory found"
+	    pushd "$PATH_TO_MOCK_SERVER" && ./insights-results-aggregator-mock &
+        else
+            echo "Make sure to start the insights-results-aggregator-mock application before running the tests"
+            exit 1
+        fi
+    fi
 else
     pushd "$PATH_TO_MOCK_SERVER" && ./insights-results-aggregator-mock &
 fi

--- a/requirements.in
+++ b/requirements.in
@@ -1,5 +1,5 @@
 behave
 pytest
 requests
-psycopg2
+psycopg2-binary
 semver

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 behave
 pytest
-psycopg2
+psycopg2-binary
 semver

--- a/requirements/exporter.txt
+++ b/requirements/exporter.txt
@@ -1,4 +1,4 @@
 behave
 pytest
 minio
-psycopg2
+psycopg2-binary

--- a/requirements/notification_service.txt
+++ b/requirements/notification_service.txt
@@ -1,6 +1,6 @@
 behave
 pytest
 requests
-psycopg2
+psycopg2-binary
 minio
 kafka-python

--- a/requirements/notification_writer.txt
+++ b/requirements/notification_writer.txt
@@ -1,4 +1,4 @@
 behave
 pytest
-psycopg2
+psycopg2-binary
 kafka-python

--- a/requirements/upgrades_data_eng_service.txt
+++ b/requirements/upgrades_data_eng_service.txt
@@ -1,6 +1,6 @@
 behave
 pytest
 requests
-psycopg2
+psycopg2-binary
 minio
 jsonschema

--- a/requirements/upgrades_inference_service.txt
+++ b/requirements/upgrades_inference_service.txt
@@ -1,6 +1,6 @@
 behave
 pytest
 requests
-psycopg2
+psycopg2-binary
 minio
 jsonschema

--- a/run_in_docker.sh
+++ b/run_in_docker.sh
@@ -1,0 +1,76 @@
+#!/bin/bash -x
+
+# This script assumes that a Go service is already built, and the Python service can be interpreted without errors
+#
+# Step 1: Define a map of makefile targets to corresponding profiles and a map of files to copy in the DBB container for each target
+declare -A docker_compose_profiles
+
+docker_compose_profiles["cleaner-tests"]=""
+docker_compose_profiles["aggregator-tests"]="test-aggregator"
+docker_compose_profiles["aggregator-mock-tests"]=""
+docker_compose_profiles["exporter-tests"]="test-exporter"
+docker_compose_profiles["notification-service-tests"]="test-notification-services"
+docker_compose_profiles["notification-writer-tests"]="test-notification-services"
+docker_compose_profiles["inference-service-tests"]=""
+docker_compose_profiles["data-engineering-service-tests"]="test-upgrades-data-eng"
+docker_compose_profiles["insights-content-service-tests"]=""
+docker_compose_profiles["insights-content-template-renderer-tests"]=""
+docker_compose_profiles["insights-sha-extractor-tests"]=""
+docker_compose_profiles["smart-proxy-tests"]=""
+
+# Function to get docker compose profile to add based on service name specified by the user
+with_profile() {
+  local profile="${docker_compose_profiles[$1]}"
+  [[ -n "$profile" ]] && echo "--profile $profile" || echo ""
+}
+
+# Function to add the no-mock profile if specified by the user
+with_no_mock() {
+  [[ -n "$1" ]] && echo "--profile no-mock" || echo ""
+}
+
+# Function to copy files based on the make target
+copy_files() {
+  local cid="$1"
+  local target="$2"
+  local path_to_service="$3"
+
+  case "$target" in
+    "aggregator-tests")
+      # Copy files for aggregator-tests
+      executable_name="insights-results-aggregator"
+      docker cp "$path_to_service/$executable_name" "$cid:$(docker exec $cid bash -c 'echo "$VIRTUAL_ENV_BIN"')"
+      docker exec -u root "$cid" /bin/bash -c "chmod +x \$VIRTUAL_ENV_BIN/$executable_name"
+      docker cp "$path_to_service/openapi.json" "$cid":$(docker exec "$cid" bash -c 'echo "$HOME"')
+      ;;
+    "other-target")
+      # Copy files for other-target
+      docker cp file3.txt "$cid:/path/in/container/"
+      docker cp file4.txt "$cid:/path/in/container/"
+      ;;
+    *)
+      echo "No specific files to copy for target: $target"
+      ;;
+  esac
+}
+# Step 2: Specify the make target for tests to run
+tests_target="$1"
+
+# Step 3: Specify the path to the compiled executable or or Python service
+path_to_service=$(realpath "$2")
+
+# Step 4: Start the Docker containers with Docker Compose
+test_profile=$(with_profile "$1")
+echo "profile -- $test_profile"
+POSTGRES_DB_NAME=test docker-compose $(with_profile "$1") $(with_no_mock "$3") up -d
+
+# Step 5: Find the container ID of the insights-behavioral-spec container
+cid=$(docker ps | grep 'insights-behavioral-spec:latest' | cut -d ' ' -f 1)
+
+# Step 6: Copy the executable and needed dependencies or Python service into the container
+# TODO: Discuss including archives in compiled Go executables for testing
+copy_files "$cid" "$tests_target" "$path_to_service"
+
+# Step 9: Execute the specified make target
+docker exec -it "$cid" /bin/bash -c "env && make $tests_target"
+

--- a/run_in_docker.sh
+++ b/run_in_docker.sh
@@ -63,6 +63,11 @@ copy_files() {
       docker cp "$path_to_service/$executable_name" "$cid:$(docker exec $cid bash -c 'echo "$VIRTUAL_ENV_BIN"')"
       docker exec -u root "$cid" /bin/bash -c "chmod +x \$VIRTUAL_ENV_BIN/$executable_name"
       ;;
+    "notification-writer-tests")
+      executable_name="ccx-notification-writer"
+      docker cp "$path_to_service/$executable_name" "$cid:$(docker exec $cid bash -c 'echo "$VIRTUAL_ENV_BIN"')"
+      docker exec -u root "$cid" /bin/bash -c "chmod +x \$VIRTUAL_ENV_BIN/$executable_name"
+      ;;
     *)
       echo "No specific files to copy for target: $target"
       ;;

--- a/run_in_docker.sh
+++ b/run_in_docker.sh
@@ -37,10 +37,19 @@ copy_files() {
       docker cp "$path_to_service/$executable_name" "$cid:$(docker exec $cid bash -c 'echo "$VIRTUAL_ENV_BIN"')"
       docker exec -u root "$cid" /bin/bash -c "chmod +x \$VIRTUAL_ENV_BIN/$executable_name"
       ;;
+    "data-engineering-service-tests")
+      ;;
     "exporter-tests")
       executable_name="insights-results-aggregator-exporter"
       docker cp "$path_to_service/$executable_name" "$cid:$(docker exec $cid bash -c 'echo "$VIRTUAL_ENV_BIN"')"
       docker exec -u root "$cid" /bin/bash -c "chmod +x \$VIRTUAL_ENV_BIN/$executable_name"
+      ;;
+    "inference-service-tests")
+      ;;
+    "insights-content-service-tests")
+      echo -e "\033[33mWARNING! Content service should include test-rules for these tests to run properly.\033[0m"
+      echo -e "\033[33mPlease build using './build.sh --test-rules-only' or './build.sh --include-test-rules'\033[0m"
+      docker cp $path_to_service "$cid:$(docker exec $cid bash -c 'echo "$HOME"')"
       ;;
     *)
       echo "No specific files to copy for target: $target"

--- a/run_in_docker.sh
+++ b/run_in_docker.sh
@@ -5,17 +5,17 @@
 # Step 1: Define a map of makefile targets to corresponding profiles and a map of files to copy in the DBB container for each target
 declare -A docker_compose_profiles
 
-docker_compose_profiles["cleaner-tests"]=""
 docker_compose_profiles["aggregator-tests"]="test-aggregator"
 docker_compose_profiles["aggregator-mock-tests"]=""
-docker_compose_profiles["exporter-tests"]="test-exporter"
-docker_compose_profiles["notification-service-tests"]="test-notification-services"
-docker_compose_profiles["notification-writer-tests"]="test-notification-services"
-docker_compose_profiles["inference-service-tests"]=""
+docker_compose_profiles["cleaner-tests"]=""
 docker_compose_profiles["data-engineering-service-tests"]="test-upgrades-data-eng"
+docker_compose_profiles["exporter-tests"]="test-exporter"
+docker_compose_profiles["inference-service-tests"]=""
 docker_compose_profiles["insights-content-service-tests"]=""
 docker_compose_profiles["insights-content-template-renderer-tests"]=""
 docker_compose_profiles["insights-sha-extractor-tests"]=""
+docker_compose_profiles["notification-service-tests"]="test-notification-services"
+docker_compose_profiles["notification-writer-tests"]="test-notification-services"
 docker_compose_profiles["smart-proxy-tests"]=""
 
 # Function to get docker compose profile to add based on service name specified by the user
@@ -42,7 +42,13 @@ copy_files() {
       docker exec -u root "$cid" /bin/bash -c "chmod +x \$VIRTUAL_ENV_BIN/$executable_name"
       docker cp "$path_to_service/openapi.json" "$cid":$(docker exec "$cid" bash -c 'echo "$HOME"')
       ;;
-    "cleaner-tests")
+    "aggregator-mock-tests")
+      executable_name="insights-results-aggregator-mock"
+      docker cp $path_to_service "$cid:$(docker exec $cid bash -c 'echo "$HOME"')/mock_server"
+      docker cp "$path_to_service/$executable_name" "$cid:$(docker exec $cid bash -c 'echo "$VIRTUAL_ENV_BIN"')"
+      docker exec -u root "$cid" /bin/bash -c "chmod +x \$VIRTUAL_ENV_BIN/$executable_name"
+      ;;
+   "cleaner-tests")
       # Copy files for other-target
       executable_name="insights-results-aggregator-cleaner"
       docker cp "$path_to_service/$executable_name" "$cid:$(docker exec $cid bash -c 'echo "$VIRTUAL_ENV_BIN"')"

--- a/run_in_docker.sh
+++ b/run_in_docker.sh
@@ -70,6 +70,12 @@ copy_files() {
     "insights-content-template-renderer-tests")
       copy_python_project $cid $path_to_service
       ;;
+    "insights-sha-extractor-tests")
+      echo -e "\033[0;31mThese tests are not ready to be run. Aborting!\033[0m"
+      echo "This option will be enabled after https://issues.redhat.com/browse/CCXDEV-11895 is done."
+      exit 0
+      # copy_python_project $cid $path_to_service
+      ;;
     "notification-service-tests")
       copy_go_executable "$cid" "$path_to_service" "ccx-notification-service"
       ;;
@@ -97,7 +103,7 @@ docker_compose_profiles["exporter-tests"]="test-exporter"
 docker_compose_profiles["inference-service-tests"]=""
 docker_compose_profiles["insights-content-service-tests"]=""
 docker_compose_profiles["insights-content-template-renderer-tests"]=""
-docker_compose_profiles["insights-sha-extractor-tests"]=""
+docker_compose_profiles["insights-sha-extractor-tests"]="text-sha-extractor"
 docker_compose_profiles["notification-service-tests"]="test-notification-services"
 docker_compose_profiles["notification-writer-tests"]="test-notification-services"
 docker_compose_profiles["smart-proxy-tests"]=""

--- a/run_in_docker.sh
+++ b/run_in_docker.sh
@@ -121,7 +121,8 @@ else
   db_name="test"
 fi
 
-POSTGRES_DB_NAME="$db_name" docker-compose "$(with_profile "$1")" "$(with_no_mock "$3")" up -d
+# shellcheck disable=SC2046
+POSTGRES_DB_NAME="$db_name" docker-compose $(with_profile "$1") $(with_no_mock "$3") up -d
 
 # Step 5: Find the container ID of the insights-behavioral-spec container
 cid=$(docker ps | grep 'insights-behavioral-spec:latest' | cut -d ' ' -f 1)

--- a/run_in_docker.sh
+++ b/run_in_docker.sh
@@ -46,6 +46,9 @@ copy_files() {
       copy_go_executable "$cid" "$path_to_service" "insights-results-aggregator-cleaner"
       ;;
     "data-engineering-service-tests")
+      docker cp $path_to_service "$cid:/."
+      # service will be pip-installed so user will need write and exec permissions
+      docker exec -u root "$cid" /bin/bash -c "chmod -R 777 /$(basename $path_to_service)"
       ;;
     "exporter-tests")
       copy_go_executable "$cid" "$path_to_service" "insights-results-aggregator-exporter"
@@ -114,5 +117,5 @@ copy_files "$cid" "$tests_target" "$path_to_service"
 # Step 9: Execute the specified make target
 
 
-docker exec -it "$cid" /bin/bash -c " env && $(with_mocked_dependencies "$3") make $tests_target"
+docker exec -it "$cid" /bin/bash -c "source \$VIRTUAL_ENV/bin/activate && env && $(with_mocked_dependencies "$3") make $tests_target"
 

--- a/run_in_docker.sh
+++ b/run_in_docker.sh
@@ -19,6 +19,13 @@ with_no_mock() {
   [[ -n "$1" ]] && echo "--profile no-mock" || echo ""
 }
 
+copy_go_executable() {
+  local cid="$1"
+  local path_to_service="$2"
+  local executable_name="$3"
+  docker cp "$path_to_service/$executable_name" "$cid:$(docker exec $cid bash -c 'echo "$VIRTUAL_ENV_BIN"')"
+  docker exec -u root "$cid" /bin/bash -c "chmod +x \$VIRTUAL_ENV_BIN/$executable_name"
+}
 
 # Function to copy files based on the make target
 copy_files() {
@@ -28,28 +35,20 @@ copy_files() {
 
   case "$target" in
     "aggregator-tests")
-      executable_name="insights-results-aggregator"
-      docker cp "$path_to_service/$executable_name" "$cid:$(docker exec $cid bash -c 'echo "$VIRTUAL_ENV_BIN"')"
-      docker exec -u root "$cid" /bin/bash -c "chmod +x \$VIRTUAL_ENV_BIN/$executable_name"
+      copy_go_executable "$cid" "$path_to_service" "insights-results-aggregator"
       docker cp "$path_to_service/openapi.json" "$cid":$(docker exec "$cid" bash -c 'echo "$HOME"')
       ;;
     "aggregator-mock-tests")
-      executable_name="insights-results-aggregator-mock"
+      copy_go_executable "$cid" "$path_to_service" "insights-results-aggregator-mock"
       docker cp $path_to_service "$cid:$(docker exec $cid bash -c 'echo "$HOME"')/mock_server"
-      docker cp "$path_to_service/$executable_name" "$cid:$(docker exec $cid bash -c 'echo "$VIRTUAL_ENV_BIN"')"
-      docker exec -u root "$cid" /bin/bash -c "chmod +x \$VIRTUAL_ENV_BIN/$executable_name"
       ;;
     "cleaner-tests")
-      executable_name="insights-results-aggregator-cleaner"
-      docker cp "$path_to_service/$executable_name" "$cid:$(docker exec $cid bash -c 'echo "$VIRTUAL_ENV_BIN"')"
-      docker exec -u root "$cid" /bin/bash -c "chmod +x \$VIRTUAL_ENV_BIN/$executable_name"
+      copy_go_executable "$cid" "$path_to_service" "insights-results-aggregator-cleaner"
       ;;
     "data-engineering-service-tests")
       ;;
     "exporter-tests")
-      executable_name="insights-results-aggregator-exporter"
-      docker cp "$path_to_service/$executable_name" "$cid:$(docker exec $cid bash -c 'echo "$VIRTUAL_ENV_BIN"')"
-      docker exec -u root "$cid" /bin/bash -c "chmod +x \$VIRTUAL_ENV_BIN/$executable_name"
+      copy_go_executable "$cid" "$path_to_service" "insights-results-aggregator-exporter"
       ;;
     "inference-service-tests")
       ;;
@@ -59,22 +58,17 @@ copy_files() {
       docker cp $path_to_service "$cid:$(docker exec $cid bash -c 'echo "$HOME"')"
       ;;
     "notification-service-tests")
-      executable_name="ccx-notification-service"
-      docker cp "$path_to_service/$executable_name" "$cid:$(docker exec $cid bash -c 'echo "$VIRTUAL_ENV_BIN"')"
-      docker exec -u root "$cid" /bin/bash -c "chmod +x \$VIRTUAL_ENV_BIN/$executable_name"
+      copy_go_executable "$cid" "$path_to_service" "ccx-notification-service"
       ;;
     "notification-writer-tests")
-      executable_name="ccx-notification-writer"
-      docker cp "$path_to_service/$executable_name" "$cid:$(docker exec $cid bash -c 'echo "$VIRTUAL_ENV_BIN"')"
-      docker exec -u root "$cid" /bin/bash -c "chmod +x \$VIRTUAL_ENV_BIN/$executable_name"
+      copy_go_executable "$cid" "$path_to_service" "ccx-notification-writer"
       ;;
     "smart-proxy-tests")
-      executable_name="insights-results-smart-proxy"
-      docker cp "$path_to_service/$executable_name" "$cid:$(docker exec $cid bash -c 'echo "$VIRTUAL_ENV_BIN"')"
-      docker exec -u root "$cid" /bin/bash -c "chmod +x \$VIRTUAL_ENV_BIN/$executable_name"
+      copy_go_executable "$cid" "$path_to_service" "insights-results-smart-proxy"
       ;;
     *)
-      echo "No specific files to copy for target: $target"
+      echo "Unexpected target: $target. Does it exist in Makefile?"
+      exit 2
       ;;
   esac
 }

--- a/run_in_docker.sh
+++ b/run_in_docker.sh
@@ -67,6 +67,9 @@ copy_files() {
       echo -e "\033[33mPlease build using './build.sh --test-rules-only' or './build.sh --include-test-rules'\033[0m"
       docker cp $path_to_service "$cid:$(docker exec $cid bash -c 'echo "$HOME"')"
       ;;
+    "insights-content-template-renderer-tests")
+      copy_python_project $cid $path_to_service
+      ;;
     "notification-service-tests")
       copy_go_executable "$cid" "$path_to_service" "ccx-notification-service"
       ;;

--- a/run_in_docker.sh
+++ b/run_in_docker.sh
@@ -27,6 +27,14 @@ copy_go_executable() {
   docker exec -u root "$cid" /bin/bash -c "chmod +x \$VIRTUAL_ENV_BIN/$executable_name"
 }
 
+copy_python_project() {
+  local cid="$1"
+  local path_to_service="$2"
+  docker cp $path_to_service "$cid:/."
+  # service will be pip-installed and executed, so user will need write and exec permissions
+  docker exec -u root "$cid" /bin/bash -c "chmod -R 777 /$(basename $path_to_service)"
+}
+
 # Function to copy files based on the make target
 copy_files() {
   local cid="$1"
@@ -46,16 +54,13 @@ copy_files() {
       copy_go_executable "$cid" "$path_to_service" "insights-results-aggregator-cleaner"
       ;;
     "data-engineering-service-tests")
-      docker cp $path_to_service "$cid:/."
-      # service will be pip-installed so user will need write and exec permissions
-      docker exec -u root "$cid" /bin/bash -c "chmod -R 777 /$(basename $path_to_service)"
+      copy_python_project $cid $path_to_service
       ;;
     "exporter-tests")
       copy_go_executable "$cid" "$path_to_service" "insights-results-aggregator-exporter"
       ;;
     "inference-service-tests")
-      docker cp $path_to_service "$cid:/."
-      docker exec -u root "$cid" /bin/bash -c "chmod -R 777 /$(basename $path_to_service)"
+      copy_python_project $cid $path_to_service
       ;;
     "insights-content-service-tests")
       echo -e "\033[33mWARNING! Content service should include test-rules for these tests to run properly.\033[0m"

--- a/run_in_docker.sh
+++ b/run_in_docker.sh
@@ -54,6 +54,8 @@ copy_files() {
       copy_go_executable "$cid" "$path_to_service" "insights-results-aggregator-exporter"
       ;;
     "inference-service-tests")
+      docker cp $path_to_service "$cid:/."
+      docker exec -u root "$cid" /bin/bash -c "chmod -R 777 /$(basename $path_to_service)"
       ;;
     "insights-content-service-tests")
       echo -e "\033[33mWARNING! Content service should include test-rules for these tests to run properly.\033[0m"

--- a/run_in_docker.sh
+++ b/run_in_docker.sh
@@ -68,6 +68,11 @@ copy_files() {
       docker cp "$path_to_service/$executable_name" "$cid:$(docker exec $cid bash -c 'echo "$VIRTUAL_ENV_BIN"')"
       docker exec -u root "$cid" /bin/bash -c "chmod +x \$VIRTUAL_ENV_BIN/$executable_name"
       ;;
+    "smart-proxy-tests")
+      executable_name="insights-results-smart-proxy"
+      docker cp "$path_to_service/$executable_name" "$cid:$(docker exec $cid bash -c 'echo "$VIRTUAL_ENV_BIN"')"
+      docker exec -u root "$cid" /bin/bash -c "chmod +x \$VIRTUAL_ENV_BIN/$executable_name"
+      ;;
     *)
       echo "No specific files to copy for target: $target"
       ;;

--- a/run_in_docker.sh
+++ b/run_in_docker.sh
@@ -37,16 +37,16 @@ copy_files() {
 
   case "$target" in
     "aggregator-tests")
-      # Copy files for aggregator-tests
       executable_name="insights-results-aggregator"
       docker cp "$path_to_service/$executable_name" "$cid:$(docker exec $cid bash -c 'echo "$VIRTUAL_ENV_BIN"')"
       docker exec -u root "$cid" /bin/bash -c "chmod +x \$VIRTUAL_ENV_BIN/$executable_name"
       docker cp "$path_to_service/openapi.json" "$cid":$(docker exec "$cid" bash -c 'echo "$HOME"')
       ;;
-    "other-target")
+    "cleaner-tests")
       # Copy files for other-target
-      docker cp file3.txt "$cid:/path/in/container/"
-      docker cp file4.txt "$cid:/path/in/container/"
+      executable_name="insights-results-aggregator-cleaner"
+      docker cp "$path_to_service/$executable_name" "$cid:$(docker exec $cid bash -c 'echo "$VIRTUAL_ENV_BIN"')"
+      docker exec -u root "$cid" /bin/bash -c "chmod +x \$VIRTUAL_ENV_BIN/$executable_name"
       ;;
     *)
       echo "No specific files to copy for target: $target"


### PR DESCRIPTION
# Description

- Simplify the launching of BDD tests with a runner script
- Update some launcher scripts so they work properly both in local and docker environment
- Update Dockerfile to use ubi9 (so we don't have to install Python 3.9)
- Updated requirements file to use `psycopg2-binary` so it does not have to be built with wheel

Fixes (partially) CCXDEV-10937

## Type of change

New script

## Testing steps

- Have docker daemon running 
- `./run_in_docker.sh <makefile target> <path_to_service_to_test> `

## Checklist
* [ ] Pylint passes for Python sources
* [ ] sources has been pre-processed by Black
* [ ] updated documentation wherever necessary
* [ ] new tests can be executed both locally and within docker container
* [ ] new tests have been included in scenario list (make update-scenarios)
