### PR TITLE
Use POSTGRES_DB_NAME test by default in docker-compose

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,12 +26,13 @@ Optional: Use the `run_in_docker.sh` script explained in the [additional tools d
 ### Spin up the docker containers
 
 ```
-POSTGRES_DB_NAME=test docker-compose up -d
-POSTGRES_DB_NAME=test docker-compose --profile test-exporter up -d
+docker-compose up -d
+docker-compose --profile test-exporter up -d
 POSTGRES_DB_NAME=notification docker-compose --profile test-notification-services up -d
 ```
 
-The `POSTGRES_DB_NAME` environment variable is mandatory, as the different services expect different database names: `notification` is used by services related with notification service, and `test` for the rest.
+The `POSTGRES_DB_NAME` environment variable, which defaults to the value `test`, is mandatory when starting tests related to the notification services.
+This is because the different services expect different database names: `notification` is used by services related with notification service, and `test` for the rest.
 
 If you don't want to spin up the containers, you'll need to locally run the required services (database, Kafka, etc.). You may need to add or remove the `managed` tag in the `${SERVICE}_tests.sh`.
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,7 +14,7 @@ services:
     environment:
       - POSTGRES_USER=postgres
       - POSTGRES_PASSWORD=postgres
-      - POSTGRES_DB=${POSTGRES_DB_NAME}
+      - POSTGRES_DB=${POSTGRES_DB_NAME:-test}
     healthcheck:
       test: ["CMD", "pg_isready"]
       interval: 2s


### PR DESCRIPTION
# Description

Simplify `docker-compose up` command by giving a default value to the used database

## Type of change
- Refactor (refactoring code, removing useless files)
- Documentation update

## Testing steps

`docker-compose up`

## Checklist
* [ ] Pylint passes for Python sources
* [ ] sources has been pre-processed by Black
* [x] updated documentation wherever necessary
* [ ] new tests can be executed both locally and within docker container
* [ ] new tests have been included in scenario list (make update-scenarios)
