### PR TITLE
Adding new service to our BDD tests from ccx-bdd-tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -72,7 +72,13 @@ smart-proxy-tests: ## Run BDD tests for the Insights Results Smart Proxy service
 smart-proxy-code-coverage: ## Compute code coverage for Smart Proxy service
 	./smart_proxy_tests.sh coverage
 
-style:	code-style docs-style ## Perform all style checks
+parquet-factory-tests: ## Run BDD tests for the Parquet Factory
+	./parquet_factory_tests.sh
+
+parquet-factory-code-coverage: ## Compute code coverage for Parquet Factory
+	./parquet_factory_tests.sh coverage
+
+style:	code-style docs-style shellcheck ## Perform all style checks
 
 code-style: ## Check code style for all Python sources from this repository
 	python3 tools/run_pycodestyle.py

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -57,7 +57,6 @@ services:
   createbuckets:
     profiles:
       - test-exporter
-      - test-parquet-factory
     image: minio/mc
     depends_on:
       minio:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -26,6 +26,7 @@ services:
     profiles:
       - test-notification-services
       - test-aggregator
+      - test-parquet-factory
     image: quay.io/ccxdev/kafka-no-zk:latest
     ports:
       - 9092:9092
@@ -36,6 +37,7 @@ services:
   minio:
     profiles:
       - test-exporter
+      - test-parquet-factory
     image: minio/minio
     command:
       - server
@@ -55,6 +57,7 @@ services:
   createbuckets:
     profiles:
       - test-exporter
+      - test-parquet-factory
     image: minio/mc
     depends_on:
       minio:
@@ -152,4 +155,3 @@ services:
       - SERVER_PORT=8081
     ports:
       - 8081:8081
-

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -73,6 +73,7 @@ services:
     profiles:
       - no-mock
       - test-notification-services
+      - test-parquet-factory
     image: quay.io/prometheus/pushgateway:latest
     ports:
       - 9091:9091

--- a/features/environment.py
+++ b/features/environment.py
@@ -39,7 +39,9 @@ FEATURES_CLEAN_DB = ("aggregator", "aggregator_cleaner", "aggregator_exporter")
 FEATURES_INIT_DB = ("aggregator", "notification_service")
 
 # Setup all environment variables needed to work with Kafka (local or remote)
-FEATURES_WITH_KAFKA = ("aggregator", "notification_writer", "notification_service", "parquet_service")
+FEATURES_WITH_KAFKA = (
+    "aggregator", "notification_writer", "notification_service", "parquet_service",
+)
 
 # Setup all environment variables needed to work with Minio (local or remote)
 FEATURES_WITH_MINIO = ("aggregator_exporter", "parquet_service")

--- a/features/environment.py
+++ b/features/environment.py
@@ -39,10 +39,10 @@ FEATURES_CLEAN_DB = ("aggregator", "aggregator_cleaner", "aggregator_exporter")
 FEATURES_INIT_DB = ("aggregator", "notification_service")
 
 # Setup all environment variables needed to work with Kafka (local or remote)
-FEATURES_WITH_KAFKA = ("aggregator", "notification_writer", "notification_service")
+FEATURES_WITH_KAFKA = ("aggregator", "notification_writer", "notification_service", "parquet_service")
 
 # Setup all environment variables needed to work with Minio (local or remote)
-FEATURES_WITH_MINIO = ("aggregator_exporter",)
+FEATURES_WITH_MINIO = ("aggregator_exporter", "parquet_service")
 
 # Mapping between database name and script to cleanup such database.
 CLEANUP_FILES = {

--- a/features/parquet-factory/indexes.feature
+++ b/features/parquet-factory/indexes.feature
@@ -1,0 +1,55 @@
+@parquet_service
+
+Feature: Ability to set the indexes in the generated tables correctly
+
+    Background: Initial state is ready
+      Given the system is in default state
+        And Kafka broker is available
+        And Kafka topic "incoming_features_topic" is empty and has 2 partitions
+        And Kafka topic "incoming_rules_topic" is empty and has 2 partitions
+        And S3 endpoint is set
+        And S3 port is set
+        And S3 access key is set
+        And S3 secret access key is set
+        And S3 bucket name is set to test
+        And S3 connection is established
+        And The S3 bucket is empty
+
+    Scenario: If Parquet file already exists, the index of the new one should be 1
+        When I fill the topics with messages of the previous hour
+            | topic                   | partition | type             | cluster                              |
+            | incoming_features_topic | 0         | features message | 11111111-1111-1111-1111-111111111111 |
+            | incoming_features_topic | 1         | features message | 22222222-2222-2222-2222-222222222222 |
+            | incoming_rules_topic    | 0         | rules message    | 33333333-3333-3333-3333-333333333333 |
+            | incoming_rules_topic    | 1         | rules message    | 44444444-4444-4444-4444-444444444444 |
+         And I fill the topics with messages of the current hour
+            | topic                   | partition | type             | cluster                              |
+            | incoming_features_topic | 0         | features message | 55555555-5555-5555-5555-555555555555 |
+            | incoming_features_topic | 1         | features message | 66666666-6666-6666-6666-666666666666 |
+            | incoming_rules_topic    | 0         | rules message    | 77777777-7777-7777-7777-777777777777 |
+            | incoming_rules_topic    | 1         | rules message    | 88888888-8888-8888-8888-888888888888 |
+        When I run Parquet Factory with a timeout of "10" seconds
+        Then Parquet Factory should have finish
+         And I should see following objects generated in S3
+        | File name                              |
+        | fleet_aggregations/cluster_info/hourly/date=2016-02-02/hour=05/cluster_info-0.parquet                                   |
+        # Re run and check that the index is 1. It is needed to empty the topics so that PF doesn't find the previous messages from current hour
+      Given Kafka topic "incoming_features_topic" is empty and has 2 partitions
+        And Kafka topic "incoming_rules_topic" is empty and has 2 partitions
+         When I fill the topics with messages of the previous hour
+            | topic                   | partition | type             | cluster                              |
+            | incoming_features_topic | 0         | features message | 99999999-9999-9999-9999-999999999999 |
+            | incoming_features_topic | 1         | features message | aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa |
+            | incoming_rules_topic    | 0         | rules message    | bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb |
+            | incoming_rules_topic    | 1         | rules message    | cccccccc-cccc-cccc-cccc-cccccccccccc |
+         And I fill the topics with messages of the current hour
+            | topic                   | partition | type             | cluster                              |
+            | incoming_features_topic | 0         | features message | dddddddd-dddd-dddd-dddd-dddddddddddd |
+            | incoming_features_topic | 1         | features message | eeeeeeee-eeee-eeee-eeee-eeeeeeeeeeee |
+            | incoming_rules_topic    | 0         | rules message    | ffffffff-ffff-ffff-ffff-ffffffffffff |
+            | incoming_rules_topic    | 1         | rules message    | 00000000-0000-0000-0000-000000000000 |
+        When I run Parquet Factory with a timeout of "10" seconds
+        Then Parquet Factory should have finish
+         And I should see following objects generated in S3
+        | File name                              |
+        | fleet_aggregations/cluster_info/hourly/date=2016-02-02/hour=05/cluster_info-1.parquet                                   |

--- a/features/parquet-factory/kafka_messages.feature
+++ b/features/parquet-factory/kafka_messages.feature
@@ -1,0 +1,206 @@
+@parquet_service
+
+Feature: Ability to process the Kafka messages correctly
+
+    Background: Initial state is ready
+      Given the system is in default state
+        And Kafka broker is available
+        And Kafka topic "incoming_features_topic" is empty and has 2 partitions
+        And Kafka topic "incoming_rules_topic" is empty and has 2 partitions
+        And S3 endpoint is set
+        And S3 port is set
+        And S3 access key is set
+        And S3 secret access key is set
+        And S3 bucket name is set to test
+        And S3 connection is established
+        And The S3 bucket is empty
+
+    Scenario: Parquet Factory should fail if it cannot read from Kafka
+       When I set the environment variable "PARQUET_FACTORY__KAFKA_FEATURES__ADDRESS" to "non-existent-url"
+        And I set the environment variable "PARQUET_FACTORY__KAFKA_RULES__ADDRESS" to "non-existent-url"
+        And I run Parquet Factory with a timeout of "10" seconds
+       Then Parquet Factory should have finish
+        And The logs should contain "Unable to create the Kafka consumer"
+        And The S3 bucket is empty
+
+    Scenario: Parquet Factory shouldn't finish if only messages from the previous hour arrived
+       When I fill the topics with messages of the previous hour
+      | topic                   | partition | type             | cluster                              |
+      | incoming_features_topic | 0         | features message | 11111111-1111-1111-1111-111111111111 |
+      | incoming_features_topic | 1         | features message | 22222222-2222-2222-2222-222222222222 |
+      | incoming_rules_topic    | 0         | rules message    | 33333333-3333-3333-3333-333333333333 |
+      | incoming_rules_topic    | 1         | rules message    | 44444444-4444-4444-4444-444444444444 |
+       When I set the environment variable "PARQUET_FACTORY__KAFKA_FEATURES__CONSUMER_TIMEOUT" to "20"
+        And I set the environment variable "PARQUET_FACTORY__KAFKA_RULES__CONSUMER_TIMEOUT" to "20"
+        And I run Parquet Factory with a timeout of "10" seconds
+       Then Parquet Factory shouldn't have finish
+        And The logs should contain
+      | topic                   | partition | offset | message           |
+      | incoming_features_topic | 0         | 0      | message processed |
+      | incoming_features_topic | 1         | 0      | message processed |
+      | incoming_rules_topic    | 0         | 0      | message processed |
+      | incoming_rules_topic    | 1         | 0      | message processed |
+        And The logs shouldn't contain
+      | topic                   | partition | offset | message |
+      | incoming_features_topic | 0         | 1      | FINISH  |
+      | incoming_features_topic | 1         | 1      | FINISH  |
+      | incoming_rules_topic    | 0         | 1      | FINISH  |
+      | incoming_rules_topic    | 0         | 1      | FINISH  |
+        And The S3 bucket is empty
+
+  Scenario: Parquet Factory shouldn't finish if not all the topics and partitions are filled with current hour messages
+     When I fill the topics with messages of the previous hour
+    | topic                   | partition | type             | cluster                              |
+    | incoming_features_topic | 0         | features message | 11111111-1111-1111-1111-111111111111 |
+    | incoming_features_topic | 1         | features message | 22222222-2222-2222-2222-222222222222 |
+    | incoming_rules_topic    | 0         | rules message    | 33333333-3333-3333-3333-333333333333 |
+    | incoming_rules_topic    | 1         | rules message    | 44444444-4444-4444-4444-444444444444 |
+      And I fill the topics with messages of the current hour
+    | topic                   | partition | type             | cluster                              |
+    | incoming_features_topic | 0         | features message | 55555555-5555-5555-5555-555555555555 |
+    # | incoming_features_topic | 1         | features message | 66666666-6666-6666-6666-666666666666 |
+    | incoming_rules_topic    | 0         | rules message    | 77777777-7777-7777-7777-777777777777 |
+    | incoming_rules_topic    | 1         | rules message    | 88888888-8888-8888-8888-888888888888 |
+     When I run Parquet Factory with a timeout of "10" seconds
+     Then Parquet Factory shouldn't have finish
+      And The logs should contain
+    | topic                   | partition | offset | message           |
+    | incoming_features_topic | 0         | 0      | message processed |
+    | incoming_features_topic | 1         | 0      | message processed |
+    | incoming_rules_topic    | 0         | 0      | message processed |
+    | incoming_rules_topic    | 1         | 0      | message processed |
+    | incoming_features_topic | 0         | 1      | FINISH            |
+    # | incoming_features_topic | 1         | 1      | FINISH            |
+    | incoming_rules_topic    | 0         | 1      | FINISH            |
+    | incoming_rules_topic    | 0         | 1      | FINISH            |
+      And The S3 bucket is empty
+
+  Scenario: Parquet Factory should finish if all the topics and partitions are filled with current hour messages
+     When I fill the topics with messages of the previous hour
+    | topic                   | partition | type             | cluster                              |
+    | incoming_features_topic | 0         | features message | 11111111-1111-1111-1111-111111111111 |
+    | incoming_features_topic | 1         | features message | 22222222-2222-2222-2222-222222222222 |
+    | incoming_rules_topic    | 0         | rules message    | 33333333-3333-3333-3333-333333333333 |
+    | incoming_rules_topic    | 1         | rules message    | 44444444-4444-4444-4444-444444444444 |
+      And I fill the topics with messages of the current hour
+    | topic                   | partition | type             | cluster                              |
+    | incoming_features_topic | 0         | features message | 55555555-5555-5555-5555-555555555555 |
+    | incoming_features_topic | 1         | features message | 66666666-6666-6666-6666-666666666666 |
+    | incoming_rules_topic    | 0         | rules message    | 77777777-7777-7777-7777-777777777777 |
+    | incoming_rules_topic    | 1         | rules message    | 88888888-8888-8888-8888-888888888888 |
+     When I run Parquet Factory with a timeout of "10" seconds
+     Then Parquet Factory should have finish
+      And The logs should contain
+    | topic                   | partition | offset | message           |
+    | incoming_features_topic | 0         | 0      | message processed |
+    | incoming_features_topic | 1         | 0      | message processed |
+    | incoming_rules_topic    | 0         | 0      | message processed |
+    | incoming_rules_topic    | 1         | 0      | message processed |
+    | incoming_features_topic | 0         | 1      | FINISH            |
+    | incoming_features_topic | 1         | 1      | FINISH            |
+    | incoming_rules_topic    | 0         | 1      | FINISH            |
+    | incoming_rules_topic    | 0         | 1      | FINISH            |
+      And The S3 bucket is not empty
+
+  Scenario: After aggregating messages from previous hour, the first messages from current hour has to be processed first
+     When I fill the topics with messages of the previous hour
+    | topic                   | partition | type             | cluster                              |
+    | incoming_features_topic | 0         | features message | 11111111-1111-1111-1111-111111111111 |
+    | incoming_features_topic | 1         | features message | 22222222-2222-2222-2222-222222222222 |
+    | incoming_rules_topic    | 0         | rules message    | 33333333-3333-3333-3333-333333333333 |
+    | incoming_rules_topic    | 1         | rules message    | 44444444-4444-4444-4444-444444444444 |
+      And I fill the topics with messages of the current hour
+    | topic                   | partition | type             | cluster                              |
+    | incoming_features_topic | 0         | features message | 55555555-5555-5555-5555-555555555555 |
+    | incoming_features_topic | 1         | features message | 66666666-6666-6666-6666-666666666666 |
+    | incoming_rules_topic    | 0         | rules message    | 77777777-7777-7777-7777-777777777777 |
+    | incoming_rules_topic    | 1         | rules message    | 88888888-8888-8888-8888-888888888888 |
+     When I run Parquet Factory with a timeout of "10" seconds
+     Then Parquet Factory should have finish
+      And The logs should contain
+    | topic                   | partition | offset | message           |
+    | incoming_features_topic | 0         | 0      | message processed |
+    | incoming_features_topic | 1         | 0      | message processed |
+    | incoming_rules_topic    | 0         | 0      | message processed |
+    | incoming_rules_topic    | 1         | 0      | message processed |
+    | incoming_features_topic | 0         | 1      | FINISH            |
+    | incoming_features_topic | 1         | 1      | FINISH            |
+    | incoming_rules_topic    | 0         | 1      | FINISH            |
+    | incoming_rules_topic    | 0         | 1      | FINISH            |
+     Then The S3 bucket is not empty
+     When I run Parquet Factory with a timeout of "10" seconds
+     Then Parquet Factory should have finish
+      And The logs should contain
+    | topic                   | partition | offset | message |
+    | incoming_features_topic | 0         | 1      | FINISH  |
+    | incoming_features_topic | 1         | 1      | FINISH  |
+    | incoming_rules_topic    | 0         | 1      | FINISH  |
+    | incoming_rules_topic    | 1         | 1      | FINISH  |
+
+  Scenario: Parquet Factory should finish if the limit of kafka messages is exceeded even if no messages from current hour arrived
+     When I fill the topics with messages of the previous hour
+    | topic                   | partition | type             | cluster                              |
+    | incoming_features_topic | 0         | features message | 11111111-1111-1111-1111-111111111111 |
+    | incoming_features_topic | 1         | features message | 22222222-2222-2222-2222-222222222222 |
+    | incoming_rules_topic    | 0         | rules message    | 33333333-3333-3333-3333-333333333333 |
+    | incoming_rules_topic    | 1         | rules message    | 44444444-4444-4444-4444-444444444444 |
+    | incoming_features_topic | 0         | features message | 55555555-5555-5555-5555-555555555555 |
+    | incoming_features_topic | 1         | features message | 66666666-6666-6666-6666-666666666666 |
+    | incoming_rules_topic    | 0         | rules message    | 77777777-7777-7777-7777-777777777777 |
+    | incoming_rules_topic    | 1         | rules message    | 88888888-8888-8888-8888-888888888888 |
+    | incoming_features_topic | 0         | features message | 99999999-9999-9999-9999-999999999999 |
+    | incoming_features_topic | 1         | features message | aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa |
+    | incoming_rules_topic    | 0         | rules message    | bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb |
+    | incoming_rules_topic    | 1         | rules message    | cccccccc-cccc-cccc-cccc-cccccccccccc |
+      And I set the environment variable "PARQUET_FACTORY__KAFKA_RULES__MAX_CONSUMED_RECORDS" to "1"
+      And I set the environment variable "PARQUET_FACTORY__KAFKA_FEATURES__MAX_CONSUMED_RECORDS" to "1"
+      And I run Parquet Factory with a timeout of "10" seconds
+     Then Parquet Factory should have finish
+      And The logs should contain
+    | topic                   | partition | offset | message           |
+    | incoming_features_topic | 0         | 0      | message processed |
+    | incoming_features_topic | 1         | 0      | message processed |
+    | incoming_rules_topic    | 0         | 0      | message processed |
+    | incoming_rules_topic    | 1         | 0      | message processed |
+    | incoming_features_topic | 0         | 1      | FINISH            |
+    | incoming_features_topic | 1         | 1      | FINISH            |
+    | incoming_rules_topic    | 0         | 1      | FINISH            |
+    | incoming_rules_topic    | 0         | 1      | FINISH            |
+     Then The S3 bucket is not empty
+
+  Scenario: Parquet Factory should not commit the messages from current hour if there are no prior messages
+     When I fill the topics with messages of the current hour
+    | topic                   | partition | type             | cluster                              |
+    | incoming_features_topic | 0         | features message | 11111111-1111-1111-1111-111111111111 |
+    | incoming_features_topic | 1         | features message | 22222222-2222-2222-2222-222222222222 |
+    | incoming_rules_topic    | 0         | rules message    | 33333333-3333-3333-3333-333333333333 |
+    | incoming_rules_topic    | 1         | rules message    | 44444444-4444-4444-4444-444444444444 |
+     When I run Parquet Factory with a timeout of "10" seconds
+     Then Parquet Factory should have finish
+      And The logs should contain
+    | topic                   | partition | offset | message |
+    | incoming_features_topic | 0         | 0      | FINISH  |
+    | incoming_features_topic | 1         | 0      | FINISH  |
+    | incoming_rules_topic    | 0         | 0      | FINISH  |
+    | incoming_rules_topic    | 0         | 0      | FINISH  |
+     Then The S3 bucket is empty
+     # Rerun it to check that it starts with the same messages
+     When I run Parquet Factory with a timeout of "10" seconds
+     Then Parquet Factory should have finish
+      And The logs should contain
+    | topic                   | partition | offset | message |
+    | incoming_features_topic | 0         | 0      | FINISH  |
+    | incoming_features_topic | 1         | 0      | FINISH  |
+    | incoming_rules_topic    | 0         | 0      | FINISH  |
+    | incoming_rules_topic    | 0         | 0      | FINISH  |
+    Then The S3 bucket is empty
+
+Scenario: Parquet Factory shouldn't send duplicate rows
+     When I fill the topics with messages of the previous hour
+    | topic                   | partition | type             | cluster                              |
+    | incoming_features_topic | 0         | features message | 11111111-1111-1111-1111-111111111111 |
+    | incoming_features_topic | 1         | features message | 11111111-1111-1111-1111-111111111111 |
+    | incoming_rules_topic    | 0         | rules message    | 33333333-3333-3333-3333-333333333333 |
+    | incoming_rules_topic    | 1         | rules message    | 44444444-4444-4444-4444-444444444444 |
+     When I run Parquet Factory with a timeout of "10" seconds
+     Then The logs should contain "factory was about to duplicate a row, skipping"

--- a/features/parquet-factory/metrics.feature
+++ b/features/parquet-factory/metrics.feature
@@ -1,0 +1,118 @@
+@parquet_service
+
+Feature: Ability to send metrics correctly
+
+    Background: Initial state is ready
+      Given the system is in default state
+        And Kafka broker is available
+        And Kafka topic "incoming_features_topic" is empty and has 2 partitions
+        And Kafka topic "incoming_rules_topic" is empty and has 2 partitions
+        And S3 endpoint is set
+        And S3 port is set
+        And S3 access key is set
+        And S3 secret access key is set
+        And S3 bucket name is set to test
+        And S3 connection is established
+        And The S3 bucket is empty
+        And Pushgateway in "pushgateway:9091" is empty of metrics
+
+    Scenario: If the Pushgateway is not accessible, Parquet Factory should run successfully
+       When I fill the topics with messages of the current hour
+        | topic                   | partition | type             | cluster                              |
+        | incoming_features_topic | 0         | features message | 11111111-1111-1111-1111-111111111111 |
+        | incoming_features_topic | 1         | features message | 22222222-2222-2222-2222-222222222222 |
+        | incoming_rules_topic    | 0         | rules message    | 33333333-3333-3333-3333-333333333333 |
+        | incoming_rules_topic    | 1         | rules message    | 44444444-4444-4444-4444-444444444444 |
+        And I set the environment variable "PARQUET_FACTORY__METRICS__GATEWAY_URL" to "non-existent-url"
+        And I run Parquet Factory with a timeout of "10" seconds
+       Then Parquet Factory should have finish
+        And The logs should contain "No files needed to be written"
+        And The logs should contain "Cannot push metrics"
+
+    Scenario: If the Pushgateway is accessible, Parquet Factory should run successfully and send the metrics to the Pushgateway
+       When I fill the topics with messages of the current hour
+        | topic                   | partition | type             | cluster                              |
+        | incoming_features_topic | 0         | features message | 11111111-1111-1111-1111-111111111111 |
+        | incoming_features_topic | 1         | features message | 22222222-2222-2222-2222-222222222222 |
+        | incoming_rules_topic    | 0         | rules message    | 33333333-3333-3333-3333-333333333333 |
+        | incoming_rules_topic    | 1         | rules message    | 44444444-4444-4444-4444-444444444444 |
+        And I set the environment variable "PARQUET_FACTORY__METRICS__GATEWAY_URL" to "pushgateway:9091"
+        And I run Parquet Factory with a timeout of "10" seconds
+        And I store the metrics from "pushgateway:9091"
+       Then Parquet Factory should have finish
+        And The logs should contain "No files needed to be written"
+        And The logs should contain "Metrics pushed successfully."
+        # Offset marked is 4 because the offset -2 is always marked
+        And Metrics are
+        | metric           | operation | value | label | label_value |
+        | error_count      | equal to  | 0     |       |             |
+        | state            | equal to  | 0     |       |             |
+        | offset_consummed | equal to  | 0     |       |             |
+        | offset_marked    | equal to  | 4     |       |             |
+        | offset_processed | equal to  | 0     |       |             |
+        And Metric "inserted_rows" is not registered
+        And Metric "files_generated" is not registered
+
+    Scenario: If the Pushgateway is accessible and I run Parquet Factory with messages from the previous hour, the "files_generated" and "inserted_rows" metrics should be 1 for all the tables
+       When I fill the topics with messages of the previous hour
+        | topic                   | partition | type             | cluster                              |
+        | incoming_features_topic | 0         | features message | 11111111-1111-1111-1111-111111111111 |
+        | incoming_features_topic | 1         | features message | 22222222-2222-2222-2222-222222222222 |
+        | incoming_rules_topic    | 0         | rules message    | 33333333-3333-3333-3333-333333333333 |
+        | incoming_rules_topic    | 1         | rules message    | 44444444-4444-4444-4444-444444444444 |
+        And I fill the topics with messages of the current hour
+        | topic                   | partition | type             | cluster                              |
+        | incoming_features_topic | 0         | features message | 11111111-1111-1111-1111-111111111111 |
+        | incoming_features_topic | 1         | features message | 22222222-2222-2222-2222-222222222222 |
+        | incoming_rules_topic    | 0         | rules message    | 33333333-3333-3333-3333-333333333333 |
+        | incoming_rules_topic    | 1         | rules message    | 44444444-4444-4444-4444-444444444444 |
+        And I set the environment variable "PARQUET_FACTORY__METRICS__GATEWAY_URL" to "pushgateway:9091"
+        And I run Parquet Factory with a timeout of "10" seconds
+        And I store the metrics from "pushgateway:9091"
+       Then Parquet Factory should have finish
+        And The logs should contain "\"rule_hits-0\" table was generated"
+        And The logs should contain "\"cluster_info-0\" table was generated"
+        And The logs should contain "\"failing_operator_conditions-0\" table was generated"
+        And The logs should contain "\"alerts-0\" table was generated"
+        And The logs should contain "\"gatherers_info-0\" table was generated"
+        And The logs should contain "Metrics pushed successfully."
+        And Metrics are
+        | metric           | operation    | value | label | label_value                 |
+        | error_count      | equal to     | 0     |       |                             |
+        | state            | equal to     | 0     |       |                             |
+        | offset_consummed | equal to     | 4     |       |                             |
+        | offset_marked    | equal to     | 4     |       |                             |
+        | offset_processed | equal to     | 4     |       |                             |
+        | inserted_rows    | greater than | 1     | table | rule_hits                   |
+        | inserted_rows    | greater than | 1     | table | cluster_info                |
+        | inserted_rows    | greater than | 1     | table | failing_operator_conditions |
+        | inserted_rows    | greater than | 1     | table | alerts                      |
+        | inserted_rows    | greater than | 1     | table | gatherers_info              |
+        | inserted_rows    | greater than | 1     | table | workload_containers         |
+        | inserted_rows    | greater than | 1     | table | workload_image_layers       |
+        | files_generated  | equal to     | 1     | table | rule_hits                   |
+        | files_generated  | equal to     | 1     | table | cluster_info                |
+        | files_generated  | equal to     | 1     | table | failing_operator_conditions |
+        | files_generated  | equal to     | 1     | table | alerts                      |
+        | files_generated  | equal to     | 1     | table | gatherers_info              |
+        | files_generated  | equal to     | 1     | table | workload_containers         |
+        | files_generated  | equal to     | 1     | table | workload_image_layers       |
+
+    Scenario: If the Pushgateway is accessible and Parquet Factory errors, the "error_count" metric should increase
+       When I set the environment variable "PARQUET_FACTORY__KAFKA_FEATURES__ADDRESS" to "non-existent-url"
+        And I set the environment variable "PARQUET_FACTORY__KAFKA_RULES__ADDRESS" to "non-existent-url"
+        And I set the environment variable "PARQUET_FACTORY__METRICS__GATEWAY_URL" to "pushgateway:9091"
+        And I run Parquet Factory with a timeout of "10" seconds
+        And I store the metrics from "pushgateway:9091"
+       Then Parquet Factory should have finish
+        And The logs should contain "Unable to create the Kafka consumer"
+        And The logs should contain "Metrics pushed successfully."
+        And Metrics are
+        | metric           | operation | value | label | label_value |
+        | error_count      | equal to  | 1     |       |             |
+        | state            | equal to  | 0     |       |             |
+        | offset_consummed | equal to  | 0     |       |             |
+        | offset_marked    | equal to  | 0     |       |             |
+        | offset_processed | equal to  | 0     |       |             |
+        And Metric "inserted_rows" is not registered
+        And Metric "files_generated" is not registered

--- a/features/parquet-factory/parquet_files.feature
+++ b/features/parquet-factory/parquet_files.feature
@@ -1,0 +1,185 @@
+@parquet_service
+
+Feature: Ability to generate parquet files correctly
+
+    Background: Initial state is ready
+      Given the system is in default state
+        And Kafka broker is available
+        And Kafka topic "incoming_features_topic" is empty and has 2 partitions
+        And Kafka topic "incoming_rules_topic" is empty and has 2 partitions
+        And S3 endpoint is set
+        And S3 port is set
+        And S3 access key is set
+        And S3 secret access key is set
+        And S3 bucket name is set to test
+        And S3 connection is established
+        And The S3 bucket is empty
+
+    Scenario: Table generation: cluster_info
+       When I fill the topics with messages of the previous hour
+        | topic                   | partition | type             | cluster                              |
+        | incoming_features_topic | 0         | features message | 11111111-1111-1111-1111-111111111111 |
+        | incoming_features_topic | 1         | features message | 22222222-2222-2222-2222-222222222222 |
+        | incoming_rules_topic    | 0         | rules message    | 33333333-3333-3333-3333-333333333333 |
+        | incoming_rules_topic    | 1         | rules message    | 44444444-4444-4444-4444-444444444444 |
+        And I fill the topics with messages of the current hour
+        | topic                   | partition | type             | cluster                              |
+        | incoming_features_topic | 0         | features message | 55555555-5555-5555-5555-555555555555 |
+        | incoming_features_topic | 1         | features message | 66666666-6666-6666-6666-666666666666 |
+        | incoming_rules_topic    | 0         | rules message    | 77777777-7777-7777-7777-777777777777 |
+        | incoming_rules_topic    | 1         | rules message    | 88888888-8888-8888-8888-888888888888 |
+       When I run Parquet Factory with a timeout of "10" seconds
+       Then Parquet Factory should have finish
+        And The logs should contain
+        | topic                   | partition | offset | message           |
+        | incoming_features_topic | 0         | 0      | message processed |
+        | incoming_features_topic | 1         | 0      | message processed |
+        | incoming_rules_topic    | 0         | 0      | message processed |
+        | incoming_rules_topic    | 1         | 0      | message processed |
+        | incoming_features_topic | 0         | 1      | FINISH            |
+        | incoming_features_topic | 1         | 1      | FINISH            |
+        | incoming_rules_topic    | 0         | 1      | FINISH            |
+        | incoming_rules_topic    | 0         | 1      | FINISH            |
+        And I should see following objects generated in S3
+        | File name                              |
+        | fleet_aggregations/cluster_info/hourly/date=2016-02-02/hour=05/cluster_info-0.parquet                                   |
+        And The parquet file fleet_aggregations/cluster_info/hourly/date=2016-02-02/hour=05/cluster_info-0.parquet is exactly this one
+        | cluster_id                           | cluster_version | platform | collected_at        | desired_version | initial_version | network_type | network_mtu | network_kind | network_size | network_host_prefix | channel    | archive_path                                                                        |
+        | 11111111-1111-1111-1111-111111111111 | 4.8.12          | AWS      | 2016-02-02 05:05:22 | 4.8.13          | 4.8.12          | OpenShiftSDN | 1450        | service      | /16          | 0                   | stable-4.8 | archives/compressed/35/11111111-1111-1111-1111-111111111111/201602/02/050522.tar.gz |
+        | 11111111-1111-1111-1111-111111111111 | 4.8.12          | AWS      | 2016-02-02 05:05:22 | 4.8.13          | 4.8.12          | OpenShiftSDN | 1450        | cluster      | /14          | 23                  | stable-4.8 | archives/compressed/35/11111111-1111-1111-1111-111111111111/201602/02/050522.tar.gz |
+        | 22222222-2222-2222-2222-222222222222 | 4.8.12          | AWS      | 2016-02-02 05:05:22 | 4.8.13          | 4.8.12          | OpenShiftSDN | 1450        | service      | /16          | 0                   | stable-4.8 | archives/compressed/35/22222222-2222-2222-2222-222222222222/201602/02/050522.tar.gz |
+        | 22222222-2222-2222-2222-222222222222 | 4.8.12          | AWS      | 2016-02-02 05:05:22 | 4.8.13          | 4.8.12          | OpenShiftSDN | 1450        | cluster      | /14          | 23                  | stable-4.8 | archives/compressed/35/22222222-2222-2222-2222-222222222222/201602/02/050522.tar.gz |
+
+    Scenario: Table generation: available_updates
+       When I fill the topics with messages of the previous hour
+        | topic                   | partition | type             | cluster                              |
+        | incoming_features_topic | 0         | features message | 11111111-1111-1111-1111-111111111111 |
+        | incoming_features_topic | 1         | features message | 22222222-2222-2222-2222-222222222222 |
+        | incoming_rules_topic    | 0         | rules message    | 33333333-3333-3333-3333-333333333333 |
+        | incoming_rules_topic    | 1         | rules message    | 44444444-4444-4444-4444-444444444444 |
+        And I fill the topics with messages of the current hour
+        | topic                   | partition | type             | cluster                              |
+        | incoming_features_topic | 0         | features message | 55555555-5555-5555-5555-555555555555 |
+        | incoming_features_topic | 1         | features message | 66666666-6666-6666-6666-666666666666 |
+        | incoming_rules_topic    | 0         | rules message    | 77777777-7777-7777-7777-777777777777 |
+        | incoming_rules_topic    | 1         | rules message    | 88888888-8888-8888-8888-888888888888 |
+       When I run Parquet Factory with a timeout of "10" seconds
+       Then Parquet Factory should have finish
+        And The logs should contain
+        | topic                   | partition | offset | message           |
+        | incoming_features_topic | 0         | 0      | message processed |
+        | incoming_features_topic | 1         | 0      | message processed |
+        | incoming_rules_topic    | 0         | 0      | message processed |
+        | incoming_rules_topic    | 1         | 0      | message processed |
+        | incoming_features_topic | 0         | 1      | FINISH            |
+        | incoming_features_topic | 1         | 1      | FINISH            |
+        | incoming_rules_topic    | 0         | 1      | FINISH            |
+        | incoming_rules_topic    | 0         | 1      | FINISH            |
+        And I should see following objects generated in S3
+        | File name                              |
+        | fleet_aggregations/available_updates/hourly/date=2016-02-02/hour=05/available_updates-0.parquet |
+        And The parquet file fleet_aggregations/available_updates/hourly/date=2016-02-02/hour=05/available_updates-0.parquet is exactly this one
+        | cluster_id                           | cluster_version | release     | collected_at        | archive_path                                                                        |
+        | 11111111-1111-1111-1111-111111111111 | 4.8.12          | 4.10.0-fc.4 | 2016-02-02 05:05:22 | archives/compressed/35/11111111-1111-1111-1111-111111111111/201602/02/050522.tar.gz |
+        | 11111111-1111-1111-1111-111111111111 | 4.8.12          | 4.10.0-fc.4 | 2016-02-02 05:05:22 | archives/compressed/35/11111111-1111-1111-1111-111111111111/201602/02/050522.tar.gz |
+        | 22222222-2222-2222-2222-222222222222 | 4.8.12          | 4.10.0-fc.4 | 2016-02-02 05:05:22 | archives/compressed/35/22222222-2222-2222-2222-222222222222/201602/02/050522.tar.gz |
+        | 22222222-2222-2222-2222-222222222222 | 4.8.12          | 4.10.0-fc.4 | 2016-02-02 05:05:22 | archives/compressed/35/22222222-2222-2222-2222-222222222222/201602/02/050522.tar.gz |
+
+    Scenario: Table generation: conditional_update_conditions
+       When I fill the topics with messages of the previous hour
+        | topic                   | partition | type             | cluster                              |
+        | incoming_features_topic | 0         | features message | 11111111-1111-1111-1111-111111111111 |
+        | incoming_features_topic | 1         | features message | 22222222-2222-2222-2222-222222222222 |
+        | incoming_rules_topic    | 0         | rules message    | 33333333-3333-3333-3333-333333333333 |
+        | incoming_rules_topic    | 1         | rules message    | 44444444-4444-4444-4444-444444444444 |
+        And I fill the topics with messages of the current hour
+        | topic                   | partition | type             | cluster                              |
+        | incoming_features_topic | 0         | features message | 55555555-5555-5555-5555-555555555555 |
+        | incoming_features_topic | 1         | features message | 66666666-6666-6666-6666-666666666666 |
+        | incoming_rules_topic    | 0         | rules message    | 77777777-7777-7777-7777-777777777777 |
+        | incoming_rules_topic    | 1         | rules message    | 88888888-8888-8888-8888-888888888888 |
+       When I run Parquet Factory with a timeout of "10" seconds
+       Then Parquet Factory should have finish
+        And The logs should contain
+        | topic                   | partition | offset | message           |
+        | incoming_features_topic | 0         | 0      | message processed |
+        | incoming_features_topic | 1         | 0      | message processed |
+        | incoming_rules_topic    | 0         | 0      | message processed |
+        | incoming_rules_topic    | 1         | 0      | message processed |
+        | incoming_features_topic | 0         | 1      | FINISH            |
+        | incoming_features_topic | 1         | 1      | FINISH            |
+        | incoming_rules_topic    | 0         | 1      | FINISH            |
+        | incoming_rules_topic    | 0         | 1      | FINISH            |
+        And I should see following objects generated in S3
+        | File name                              |
+        | fleet_aggregations/conditional_update_conditions/hourly/date=2016-02-02/hour=05/conditional_update_conditions-0.parquet |
+        And The parquet file fleet_aggregations/conditional_update_conditions/hourly/date=2016-02-02/hour=05/conditional_update_conditions-0.parquet is exactly this one
+        | cluster_id                           | cluster_version | release     | recommended | reason     | message                                                                                        | collected_at        | archive_path                                                                        |
+        | 11111111-1111-1111-1111-111111111111 | 4.8.12          | 4.10.0-fc.4 | True        | AsExpected | The update is recommended, because none of the conditional update risks apply to this cluster. | 2016-02-02 05:05:22 | archives/compressed/35/11111111-1111-1111-1111-111111111111/201602/02/050522.tar.gz |
+        | 11111111-1111-1111-1111-111111111111 | 4.8.12          | 4.10.0-fc.4 | Unknown     | AsExpected | The update is recommended, because none of the conditional update risks apply to this cluster. | 2016-02-02 05:05:22 | archives/compressed/35/11111111-1111-1111-1111-111111111111/201602/02/050522.tar.gz |
+        | 22222222-2222-2222-2222-222222222222 | 4.8.12          | 4.10.0-fc.4 | True        | AsExpected | The update is recommended, because none of the conditional update risks apply to this cluster. | 2016-02-02 05:05:22 | archives/compressed/35/22222222-2222-2222-2222-222222222222/201602/02/050522.tar.gz |
+        | 22222222-2222-2222-2222-222222222222 | 4.8.12          | 4.10.0-fc.4 | Unknown     | AsExpected | The update is recommended, because none of the conditional update risks apply to this cluster. | 2016-02-02 05:05:22 | archives/compressed/35/22222222-2222-2222-2222-222222222222/201602/02/050522.tar.gz |
+
+    Scenario: Table generation: conditional_update_risks
+       When I fill the topics with messages of the previous hour
+        | topic                   | partition | type             | cluster                              |
+        | incoming_features_topic | 0         | features message | 11111111-1111-1111-1111-111111111111 |
+        | incoming_features_topic | 1         | features message | 22222222-2222-2222-2222-222222222222 |
+        | incoming_rules_topic    | 0         | rules message    | 33333333-3333-3333-3333-333333333333 |
+        | incoming_rules_topic    | 1         | rules message    | 44444444-4444-4444-4444-444444444444 |
+        And I fill the topics with messages of the current hour
+        | topic                   | partition | type             | cluster                              |
+        | incoming_features_topic | 0         | features message | 55555555-5555-5555-5555-555555555555 |
+        | incoming_features_topic | 1         | features message | 66666666-6666-6666-6666-666666666666 |
+        | incoming_rules_topic    | 0         | rules message    | 77777777-7777-7777-7777-777777777777 |
+        | incoming_rules_topic    | 1         | rules message    | 88888888-8888-8888-8888-888888888888 |
+       When I run Parquet Factory with a timeout of "10" seconds
+       Then Parquet Factory should have finish
+        And The logs should contain
+        | topic                   | partition | offset | message           |
+        | incoming_features_topic | 0         | 0      | message processed |
+        | incoming_features_topic | 1         | 0      | message processed |
+        | incoming_rules_topic    | 0         | 0      | message processed |
+        | incoming_rules_topic    | 1         | 0      | message processed |
+        | incoming_features_topic | 0         | 1      | FINISH            |
+        | incoming_features_topic | 1         | 1      | FINISH            |
+        | incoming_rules_topic    | 0         | 1      | FINISH            |
+        | incoming_rules_topic    | 0         | 1      | FINISH            |
+        And I should see following objects generated in S3
+        | File name                              |
+        | fleet_aggregations/conditional_update_risks/hourly/date=2016-02-02/hour=05/conditional_update_risks-0.parquet |
+        And The parquet file fleet_aggregations/conditional_update_risks/hourly/date=2016-02-02/hour=05/conditional_update_risks-0.parquet is exactly this one
+        | cluster_id                           | cluster_version | release     | risk                     | collected_at        | archive_path                                                                        |
+        | 11111111-1111-1111-1111-111111111111 | 4.8.12          | 4.10.0-fc.4 | AlibabaStorageDriverDemo | 2016-02-02 05:05:22 | archives/compressed/35/11111111-1111-1111-1111-111111111111/201602/02/050522.tar.gz |
+        | 11111111-1111-1111-1111-111111111111 | 4.8.12          | 4.10.0-fc.4 | AlibabaStorageDriverDemo | 2016-02-02 05:05:22 | archives/compressed/35/11111111-1111-1111-1111-111111111111/201602/02/050522.tar.gz |
+        | 22222222-2222-2222-2222-222222222222 | 4.8.12          | 4.10.0-fc.4 | AlibabaStorageDriverDemo | 2016-02-02 05:05:22 | archives/compressed/35/22222222-2222-2222-2222-222222222222/201602/02/050522.tar.gz |
+        | 22222222-2222-2222-2222-222222222222 | 4.8.12          | 4.10.0-fc.4 | AlibabaStorageDriverDemo | 2016-02-02 05:05:22 | archives/compressed/35/22222222-2222-2222-2222-222222222222/201602/02/050522.tar.gz |
+
+    Scenario: Table generation: cluster_thanos_info
+       When I fill the topics with messages of the previous hour
+        | topic                   | partition | type             | cluster                              |
+        | incoming_features_topic | 0         | features message | 11111111-1111-1111-1111-111111111111 |
+        | incoming_features_topic | 1         | features message | 22222222-2222-2222-2222-222222222222 |
+        | incoming_rules_topic    | 0         | rules message    | 33333333-3333-3333-3333-333333333333 |
+        | incoming_rules_topic    | 1         | rules message    | 44444444-4444-4444-4444-444444444444 |
+        And I fill the topics with messages of the current hour
+        | topic                   | partition | type             | cluster                              |
+        | incoming_features_topic | 0         | features message | 55555555-5555-5555-5555-555555555555 |
+        | incoming_features_topic | 1         | features message | 66666666-6666-6666-6666-666666666666 |
+        | incoming_rules_topic    | 0         | rules message    | 77777777-7777-7777-7777-777777777777 |
+        | incoming_rules_topic    | 1         | rules message    | 88888888-8888-8888-8888-888888888888 |
+       When I run Parquet Factory with a timeout of "10" seconds
+       Then Parquet Factory should have finish
+        And The logs should contain
+        | topic                   | partition | offset | message           |
+        | incoming_features_topic | 0         | 0      | message processed |
+        | incoming_features_topic | 1         | 0      | message processed |
+        | incoming_rules_topic    | 0         | 0      | message processed |
+        | incoming_rules_topic    | 1         | 0      | message processed |
+        | incoming_features_topic | 0         | 1      | FINISH            |
+        | incoming_features_topic | 1         | 1      | FINISH            |
+        | incoming_rules_topic    | 0         | 1      | FINISH            |
+        | incoming_rules_topic    | 0         | 1      | FINISH            |
+        And I should not see following objects generated in S3
+        | File name                              |
+        | fleet_aggregations/cluster_thanos_info/hourly/date=2016-02-02/hour=05/cluster_thanos_info-0.parquet |

--- a/features/parquet-factory/s3.feature
+++ b/features/parquet-factory/s3.feature
@@ -1,0 +1,130 @@
+@parquet_service
+
+Feature: Ability to handle the S3 connection correctly
+
+    Background: Initial state is ready
+      Given the system is in default state
+        And Kafka broker is available
+        And Kafka topic "incoming_features_topic" is empty and has 2 partitions
+        And Kafka topic "incoming_rules_topic" is empty and has 2 partitions
+        And S3 endpoint is set
+        And S3 port is set
+        And S3 access key is set
+        And S3 secret access key is set
+        And S3 bucket name is set to test
+        And S3 connection is established
+        And The S3 bucket is empty
+
+    Scenario: Parquet Factory should fail if it cannot connect with S3. When I rerun it, it should re-process the messages from the beginning
+     When I set the environment variable "PARQUET_FACTORY__S3__ENDPOINT" to "non-existent-url"
+      And I fill the topics with messages of the previous hour
+        | topic                   | partition | type             | cluster                              |
+        | incoming_features_topic | 0         | features message | 11111111-1111-1111-1111-111111111111 |
+        | incoming_features_topic | 1         | features message | 22222222-2222-2222-2222-222222222222 |
+        | incoming_rules_topic    | 0         | rules message    | 33333333-3333-3333-3333-333333333333 |
+        | incoming_rules_topic    | 1         | rules message    | 44444444-4444-4444-4444-444444444444 |
+      And I fill the topics with messages of the current hour
+        | topic                   | partition | type             | cluster                              |
+        | incoming_features_topic | 0         | features message | 55555555-5555-5555-5555-555555555555 |
+        | incoming_features_topic | 1         | features message | 66666666-6666-6666-6666-666666666666 |
+        | incoming_rules_topic    | 0         | rules message    | 77777777-7777-7777-7777-777777777777 |
+        | incoming_rules_topic    | 1         | rules message    | 88888888-8888-8888-8888-888888888888 |
+      And I run Parquet Factory with a timeout of "20" seconds
+      # Then  Parquet Factory shouldn't have finish
+      # I removed this step because in CI PF takes 0 seconds to discover that the URL doesn't exist whether in local it takes more than 20
+     Then The S3 bucket is empty
+      And The logs should contain
+        | topic                   | partition | offset | message           |
+        | incoming_features_topic | 0         | 0      | message processed |
+        | incoming_features_topic | 1         | 0      | message processed |
+        | incoming_rules_topic    | 0         | 0      | message processed |
+        | incoming_rules_topic    | 1         | 0      | message processed |
+        | incoming_features_topic | 0         | 1      | FINISH            |
+        | incoming_features_topic | 1         | 1      | FINISH            |
+        | incoming_rules_topic    | 0         | 1      | FINISH            |
+        | incoming_rules_topic    | 1         | 1      | FINISH            |
+      And The logs should contain "Unable to retrieve the indexes from S3 bucket"
+      # Check that it reprocess the same messages
+     When I run Parquet Factory with a timeout of "20" seconds
+     Then The logs should contain
+        | topic                   | partition | offset | message           |
+        | incoming_features_topic | 0         | 0      | message processed |
+        | incoming_features_topic | 1         | 0      | message processed |
+        | incoming_rules_topic    | 0         | 0      | message processed |
+        | incoming_rules_topic    | 1         | 0      | message processed |
+        | incoming_features_topic | 0         | 1      | FINISH            |
+        | incoming_features_topic | 1         | 1      | FINISH            |
+        | incoming_rules_topic    | 0         | 1      | FINISH            |
+        | incoming_rules_topic    | 1         | 1      | FINISH            |
+
+    Scenario: Parquet Factory should fail if it cannot find the bucket
+     When I set the environment variable "PARQUET_FACTORY__S3__BUCKET" to "non_existent_bucket"
+      And I fill the topics with messages of the previous hour
+        | topic                   | partition | type             | cluster                              |
+        | incoming_features_topic | 0         | features message | 11111111-1111-1111-1111-111111111111 |
+        | incoming_features_topic | 1         | features message | 22222222-2222-2222-2222-222222222222 |
+        | incoming_rules_topic    | 0         | rules message    | 33333333-3333-3333-3333-333333333333 |
+        | incoming_rules_topic    | 1         | rules message    | 44444444-4444-4444-4444-444444444444 |
+      And I fill the topics with messages of the current hour
+        | topic                   | partition | type             | cluster                              |
+        | incoming_features_topic | 0         | features message | 55555555-5555-5555-5555-555555555555 |
+        | incoming_features_topic | 1         | features message | 66666666-6666-6666-6666-666666666666 |
+        | incoming_rules_topic    | 0         | rules message    | 77777777-7777-7777-7777-777777777777 |
+        | incoming_rules_topic    | 1         | rules message    | 88888888-8888-8888-8888-888888888888 |
+      And I run Parquet Factory with a timeout of "10" seconds
+     Then Parquet Factory should have finish
+     Then The S3 bucket is empty
+      And The logs should contain
+        | topic                   | partition | offset | message           |
+        | incoming_features_topic | 0         | 0      | message processed |
+        | incoming_features_topic | 1         | 0      | message processed |
+        | incoming_rules_topic    | 0         | 0      | message processed |
+        | incoming_rules_topic    | 1         | 0      | message processed |
+        | incoming_features_topic | 0         | 1      | FINISH            |
+        | incoming_features_topic | 1         | 1      | FINISH            |
+        | incoming_rules_topic    | 0         | 1      | FINISH            |
+        | incoming_rules_topic    | 1         | 1      | FINISH            |
+      And The logs should contain "NoSuchBucket"
+      # Check that it reprocess the same messages
+     When I run Parquet Factory with a timeout of "10" seconds
+     # FIXME: PF doesn't start from the beginning in case of the bucket not existing
+     Then The logs should contain
+        | topic                   | partition | offset | message           |
+        | incoming_features_topic | 0         | 0      | message processed |
+        | incoming_features_topic | 1         | 0      | message processed |
+        | incoming_rules_topic    | 0         | 0      | message processed |
+        | incoming_rules_topic    | 1         | 0      | message processed |
+        | incoming_features_topic | 0         | 1      | FINISH            |
+        | incoming_features_topic | 1         | 1      | FINISH            |
+        | incoming_rules_topic    | 0         | 1      | FINISH            |
+        | incoming_rules_topic    | 1         | 1      | FINISH            |
+      And The logs should contain "NoSuchBucket"
+
+    Scenario: Parquet Factory shouldn't fail if it cannot find the folder/prefix where the files are stored
+     When I set the environment variable "PARQUET_FACTORY__S3__PREFIX" to "non_existing_folder"
+      And I fill the topics with messages of the previous hour
+        | topic                   | partition | type             | cluster                              |
+        | incoming_features_topic | 0         | features message | 11111111-1111-1111-1111-111111111111 |
+        | incoming_features_topic | 1         | features message | 22222222-2222-2222-2222-222222222222 |
+        | incoming_rules_topic    | 0         | rules message    | 33333333-3333-3333-3333-333333333333 |
+        | incoming_rules_topic    | 1         | rules message    | 44444444-4444-4444-4444-444444444444 |
+      And I fill the topics with messages of the current hour
+        | topic                   | partition | type             | cluster                              |
+        | incoming_features_topic | 0         | features message | 55555555-5555-5555-5555-555555555555 |
+        | incoming_features_topic | 1         | features message | 66666666-6666-6666-6666-666666666666 |
+        | incoming_rules_topic    | 0         | rules message    | 77777777-7777-7777-7777-777777777777 |
+        | incoming_rules_topic    | 1         | rules message    | 88888888-8888-8888-8888-888888888888 |
+      And I run Parquet Factory with a timeout of "10" seconds
+     Then Parquet Factory should have finish
+      And The S3 bucket is not empty
+      And The logs should contain
+        | topic                   | partition | offset | message           |
+        | incoming_features_topic | 0         | 0      | message processed |
+        | incoming_features_topic | 1         | 0      | message processed |
+        | incoming_rules_topic    | 0         | 0      | message processed |
+        | incoming_rules_topic    | 1         | 0      | message processed |
+        | incoming_features_topic | 0         | 1      | FINISH            |
+        | incoming_features_topic | 1         | 1      | FINISH            |
+        | incoming_rules_topic    | 0         | 1      | FINISH            |
+        | incoming_rules_topic    | 1         | 1      | FINISH            |
+      And The logs should contain "File will be stored in non_existing_folder/"

--- a/features/src/minio.py
+++ b/features/src/minio.py
@@ -43,6 +43,18 @@ def minio_client(context: Context):
         context.minio_client = client
 
 
+def create_bucket(context: Context):
+    """Remove the bucket if exists and re-create again."""
+    bucket_name = context.S3_bucket_name
+    found = context.minio_client.bucket_exists(bucket_name)
+
+    if found:
+        clean_bucket(context)
+        context.minio_client.remove_bucket(bucket_name)
+
+    context.minio_client.make_bucket(bucket_name)
+
+
 def bucket_check(context: Context):
     """Check bucket existence."""
     bucket_name = context.S3_bucket_name

--- a/features/src/minio.py
+++ b/features/src/minio.py
@@ -14,9 +14,11 @@
 
 """Minio/S3-related functions that can be called from other sources and test step definitions."""
 
-from minio import Minio
-from io import StringIO
+from io import BytesIO, StringIO
+from typing import List
+
 from behave.runner import Context
+from minio import Minio
 
 
 def minio_client(context: Context):
@@ -62,9 +64,35 @@ def read_object_into_buffer(context: Context, object_name):
     return buff
 
 
+def read_object_into_bytes_buffer(context: Context, object_name: str) -> BytesIO:
+    """Retrieve ibject from pre-selected bucket into a bytes buffer."""
+    bucket_name = context.S3_bucket_name
+    response = context.minio_client.get_object(bucket_name, object_name)
+    assert response is not None, "No response from storage."
+
+    # convert into buffer
+    buff = BytesIO(response.read())
+    assert buff is not None, "Read error"
+
+    return buff
+
+
 def get_object_name(context: Context, filename):
     """Retrieve object name compatible with S3 and Minio, including older versions."""
     if context.S3_old_minio_compatibility:
         return filename
     else:
         return f"{context.S3_bucket_name}/{filename}"
+
+
+def clean_bucket(context: Context):
+    """Remove all the objects from the bucket."""
+    objects = context.minio_client.list_objects(context.S3_bucket_name, recursive=True)
+    object_names = [o.object_name for o in objects]
+    remove_objects_by_name(context, object_names)
+
+
+def remove_objects_by_name(context: Context, object_names: List[str]):
+    """Remove the objects from the list in the configured bucket."""
+    for object_name in object_names:
+        context.minio_client.remove_object(context.S3_bucket_name, object_name)

--- a/features/steps/exporter_s3.py
+++ b/features/steps/exporter_s3.py
@@ -158,7 +158,7 @@ def check_objects_in_s3(context):
 
 @then("I should not see following objects generated in S3")
 def check_objects_not_in_s3(context):
-    "Check that all specified objects were not generated."""
+    """Check that all specified objects were not generated."""
     bucket_check(context)
 
     # retrieve all objects stored in bucket

--- a/features/steps/exporter_s3.py
+++ b/features/steps/exporter_s3.py
@@ -20,7 +20,6 @@ from behave import given, then
 from src.csv_checks import check_table_content
 from src.minio import (
     bucket_check,
-    clean_bucket,
     create_bucket,
     get_object_name,
     minio_client,

--- a/features/steps/exporter_s3.py
+++ b/features/steps/exporter_s3.py
@@ -21,6 +21,7 @@ from src.csv_checks import check_table_content
 from src.minio import (
     bucket_check,
     clean_bucket,
+    create_bucket,
     get_object_name,
     minio_client,
     read_object_into_buffer,
@@ -111,8 +112,7 @@ def assert_s3_bucket_is_empty(context):
 @given("The S3 bucket is empty")
 def ensure_s3_bucket_is_empty(context):
     """Ensure that the bucket is empty."""
-    bucket_check(context)
-    clean_bucket(context)
+    create_bucket(context)
 
 
 @then("The S3 bucket is empty")

--- a/features/steps/exporter_s3.py
+++ b/features/steps/exporter_s3.py
@@ -115,6 +115,26 @@ def ensure_s3_bucket_is_empty(context):
     clean_bucket(context)
 
 
+@then("The S3 bucket is empty")
+def check_bucket_is_empty(context):
+    """Check if the bucket is empty."""
+    bucket_check(context)
+    # retrieve all objects stored in bucket
+    objects = context.minio_client.list_objects(context.S3_bucket_name, recursive=True)
+    names = [o.object_name for o in objects]
+    assert len(names) == 0
+
+
+@then("The S3 bucket is not empty")
+def check_bucket_contains_files(context):
+    """Check that the S3 bucket has, at least, 1 file."""
+    bucket_check(context)
+    # retrieve all objects stored in bucket
+    objects = context.minio_client.list_objects(context.S3_bucket_name, recursive=True)
+    names = [o.object_name for o in objects]
+    assert len(names) > 0
+
+
 @then("I should see following objects generated in S3")
 def check_objects_in_s3(context):
     """Check that all specified objects was generated."""

--- a/features/steps/kafka_steps.py
+++ b/features/steps/kafka_steps.py
@@ -83,7 +83,7 @@ def delete_kafka_topic(context, topic):
 
 @given('Kafka topic "{topic}" is empty and has {partitions} partition')
 @given('Kafka topic "{topic}" is empty and has {partitions} partitions')
-def delete_kafka_topic(context, topic, partitions):
+def delete_kafka_topic_with_partition(context, topic, partitions):
     """Delete a Kafka topic."""
     delete_topic(context, topic)
     bootstrap_server = f"{context.kafka_hostname}:{context.kafka_port}"

--- a/features/steps/kafka_steps.py
+++ b/features/steps/kafka_steps.py
@@ -18,9 +18,9 @@
 import subprocess
 import json
 
+from src.kafka_util import create_topic, delete_topic
+
 from behave import given, then, when
-from kafka import KafkaAdminClient
-from kafka.errors import UnknownTopicOrPartitionError
 
 
 @when("I retrieve metadata from Kafka broker")
@@ -78,12 +78,17 @@ def find_available_brokers(context):
 @given('Kafka topic "{topic}" is empty')
 def delete_kafka_topic(context, topic):
     """Delete a Kafka topic."""
-    admin_client = KafkaAdminClient(
-        bootstrap_servers=[f"{context.kafka_hostname}:{context.kafka_port}"]
+    delete_topic(context, topic)
+
+
+@given('Kafka topic "{topic}" is empty and has {partitions} partition')
+@given('Kafka topic "{topic}" is empty and has {partitions} partitions')
+def delete_kafka_topic(context, topic, partitions):
+    """Delete a Kafka topic."""
+    delete_topic(context, topic)
+    bootstrap_server = f"{context.kafka_hostname}:{context.kafka_port}"
+    create_topic(
+        bootstrap_server,
+        topic,
+        int(partitions),
     )
-    try:
-        admin_client.delete_topics(topics=[topic])
-    except UnknownTopicOrPartitionError:
-        pass
-    except Exception as e:
-        print("Topic {} was not deleted. Error: {}".format(topic, e))

--- a/features/steps/parquet_factory.py
+++ b/features/steps/parquet_factory.py
@@ -1,0 +1,165 @@
+import json
+import logging
+import os
+import subprocess
+import tempfile
+import time
+from threading import Timer
+
+from src import kafka_util
+
+
+# parquet-factory binary file name
+PARQUET_FACTORY_BINARY = "parquet-factory"
+
+# path do directory with rules results templates to be used
+DATA_DIRECTORY = "test_data"
+
+
+@when('I run Parquet Factory with a timeout of "{timeout_sec:d}" seconds')
+def run_parquet_factory(context, timeout_sec: int) -> str:
+    """
+    Run Parquet Factory.
+
+    This function waits for {timeout_sec} to save its result in context.
+    """
+    context.parquet_factory_timed_out = False
+
+    os.environ["PARQUET_FACTORY__LOGGING__DEBUG"] = "false"
+    proc = subprocess.Popen(
+        [PARQUET_FACTORY_BINARY],
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+    )
+
+    timer = Timer(timeout_sec, proc.kill)
+    try:
+        timer.start()
+    finally:
+        if timer.is_alive():
+            print("Timer was still alive")
+            timed_out = False
+        else:
+            print("Timer wasn't alive")
+            timed_out = True
+        timer.cancel()
+
+    stdout, stderr = proc.communicate()
+    output = f"""----------------- STDOUT -----------------
+{stdout.decode("utf-8")}
+----------------- STDERR -----------------
+{stderr.decode("utf-8") if stderr else ""}
+"""
+    context.parquet_factory_logs = output
+    context.parquet_factory_timed_out = timed_out
+
+    save_logs_to_tempfile(output)
+
+    print("-v-" * 10)
+    print(output)
+
+
+@then("Parquet Factory should have finish")
+def check_has_finished(context):
+    """Make sure Parquet Factory finished gracefully."""
+    assert not context.parquet_factory_timed_out, "PF was still running"
+
+
+@when("I fill the topics with messages of the {moment} hour")
+def send_rules_results_to_kafka(context, moment):
+    """Send rule results into seleted topic on selected broker."""
+    shift = {
+        "previous": -3600,
+        "current": 0,
+    }.get(moment, 0)
+
+    with open(f"{DATA_DIRECTORY}/rules_message.json", "r") as payload_file:
+        rules_payload = payload_file.read()
+
+    with open(f"{DATA_DIRECTORY}/features_message.json", "r") as payload_file:
+        features_payload = payload_file.read()
+
+    for row in context.table:
+        topic = row["topic"]
+        partition = int(row["partition"])
+        if row["type"] == "rules message":
+            payload = rules_payload
+        elif row["type"] == "features message":
+            payload = features_payload
+        else:
+            payload = row["payload"]
+
+        cluster_id = row.get("cluster", "")
+        if cluster_id != "":
+            payload = payload.replace("CLUSTER_ID_TO_BE_REPLACED", cluster_id)
+
+        kafka_util.send_event(
+            f"{context.kafka_hostname}:{context.kafka_port}",
+            topic, payload.encode("utf-8"), partition=partition,
+            timestamp=time.time() + shift
+        )
+
+
+def save_logs_to_tempfile(logs):
+    """Store the logs in a temporary file."""
+    tf = tempfile.NamedTemporaryFile(delete=False)
+    with open(tf.name, "w") as pf_log_file:
+        pf_log_file.write(logs)
+    logging.info(f"You can check Parquet Factory logs at {tf.name}.")
+
+
+@then("The logs should contain")
+def check_logs_table(context):
+    """Make sure the messaging log is in Parquet Factory logs."""
+    for row in context.table:
+        ok = check_logs(
+            context.parquet_factory_logs,
+            row["topic"],
+            row["partition"],
+            row["offset"],
+            row["message"],
+        )
+        assert ok, \
+            f'topic {row["topic"]}, partition {row["partition"]}, ' + \
+            f'offset {row["offset"]}, message {row["message"]}, ' + \
+            'not found'
+
+
+def check_logs(logs: str, topic: str, partition: int,
+               offset: int, message: str):
+    """
+    Make sure that a messaging log exists in Parquet Factory logs.
+
+    The log is build from the topic, partition, offset and
+    message arguments.
+    """
+    # Parse the fields and values into a dictionary
+    map_checker = {
+        "topic": topic,
+        "partition": partition,
+        "offset": offset,
+        "message": message,
+    }
+
+    num_fields_to_check = len(map_checker)
+
+    logs = logs.split("\n")
+
+    for log in logs:
+        found = 0
+        try:
+            log_as_json = json.loads(log)
+        except json.decoder.JSONDecodeError:
+            continue
+
+        if not set(map_checker.keys()) <= set(log_as_json.keys()):
+            # Make sure all the expected fields are in the JSON
+            continue
+
+        for k, v in map_checker.items():
+            if str(log_as_json[k]) == v:
+                found += 1
+        if found == num_fields_to_check:
+            return True
+    logging.debug(map_checker, "not found")
+    return False

--- a/features/steps/parquet_factory.py
+++ b/features/steps/parquet_factory.py
@@ -1,3 +1,5 @@
+"""Module with steps implementation related to parquet-factory tests."""
+
 import json
 import logging
 import os
@@ -5,6 +7,8 @@ import subprocess
 import tempfile
 import time
 from threading import Timer
+
+from behave import then, when
 
 from src import kafka_util
 
@@ -18,8 +22,7 @@ DATA_DIRECTORY = "test_data"
 
 @when('I run Parquet Factory with a timeout of "{timeout_sec:d}" seconds')
 def run_parquet_factory(context, timeout_sec: int) -> str:
-    """
-    Run Parquet Factory.
+    """Run Parquet Factory.
 
     This function waits for {timeout_sec} to save its result in context.
     """
@@ -127,8 +130,7 @@ def check_logs_table(context):
 
 def check_logs(logs: str, topic: str, partition: int,
                offset: int, message: str):
-    """
-    Make sure that a messaging log exists in Parquet Factory logs.
+    """Make sure that a messaging log exists in Parquet Factory logs.
 
     The log is build from the topic, partition, offset and
     message arguments.

--- a/features/steps/parquet_factory.py
+++ b/features/steps/parquet_factory.py
@@ -7,7 +7,6 @@ import subprocess
 import tempfile
 import time
 from threading import Timer
-from typing import Dict
 
 from behave import then, when
 

--- a/features/steps/parquet_files.py
+++ b/features/steps/parquet_files.py
@@ -1,0 +1,45 @@
+from behave import then
+
+import pandas as pd
+
+from src.minio import read_object_into_bytes_buffer
+
+
+@then("The parquet file {object_name} is exactly this one")
+def check_parquet_table_is(context, object_name):
+    """Check that the parquet table is exactly the one in context."""
+    data = read_object_into_bytes_buffer(context, object_name)
+    got_df = pd.read_parquet(data, engine="pyarrow")
+    got_df = decode_df(got_df)
+
+    want_df = gherkin_table_to_df(context.table)
+    got_df = got_df.astype(str)  # in order to have same format as in want_df
+
+    want_df = want_df.sort_values(
+        by=['archive_path'], ascending=False).reset_index(drop=True)
+    got_df = got_df.sort_values(
+        by=['archive_path'], ascending=False).reset_index(drop=True)
+
+    assert want_df.equals(got_df), f"Got:\n{got_df}\nwant:\n{want_df}"
+
+
+def decode_df(df):
+    """Decode all bytes column into strings."""
+    str_df = df.select_dtypes([object])
+    str_df = str_df.stack().str.decode("utf-8").unstack()
+
+    for col in str_df:
+        df[col] = str_df[col]
+    return df
+
+
+def gherkin_table_to_df(table):
+    """Convert a Gherkin table into a Pandas Dataframe.
+
+    Args:
+        table (behave.model.Table): the Gherkin table.
+
+    Returns:
+        pandas.DataFrame: the table as a Dataframe
+    """
+    return pd.DataFrame(table, columns=table.headings)

--- a/features/steps/parquet_files.py
+++ b/features/steps/parquet_files.py
@@ -1,3 +1,5 @@
+"""Steps implementation for parquet-factory features, related to parquet files."""
+
 from behave import then
 
 import pandas as pd
@@ -36,10 +38,10 @@ def decode_df(df):
 def gherkin_table_to_df(table):
     """Convert a Gherkin table into a Pandas Dataframe.
 
-    Args:
+    _Args:
         table (behave.model.Table): the Gherkin table.
 
-    Returns:
+    _Returns:
         pandas.DataFrame: the table as a Dataframe
     """
     return pd.DataFrame(table, columns=table.headings)

--- a/features/steps/pushgateway.py
+++ b/features/steps/pushgateway.py
@@ -1,3 +1,6 @@
+"""Contains different Pushgateway utilities."""
+
+from pprint import pformat
 from typing import Dict, List
 
 import requests
@@ -91,8 +94,7 @@ def extract_labels(metric: str) -> (str, Dict):
 
 
 def compare(operation, a, b):
-    """
-    Compare {a} and {b} with {operation}.
+    """Compare {a} and {b} with {operation}.
 
     Valid operations:
         - lower than: "<"
@@ -112,8 +114,7 @@ def compare(operation, a, b):
 
 
 def assert_metric_with_label(context, metric, operation, value, label, label_value):
-    """
-    Check a metric in the Pushgateway taking in account the label.
+    """Check a metric in the Pushgateway taking in account the label.
 
     Make sure a metric {metric} has value {value} in {context.metrics}
     dictionary for the given {label} and {label_value}. The value is compared

--- a/features/steps/pushgateway.py
+++ b/features/steps/pushgateway.py
@@ -1,0 +1,133 @@
+from typing import Dict, List
+
+import requests
+
+
+def reset_metrics(pushgateway_url: str) -> None:
+    """Delete all metrics in {PUSHGATEWAY_URL}."""
+    url = f"http://{pushgateway_url}/api/v1/admin/wipe"
+    resp = requests.put(url)
+    assert resp.status_code == 202, \
+        f"Got error code {resp.status_code} while deleting the metrics " + \
+        f"from {url}"
+    metrics = list(get_metrics(pushgateway_url).keys())
+    print(f"Metrics after reseting the pushgateway:\n{metrics}")
+
+
+def get_metrics(pushgateway_url) -> str | Dict[str,List]:
+    """Download the metrics from {pushgateway_url} and store as Dict."""
+    ans = requests.get(f"http://{pushgateway_url}/metrics")
+    if ans.status_code != 200:
+        return ""
+    else:
+        return parse_metrics(ans.text)
+
+
+def parse_metrics(metrics: str) -> Dict[str,List]:
+    """Convert the raw string of metrics into a dictionary.
+
+    {
+        metric: [
+            {
+                value: value,
+                labels: labels
+            },
+            ...
+        }
+    }.
+    """
+    metrics_list = metrics.split("\n")
+    metrics_list = [metric for metric in metrics_list if len(
+        metric) > 0 and metric[0] != "#"]
+    parsed_metrics = {}
+    for metric in metrics_list:
+        key, val = metric.split(" ")
+        metric_name, metric_labels = extract_labels(key)
+
+        if metric_name not in parsed_metrics:
+            parsed_metrics[metric_name] = []
+
+        parsed_metrics[metric_name].append(
+            {
+                "value": val,
+                "labels": metric_labels
+            })
+
+    return parsed_metrics
+
+
+def extract_labels(metric: str) -> (str, Dict):
+    """Parse a metric into a dictionary.
+
+    Convert
+        metric{key1="val1",key2="val2"}
+    into a dictionary like
+        {
+            "key1": "val1",
+            "key2": "val2"
+        }
+    Returns the name of the metric and their additional labels.
+    """
+    splited_metric = metric.split("{")  # Extract the rest of the fields
+    if len(splited_metric) == 1:
+        return metric, {}  # No additional fields
+    elif len(splited_metric) == 2:
+        metric_name, labels = splited_metric
+        if labels[-1] != "}":
+            # Unexpected format
+            return metric_name, {}
+        labels = labels[:-1]  # remove trailing "}"
+        out = {}
+        for pair_of_key_var in labels.split(","):
+            pair_of_key_var = pair_of_key_var.replace(
+                '"', '')  # Remove additional captions
+            key, val = pair_of_key_var.split("=")
+            out[key] = val
+        return metric_name, out
+
+    else:
+        # This is not supposed to happen, so just ignore it
+        return "", {}
+
+
+def compare(operation, a, b):
+    """
+    Compare {a} and {b} with {operation}.
+
+    Valid operations:
+        - lower than: "<"
+        - greater than: ">"
+        - equal to: "=="
+        - not equal to: "!="
+    """
+    if operation == "lower than":
+        return a < b
+    elif operation == "greater than":
+        return a > b
+    elif operation == "equal to":
+        return a == b
+    elif operation == "not equal to":
+        return a != b
+    raise ValueError(f"Invalid operation {operation}")
+
+
+def assert_metric_with_label(context, metric, operation, value, label, label_value):
+    """
+    Check a metric in the Pushgateway taking in account the label.
+
+    Make sure a metric {metric} has value {value} in {context.metrics}
+    dictionary for the given {label} and {label_value}. The value is compared
+    using the operation parameter.
+    """
+    assert metric in context.metrics, \
+        f"Metric {metric} not found in {context.metrics.keys()}"
+
+    for sub_metric in context.metrics[metric]:
+        if not compare(operation, sub_metric["value"], value):
+            continue
+        if not sub_metric["labels"][label] == label_value:
+            continue
+        return
+    assert False, \
+        f"Couldn't find metric {metric} {operation} {value} and label " + \
+        f"{label} as {label_value} in:\n{pformat(context.metrics[metric])}."

--- a/features/steps/pushgateway.py
+++ b/features/steps/pushgateway.py
@@ -17,7 +17,7 @@ def reset_metrics(pushgateway_url: str) -> None:
     print(f"Metrics after reseting the pushgateway:\n{metrics}")
 
 
-def get_metrics(pushgateway_url) -> str | Dict[str,List]:
+def get_metrics(pushgateway_url) -> str | Dict[str, List]:
     """Download the metrics from {pushgateway_url} and store as Dict."""
     ans = requests.get(f"http://{pushgateway_url}/metrics")
     if ans.status_code != 200:
@@ -26,7 +26,7 @@ def get_metrics(pushgateway_url) -> str | Dict[str,List]:
         return parse_metrics(ans.text)
 
 
-def parse_metrics(metrics: str) -> Dict[str,List]:
+def parse_metrics(metrics: str) -> Dict[str, List]:
     """Convert the raw string of metrics into a dictionary.
 
     {

--- a/features/steps/pushgateway_steps.py
+++ b/features/steps/pushgateway_steps.py
@@ -1,0 +1,69 @@
+from behave import when
+
+from pushgateway import (
+    assert_metric_with_label,
+    compare,
+    get_metrics,
+    reset_metrics,
+)
+
+
+@given('Pushgateway in "{pushgateway_url}" is empty of metrics')
+@when('I delete all metrics from "{pushgateway_url}"')
+def _reset_metrics(context, pushgateway_url):
+    """Delete all metrics in {PUSHGATEWAY_URL}."""
+    reset_metrics(pushgateway_url)
+    context.metrics = {}
+
+
+@when('I store the metrics from "{pushgateway_url}"')
+def store_metrics(context, pushgateway_url):
+    """Store the metrics into context.metrics as a dictionary."""
+    context.metrics = get_metrics(pushgateway_url)
+
+
+@then("Metrics are")
+def assert_metrics_table(context):
+    """Check a metric given in context is in the Pushgateway.
+
+    It makes sure a metric {metric} has value {value} in {context.metrics}
+    dictionary for the given {label} and {label_value}. The value is compared
+    using the {operation} parameter. Parameters are read from {context.row}.
+    """
+    for row in context.table:
+        metric = row["metric"]
+        operation = row["operation"]
+        value = row["value"]
+        label = row["label"]
+        label_value = row["label_value"]
+        if label == "" or label_value == "":
+            assert_metric(context, metric, operation, value)
+        else:
+            assert_metric_with_label(
+                context, metric, operation, value, label, label_value)
+
+
+@then('Metric "{metric}" has value "{operation}" "{value}"')
+def assert_metric(context, metric, operation, value):
+    """
+    Check a metric in the Pushgateway.
+
+    Make sure a metric {metric} has value {value} in {context.metrics}
+    dictionary.
+    """
+    assert metric in context.metrics, \
+        f"Metric {metric} not found in {context.metrics.keys()}"
+
+    for sub_metric in context.metrics[metric]:
+        if compare(operation, sub_metric["value"], value):
+            return
+    assert False, \
+        f"Couldn't find metric {metric} {operation} {value} in:" + \
+        f"\n{pformat(context.metrics[metric])}."
+
+
+@then('Metric "{metric}" is not registered')
+def assert_metric_not_registered(context, metric):
+    """Make sure a metric {metric} is not registered."""
+    assert metric not in context.metrics, \
+        f"Metric {metric} found in {context.metrics.keys()}"

--- a/features/steps/pushgateway_steps.py
+++ b/features/steps/pushgateway_steps.py
@@ -1,4 +1,8 @@
-from behave import when
+"""Implementation for metrics push gateway steps."""
+
+from pprint import pformat
+
+from behave import given, then, when
 
 from pushgateway import (
     assert_metric_with_label,
@@ -45,8 +49,7 @@ def assert_metrics_table(context):
 
 @then('Metric "{metric}" has value "{operation}" "{value}"')
 def assert_metric(context, metric, operation, value):
-    """
-    Check a metric in the Pushgateway.
+    """Check a metric in the Pushgateway.
 
     Make sure a metric {metric} has value {value} in {context.metrics}
     dictionary.

--- a/parquet_factory_tests.sh
+++ b/parquet_factory_tests.sh
@@ -1,0 +1,104 @@
+#!/bin/bash -x
+
+# Copyright 2023 Red Hat, Inc
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+dir_path=$(dirname "$(realpath "$0")")
+export PATH=$PATH:$dir_path
+PATH_TO_LOCAL_PARQUET_FACTORY=${PATH_TO_LOCAL_PARQUET_FACTORY:="../parquet-factory"}
+
+#set NOVENV is current environment is not a python virtual env
+[ "$VIRTUAL_ENV" != "" ] || NOVENV=1
+
+function install_reqs() {
+        python3 "$(which pip3)" install -r requirements.txt
+}
+
+function prepare_venv() {
+    echo "Preparing environment"
+    # shellcheck disable=SC1091
+    virtualenv -p python3 venv && source venv/bin/activate && python3 "$(which pip3)" install -r requirements/insights_results_aggregator_mock.txt || exit 1
+    echo "Environment ready"
+}
+
+function get_binary() {
+    (
+        cd "$PATH_TO_LOCAL_PARQUET_FACTORY" || exit
+        make build
+    )
+    cp "$PATH_TO_LOCAL_PARQUET_FACTORY/parquet-factory" .
+    cp "$PATH_TO_LOCAL_PARQUET_FACTORY/config.toml" .
+    add_exit_trap 'rm parquet-factory; config.toml'
+}
+
+function set_env_vars(){
+    export S3_OLDER_MINIO_COMPATIBILITY=1 \
+        PARQUET_FACTORY__S3__ENDPOINT=localhost:9000 \
+        PARQUET_FACTORY__S3__BUCKET=test \
+        PARQUET_FACTORY__S3__ACCESS_KEY=test_access_key \
+        PARQUET_FACTORY__S3__SECRET_KEY=test_secret_access_key
+}
+
+
+function prepare_code_coverage() {
+    echo "Preparing code coverage environment"
+    rm -rf coverage
+    mkdir coverage
+    export GOCOVERDIR=coverage/
+}
+
+function code_coverage_report() {
+    echo "Preparing code coverage report"
+    go tool covdata merge -i=coverage/ -o=.
+    go tool covdata textfmt -i=. -o=coverage.txt
+    cat << EOF
+    +--------------------------------------------------------------+
+    | Coverage report is stored in file named 'coverage.txt'.      |
+    | Copy that file into Smart Proxy project                      |
+    | directory and run the following command to get report        |
+    | in readable form:                                            |
+    |                                                              |
+    | go tool cover -func=coverage.txt                             |
+    |                                                              |
+    +--------------------------------------------------------------+
+EOF
+}
+
+flag=${1:-""}
+
+if [[ "${flag}" = "coverage" ]]
+then
+    shift
+    prepare_code_coverage
+fi
+
+# prepare virtual environment if necessary
+case "$NOVENV" in
+    "") echo "using existing virtual env";;
+    "1") install_reqs && prepare_venv ;;
+esac
+
+set_env_vars
+get_binary
+
+PYTHONDONTWRITEBYTECODE=1 python3 -m behave --tags=-skip -D dump_errors=true @test_list/parquet_factory.txt "$@"
+
+bddExecutionExitCode=$?
+
+if [[ "${flag}" == "coverage" ]]
+then
+    code_coverage_report
+fi
+
+exit $bddExecutionExitCode

--- a/requirements/parquet-factory.txt
+++ b/requirements/parquet-factory.txt
@@ -1,0 +1,6 @@
+behave
+kafka-python
+minio
+pandas
+pyarrow
+numpy

--- a/test_data/features_message.json
+++ b/test_data/features_message.json
@@ -1,0 +1,802 @@
+{
+    "path": "archives/compressed/35/CLUSTER_ID_TO_BE_REPLACED/201602/02/050522.tar.gz",
+    "metadata": {
+        "cluster_id": "CLUSTER_ID_TO_BE_REPLACED",
+        "external_organization": "35"
+    },
+    "report": [
+        {
+            "metadata": {
+                "feature_id": "foc",
+                "component": "fe.features.foc.feature"
+            },
+            "schema": {
+                "version": "1.0",
+                "fields": [
+                    {
+                        "name": "cluster_id",
+                        "type": "String"
+                    },
+                    {
+                        "name": "operator",
+                        "type": "String"
+                    },
+                    {
+                        "name": "type",
+                        "type": "String"
+                    },
+                    {
+                        "name": "status",
+                        "type": "Boolean"
+                    },
+                    {
+                        "name": "last_transition_time",
+                        "type": "DateTime"
+                    },
+                    {
+                        "name": "reason",
+                        "type": "String"
+                    },
+                    {
+                        "name": "message",
+                        "type": "String"
+                    },
+                    {
+                        "name": "analysis_time",
+                        "type": "DateTime"
+                    },
+                    {
+                        "name": "path",
+                        "type": "String"
+                    }
+                ]
+            },
+            "data": [
+                {
+                    "cluster_id": "CLUSTER_ID_TO_BE_REPLACED",
+                    "operator": "machine-config",
+                    "type": "Progressing",
+                    "status": true,
+                    "last_transition_time": "2021-10-08T09:40:54",
+                    "reason": null,
+                    "message": "Working towards 4.8.13",
+                    "analysis_time": "2021-12-13T14:36:18",
+                    "path": "archives/compressed/35/CLUSTER_ID_TO_BE_REPLACED/201602/02/050522.tar.gz"
+                },
+                {
+                    "cluster_id": "CLUSTER_ID_TO_BE_REPLACED",
+                    "operator": "service-ca",
+                    "type": "Progressing",
+                    "status": true,
+                    "last_transition_time": "2021-10-08T09:44:19",
+                    "reason": "_ManagedDeploymentsAvailable",
+                    "message": "Progressing: \nProgressing: service-ca does not have available replicas",
+                    "analysis_time": "2021-12-13T14:36:18",
+                    "path": "archives/compressed/35/CLUSTER_ID_TO_BE_REPLACED/201602/02/050522.tar.gz"
+                }
+            ]
+        },
+        {
+            "metadata": {
+                "feature_id": "cluster_info",
+                "component": "fe.features.cluster_info.feature"
+            },
+            "schema": {
+                "version": "1.0",
+                "fields": [
+                    {
+                        "name": "cluster_id",
+                        "type": "String"
+                    },
+                    {
+                        "name": "platform",
+                        "type": "String"
+                    },
+                    {
+                        "name": "network_type",
+                        "type": "String"
+                    },
+                    {
+                        "name": "network_mtu",
+                        "type": "Integer"
+                    },
+                    {
+                        "name": "channel",
+                        "type": "String"
+                    },
+                    {
+                        "name": "initial_version",
+                        "type": "String"
+                    },
+                    {
+                        "name": "current_version",
+                        "type": "String"
+                    },
+                    {
+                        "name": "desired_version",
+                        "type": "String"
+                    },
+                    {
+                        "name": "installed_at",
+                        "type": "DateTime"
+                    },
+                    {
+                        "name": "failing_since",
+                        "type": "DateTime"
+                    },
+                    {
+                        "name": "upgrading_since",
+                        "type": "DateTime"
+                    },
+                    {
+                        "name": "last_y_upgrade_at",
+                        "type": "DateTime"
+                    },
+                    {
+                        "name": "last_z_upgrade_at",
+                        "type": "DateTime"
+                    },
+                    {
+                        "name": "analysis_time",
+                        "type": "DateTime"
+                    },
+                    {
+                        "name": "path",
+                        "type": "String"
+                    }
+                ]
+            },
+            "data": [
+                {
+                    "cluster_id": "CLUSTER_ID_TO_BE_REPLACED",
+                    "platform": "AWS",
+                    "network_type": "OpenShiftSDN",
+                    "network_mtu": 1450,
+                    "networks": [
+                        {
+                            "kind": "service",
+                            "size": "/16",
+                            "host_prefix": null
+                        },
+                        {
+                            "kind": "cluster",
+                            "size": "/14",
+                            "host_prefix": 23
+                        }
+                    ],
+                    "channel": "stable-4.8",
+                    "initial_version": "4.8.12",
+                    "current_version": "4.8.12",
+                    "desired_version": "4.8.13",
+                    "installed_at": "2021-10-08T08:00:00+00:00",
+                    "failing_since": null,
+                    "upgrading_since": "2021-10-08T08:52:20+00:00",
+                    "last_y_upgrade_at": null,
+                    "last_z_upgrade_at": "2021-10-08T08:52:20+00:00",
+                    "analysis_time": "2021-12-13T14:36:18",
+                    "path": "archives/compressed/35/CLUSTER_ID_TO_BE_REPLACED/201602/02/050522.tar.gz"
+                }
+            ]
+        },
+        {
+            "metadata": {
+                "feature_id": "gatherers",
+                "component": "fe.features.gatherer_info.feature"
+            },
+            "schema": {
+                "version": "1.0",
+                "fields": [
+                    {
+                        "name": "cluster_id",
+                        "type": "String"
+                    },
+                    {
+                        "name": "name",
+                        "type": "String"
+                    },
+                    {
+                        "name": "duration_in_ms",
+                        "type": "Integer"
+                    },
+                    {
+                        "name": "analysis_time",
+                        "type": "DateTime"
+                    },
+                    {
+                        "name": "path",
+                        "type": "String"
+                    }
+                ]
+            },
+            "data": [
+                {
+                    "cluster_id": "CLUSTER_ID_TO_BE_REPLACED",
+                    "name": "clusterconfig/image_pruners",
+                    "duration_in_ms": 19,
+                    "analysis_time": "2021-12-13T14:36:18",
+                    "path": "archives/compressed/35/CLUSTER_ID_TO_BE_REPLACED/201602/02/050522.tar.gz"
+                },
+                {
+                    "cluster_id": "CLUSTER_ID_TO_BE_REPLACED",
+                    "name": "clusterconfig/sap_datahubs",
+                    "duration_in_ms": 33,
+                    "analysis_time": "2021-12-13T14:36:18",
+                    "path": "archives/compressed/35/CLUSTER_ID_TO_BE_REPLACED/201602/02/050522.tar.gz"
+                },
+                {
+                    "cluster_id": "CLUSTER_ID_TO_BE_REPLACED",
+                    "name": "clusterconfig/ingress",
+                    "duration_in_ms": 83,
+                    "analysis_time": "2021-12-13T14:36:18",
+                    "path": "archives/compressed/35/CLUSTER_ID_TO_BE_REPLACED/201602/02/050522.tar.gz"
+                },
+                {
+                    "cluster_id": "CLUSTER_ID_TO_BE_REPLACED",
+                    "name": "clusterconfig/pdbs",
+                    "duration_in_ms": 29,
+                    "analysis_time": "2021-12-13T14:36:18",
+                    "path": "archives/compressed/35/CLUSTER_ID_TO_BE_REPLACED/201602/02/050522.tar.gz"
+                },
+                {
+                    "cluster_id": "CLUSTER_ID_TO_BE_REPLACED",
+                    "name": "clusterconfig/crds",
+                    "duration_in_ms": 113,
+                    "analysis_time": "2021-12-13T14:36:18",
+                    "path": "archives/compressed/35/CLUSTER_ID_TO_BE_REPLACED/201602/02/050522.tar.gz"
+                },
+                {
+                    "cluster_id": "CLUSTER_ID_TO_BE_REPLACED",
+                    "name": "clusterconfig/metrics",
+                    "duration_in_ms": 144,
+                    "analysis_time": "2021-12-13T14:36:18",
+                    "path": "archives/compressed/35/CLUSTER_ID_TO_BE_REPLACED/201602/02/050522.tar.gz"
+                },
+                {
+                    "cluster_id": "CLUSTER_ID_TO_BE_REPLACED",
+                    "name": "clusterconfig/sap_config",
+                    "duration_in_ms": 16,
+                    "analysis_time": "2021-12-13T14:36:18",
+                    "path": "archives/compressed/35/CLUSTER_ID_TO_BE_REPLACED/201602/02/050522.tar.gz"
+                },
+                {
+                    "cluster_id": "CLUSTER_ID_TO_BE_REPLACED",
+                    "name": "clusterconfig/certificate_signing_requests",
+                    "duration_in_ms": 127,
+                    "analysis_time": "2021-12-13T14:36:18",
+                    "path": "archives/compressed/35/CLUSTER_ID_TO_BE_REPLACED/201602/02/050522.tar.gz"
+                },
+                {
+                    "cluster_id": "CLUSTER_ID_TO_BE_REPLACED",
+                    "name": "clusterconfig/container_images",
+                    "duration_in_ms": 396,
+                    "analysis_time": "2021-12-13T14:36:18",
+                    "path": "archives/compressed/35/CLUSTER_ID_TO_BE_REPLACED/201602/02/050522.tar.gz"
+                },
+                {
+                    "cluster_id": "CLUSTER_ID_TO_BE_REPLACED",
+                    "name": "workloads/workload_info",
+                    "duration_in_ms": 7410,
+                    "analysis_time": "2021-12-13T14:36:18",
+                    "path": "archives/compressed/35/CLUSTER_ID_TO_BE_REPLACED/201602/02/050522.tar.gz"
+                },
+                {
+                    "cluster_id": "CLUSTER_ID_TO_BE_REPLACED",
+                    "name": "clusterconfig/infrastructures",
+                    "duration_in_ms": 85,
+                    "analysis_time": "2021-12-13T14:36:18",
+                    "path": "archives/compressed/35/CLUSTER_ID_TO_BE_REPLACED/201602/02/050522.tar.gz"
+                },
+                {
+                    "cluster_id": "CLUSTER_ID_TO_BE_REPLACED",
+                    "name": "clusterconfig/machine_configs",
+                    "duration_in_ms": 219,
+                    "analysis_time": "2021-12-13T14:36:18",
+                    "path": "archives/compressed/35/CLUSTER_ID_TO_BE_REPLACED/201602/02/050522.tar.gz"
+                },
+                {
+                    "cluster_id": "CLUSTER_ID_TO_BE_REPLACED",
+                    "name": "clusterconfig/sap_pods",
+                    "duration_in_ms": 29,
+                    "analysis_time": "2021-12-13T14:36:18",
+                    "path": "archives/compressed/35/CLUSTER_ID_TO_BE_REPLACED/201602/02/050522.tar.gz"
+                },
+                {
+                    "cluster_id": "CLUSTER_ID_TO_BE_REPLACED",
+                    "name": "clusterconfig/machine_autoscalers",
+                    "duration_in_ms": 52,
+                    "analysis_time": "2021-12-13T14:36:18",
+                    "path": "archives/compressed/35/CLUSTER_ID_TO_BE_REPLACED/201602/02/050522.tar.gz"
+                },
+                {
+                    "cluster_id": "CLUSTER_ID_TO_BE_REPLACED",
+                    "name": "clusterconfig/machine_sets",
+                    "duration_in_ms": 54,
+                    "analysis_time": "2021-12-13T14:36:18",
+                    "path": "archives/compressed/35/CLUSTER_ID_TO_BE_REPLACED/201602/02/050522.tar.gz"
+                },
+                {
+                    "cluster_id": "CLUSTER_ID_TO_BE_REPLACED",
+                    "name": "clusterconfig/authentication",
+                    "duration_in_ms": 96,
+                    "analysis_time": "2021-12-13T14:36:18",
+                    "path": "archives/compressed/35/CLUSTER_ID_TO_BE_REPLACED/201602/02/050522.tar.gz"
+                },
+                {
+                    "cluster_id": "CLUSTER_ID_TO_BE_REPLACED",
+                    "name": "clusterconfig/openshift_sdn_logs",
+                    "duration_in_ms": 1189,
+                    "analysis_time": "2021-12-13T14:36:18",
+                    "path": "archives/compressed/35/CLUSTER_ID_TO_BE_REPLACED/201602/02/050522.tar.gz"
+                },
+                {
+                    "cluster_id": "CLUSTER_ID_TO_BE_REPLACED",
+                    "name": "clusterconfig/version",
+                    "duration_in_ms": 153,
+                    "analysis_time": "2021-12-13T14:36:18",
+                    "path": "archives/compressed/35/CLUSTER_ID_TO_BE_REPLACED/201602/02/050522.tar.gz"
+                },
+                {
+                    "cluster_id": "CLUSTER_ID_TO_BE_REPLACED",
+                    "name": "clusterconfig/openshift_authentication_logs",
+                    "duration_in_ms": 448,
+                    "analysis_time": "2021-12-13T14:36:18",
+                    "path": "archives/compressed/35/CLUSTER_ID_TO_BE_REPLACED/201602/02/050522.tar.gz"
+                },
+                {
+                    "cluster_id": "CLUSTER_ID_TO_BE_REPLACED",
+                    "name": "clusterconfig/operators",
+                    "duration_in_ms": 2419,
+                    "analysis_time": "2021-12-13T14:36:18",
+                    "path": "archives/compressed/35/CLUSTER_ID_TO_BE_REPLACED/201602/02/050522.tar.gz"
+                },
+                {
+                    "cluster_id": "CLUSTER_ID_TO_BE_REPLACED",
+                    "name": "clusterconfig/container_runtime_configs",
+                    "duration_in_ms": 41,
+                    "analysis_time": "2021-12-13T14:36:18",
+                    "path": "archives/compressed/35/CLUSTER_ID_TO_BE_REPLACED/201602/02/050522.tar.gz"
+                },
+                {
+                    "cluster_id": "CLUSTER_ID_TO_BE_REPLACED",
+                    "name": "clusterconfig/sap_license_management_logs",
+                    "duration_in_ms": 37,
+                    "analysis_time": "2021-12-13T14:36:18",
+                    "path": "archives/compressed/35/CLUSTER_ID_TO_BE_REPLACED/201602/02/050522.tar.gz"
+                },
+                {
+                    "cluster_id": "CLUSTER_ID_TO_BE_REPLACED",
+                    "name": "clusterconfig/networks",
+                    "duration_in_ms": 62,
+                    "analysis_time": "2021-12-13T14:36:18",
+                    "path": "archives/compressed/35/CLUSTER_ID_TO_BE_REPLACED/201602/02/050522.tar.gz"
+                },
+                {
+                    "cluster_id": "CLUSTER_ID_TO_BE_REPLACED",
+                    "name": "clusterconfig/image_registries",
+                    "duration_in_ms": 52,
+                    "analysis_time": "2021-12-13T14:36:18",
+                    "path": "archives/compressed/35/CLUSTER_ID_TO_BE_REPLACED/201602/02/050522.tar.gz"
+                },
+                {
+                    "cluster_id": "CLUSTER_ID_TO_BE_REPLACED",
+                    "name": "clusterconfig/feature_gates",
+                    "duration_in_ms": 42,
+                    "analysis_time": "2021-12-13T14:36:18",
+                    "path": "archives/compressed/35/CLUSTER_ID_TO_BE_REPLACED/201602/02/050522.tar.gz"
+                },
+                {
+                    "cluster_id": "CLUSTER_ID_TO_BE_REPLACED",
+                    "name": "clusterconfig/operators_pods_and_events",
+                    "duration_in_ms": 204,
+                    "analysis_time": "2021-12-13T14:36:18",
+                    "path": "archives/compressed/35/CLUSTER_ID_TO_BE_REPLACED/201602/02/050522.tar.gz"
+                },
+                {
+                    "cluster_id": "CLUSTER_ID_TO_BE_REPLACED",
+                    "name": "clusterconfig/openshift_sdn_controller_logs",
+                    "duration_in_ms": 253,
+                    "analysis_time": "2021-12-13T14:36:18",
+                    "path": "archives/compressed/35/CLUSTER_ID_TO_BE_REPLACED/201602/02/050522.tar.gz"
+                },
+                {
+                    "cluster_id": "CLUSTER_ID_TO_BE_REPLACED",
+                    "name": "clusterconfig/netnamespaces",
+                    "duration_in_ms": 154,
+                    "analysis_time": "2021-12-13T14:36:18",
+                    "path": "archives/compressed/35/CLUSTER_ID_TO_BE_REPLACED/201602/02/050522.tar.gz"
+                },
+                {
+                    "cluster_id": "CLUSTER_ID_TO_BE_REPLACED",
+                    "name": "clusterconfig/config_maps",
+                    "duration_in_ms": 113,
+                    "analysis_time": "2021-12-13T14:36:18",
+                    "path": "archives/compressed/35/CLUSTER_ID_TO_BE_REPLACED/201602/02/050522.tar.gz"
+                },
+                {
+                    "cluster_id": "CLUSTER_ID_TO_BE_REPLACED",
+                    "name": "clusterconfig/host_subnets",
+                    "duration_in_ms": 129,
+                    "analysis_time": "2021-12-13T14:36:18",
+                    "path": "archives/compressed/35/CLUSTER_ID_TO_BE_REPLACED/201602/02/050522.tar.gz"
+                },
+                {
+                    "cluster_id": "CLUSTER_ID_TO_BE_REPLACED",
+                    "name": "clusterconfig/install_plans",
+                    "duration_in_ms": 9874,
+                    "analysis_time": "2021-12-13T14:36:18",
+                    "path": "archives/compressed/35/CLUSTER_ID_TO_BE_REPLACED/201602/02/050522.tar.gz"
+                },
+                {
+                    "cluster_id": "CLUSTER_ID_TO_BE_REPLACED",
+                    "name": "clusterconfig/olm_operators",
+                    "duration_in_ms": 17,
+                    "analysis_time": "2021-12-13T14:36:18",
+                    "path": "archives/compressed/35/CLUSTER_ID_TO_BE_REPLACED/201602/02/050522.tar.gz"
+                },
+                {
+                    "cluster_id": "CLUSTER_ID_TO_BE_REPLACED",
+                    "name": "clusterconfig/nodes",
+                    "duration_in_ms": 94,
+                    "analysis_time": "2021-12-13T14:36:18",
+                    "path": "archives/compressed/35/CLUSTER_ID_TO_BE_REPLACED/201602/02/050522.tar.gz"
+                },
+                {
+                    "cluster_id": "CLUSTER_ID_TO_BE_REPLACED",
+                    "name": "clusterconfig/oauths",
+                    "duration_in_ms": 150,
+                    "analysis_time": "2021-12-13T14:36:18",
+                    "path": "archives/compressed/35/CLUSTER_ID_TO_BE_REPLACED/201602/02/050522.tar.gz"
+                },
+                {
+                    "cluster_id": "CLUSTER_ID_TO_BE_REPLACED",
+                    "name": "clusterconfig/openshift_apiserver_operator_logs",
+                    "duration_in_ms": 360,
+                    "analysis_time": "2021-12-13T14:36:18",
+                    "path": "archives/compressed/35/CLUSTER_ID_TO_BE_REPLACED/201602/02/050522.tar.gz"
+                },
+                {
+                    "cluster_id": "CLUSTER_ID_TO_BE_REPLACED",
+                    "name": "clusterconfig/proxies",
+                    "duration_in_ms": 29,
+                    "analysis_time": "2021-12-13T14:36:18",
+                    "path": "archives/compressed/35/CLUSTER_ID_TO_BE_REPLACED/201602/02/050522.tar.gz"
+                },
+                {
+                    "cluster_id": "CLUSTER_ID_TO_BE_REPLACED",
+                    "name": "clusterconfig/service_accounts",
+                    "duration_in_ms": 10618,
+                    "analysis_time": "2021-12-13T14:36:18",
+                    "path": "archives/compressed/35/CLUSTER_ID_TO_BE_REPLACED/201602/02/050522.tar.gz"
+                },
+                {
+                    "cluster_id": "CLUSTER_ID_TO_BE_REPLACED",
+                    "name": "clusterconfig/pod_network_connectivity_checks",
+                    "duration_in_ms": 198,
+                    "analysis_time": "2021-12-13T14:36:18",
+                    "path": "archives/compressed/35/CLUSTER_ID_TO_BE_REPLACED/201602/02/050522.tar.gz"
+                },
+                {
+                    "cluster_id": "CLUSTER_ID_TO_BE_REPLACED",
+                    "name": "clusterconfig/psps",
+                    "duration_in_ms": 85,
+                    "analysis_time": "2021-12-13T14:36:18",
+                    "path": "archives/compressed/35/CLUSTER_ID_TO_BE_REPLACED/201602/02/050522.tar.gz"
+                },
+                {
+                    "cluster_id": "CLUSTER_ID_TO_BE_REPLACED",
+                    "name": "clusterconfig/machine_healthchecks",
+                    "duration_in_ms": 126,
+                    "analysis_time": "2021-12-13T14:36:18",
+                    "path": "archives/compressed/35/CLUSTER_ID_TO_BE_REPLACED/201602/02/050522.tar.gz"
+                },
+                {
+                    "cluster_id": "CLUSTER_ID_TO_BE_REPLACED",
+                    "name": "clusterconfig/machine_config_pools",
+                    "duration_in_ms": 89,
+                    "analysis_time": "2021-12-13T14:36:18",
+                    "path": "archives/compressed/35/CLUSTER_ID_TO_BE_REPLACED/201602/02/050522.tar.gz"
+                }
+            ]
+        },
+        {
+            "metadata": {
+                "feature_id": "alerts",
+                "component": "fe.features.alerts.feature"
+            },
+            "schema": {
+                "version": "1.0",
+                "fields": [
+                    {
+                        "name": "cluster_id",
+                        "type": "String"
+                    },
+                    {
+                        "name": "name",
+                        "type": "String"
+                    },
+                    {
+                        "name": "state",
+                        "type": "String"
+                    },
+                    {
+                        "name": "severity",
+                        "type": "String"
+                    },
+                    {
+                        "name": "labels",
+                        "type": "Object"
+                    },
+                    {
+                        "name": "value",
+                        "type": "Float"
+                    },
+                    {
+                        "name": "last_transition_time",
+                        "type": "DateTime"
+                    },
+                    {
+                        "name": "analysis_time",
+                        "type": "DateTime"
+                    },
+                    {
+                        "name": "path",
+                        "type": "String"
+                    }
+                ]
+            },
+            "data": [
+                {
+                    "cluster_id": "CLUSTER_ID_TO_BE_REPLACED",
+                    "name": "Watchdog",
+                    "state": "firing",
+                    "severity": "none",
+                    "labels": {
+                        "instance": "",
+                        "prometheus": "openshift-monitoring/k8s",
+                        "prometheus_replica": "prometheus-k8s-1"
+                    },
+                    "value": 1.0,
+                    "last_transition_time": "2021-10-08T11:44:16",
+                    "analysis_time": "2021-12-13T14:36:18",
+                    "path": "archives/compressed/35/CLUSTER_ID_TO_BE_REPLACED/201602/02/050522.tar.gz"
+                },
+                {
+                    "cluster_id": "CLUSTER_ID_TO_BE_REPLACED",
+                    "name": "AlertmanagerReceiversNotConfigured",
+                    "state": "firing",
+                    "severity": "warning",
+                    "labels": {
+                        "instance": "",
+                        "prometheus": "openshift-monitoring/k8s",
+                        "prometheus_replica": "prometheus-k8s-1"
+                    },
+                    "value": 1.0,
+                    "last_transition_time": "2021-10-08T11:44:22",
+                    "analysis_time": "2021-12-13T14:36:18",
+                    "path": "archives/compressed/35/CLUSTER_ID_TO_BE_REPLACED/201602/02/050522.tar.gz"
+                }
+            ]
+        },
+        {
+            "metadata": {
+                "feature_id": "workload_info_namespaces",
+                "component": "fe.features.workload_info_namespaces.feature"
+            },
+            "schema": {
+                "version": "1.0",
+                "fields": [
+                    {
+                        "name": "cluster_id",
+                        "type": "String"
+                    },
+                    {
+                        "name": "namespace",
+                        "type": "String"
+                    },
+                    {
+                        "name": "shapes",
+                        "type": "List"
+                    }
+                ]
+            },
+            "data": [
+                {
+                    "cluster_id": "cluster_id",
+                    "namespace": "namespace",
+                    "shapes": [
+                        {
+                            "containers": [
+                                {
+                                    "imageID": "imageID",
+                                    "firstArg": "firstArg",
+                                    "firstCommand": "firstCommand"
+                                }
+                            ],
+                            "initContainers": [
+                                {
+                                    "imageID": "imageID",
+                                    "firstArg": "firstArg",
+                                    "firstCommand": "firstCommand"
+                                }
+                            ],
+                            "shapeInstances": 1,
+                            "restartAlways": true
+                        }
+                    ]
+                }
+            ]
+        },
+        {
+            "metadata": {
+                "feature_id": "workload_info_images",
+                "component": "fe.features.workload_info_images.feature"
+            },
+            "schema": {
+                "version": "1.0",
+                "fields": [
+                    {
+                        "name": "cluster_id",
+                        "type": "String"
+                    },
+                    {
+                        "name": "image_id",
+                        "type": "String"
+                    },
+                    {
+                        "name": "layers",
+                        "type": "List"
+                    },
+                    {
+                        "name": "first_command",
+                        "type": "String"
+                    },
+                    {
+                        "name": "first_arg",
+                        "type": "String"
+                    }
+                ]
+            },
+            "data": [
+                {
+                    "cluster_id": "cluster_id",
+                    "image_id": "image_id",
+                    "layers": [
+                        "layer1",
+                        "layer2"
+                    ],
+                    "first_command": "first_command",
+                    "first_arg": "first_arg"
+                }
+            ]
+        },
+        {
+            "metadata": {
+                "feature_id": "available_updates",
+                "component": "fe.features.available_updates.feature"
+            },
+            "schema": {
+                "version": "1.0",
+                "fields": [
+                    {
+                        "name": "cluster_id",
+                        "type": "String"
+                    },
+                    {
+                        "name": "cluster_version",
+                        "type": "String"
+                    },
+                    {
+                        "name": "release",
+                        "type": "String"
+                    }
+                ]
+            },
+            "data": [
+                {
+                    "cluster_id": "CLUSTER_ID_TO_BE_REPLACED",
+                    "cluster_version": "4.8.12",
+                    "release": "4.10.0-fc.4"
+                },
+                {
+                    "cluster_id": "CLUSTER_ID_TO_BE_REPLACED",
+                    "cluster_version": "4.8.12",
+                    "release": "4.10.0-fc.4"
+                }
+            ]
+        },
+        {
+            "metadata": {
+                "feature_id": "conditional_update_conditions",
+                "component": "fe.features.conditional_update_conditions.feature"
+            },
+            "schema": {
+                "version": "1.0",
+                "fields": [
+                    {
+                        "name": "cluster_id",
+                        "type": "String"
+                    },
+                    {
+                        "name": "cluster_version",
+                        "type": "String"
+                    },
+                    {
+                        "name": "release",
+                        "type": "String"
+                    },
+                    {
+                        "name": "recommended",
+                        "type": "String"
+                    },
+                    {
+                        "name": "reason",
+                        "type": "String"
+                    },
+                    {
+                        "name": "message",
+                        "type": "String"
+                    }
+                ]
+            },
+            "data": [
+                {
+                    "cluster_id": "CLUSTER_ID_TO_BE_REPLACED",
+                    "cluster_version": "4.8.12",
+                    "release": "4.10.0-fc.4",
+                    "recommended": "True",
+                    "reason": "AsExpected",
+                    "message": "The update is recommended, because none of the conditional update risks apply to this cluster."
+                },
+                {
+                    "cluster_id": "CLUSTER_ID_TO_BE_REPLACED",
+                    "cluster_version": "4.8.12",
+                    "release": "4.10.0-fc.4",
+                    "recommended": "Unknown",
+                    "reason": "AsExpected",
+                    "message": "The update is recommended, because none of the conditional update risks apply to this cluster."
+                }
+            ]
+        },
+        {
+            "metadata": {
+                "feature_id": "conditional_update_risks",
+                "component": "fe.features.conditional_update_risks.feature"
+            },
+            "schema": {
+                "version": "1.0",
+                "fields": [
+                    {
+                        "name": "cluster_id",
+                        "type": "String"
+                    },
+                    {
+                        "name": "cluster_version",
+                        "type": "String"
+                    },
+                    {
+                        "name": "release",
+                        "type": "String"
+                    },
+                    {
+                        "name": "risk",
+                        "type": "String"
+                    }
+                ]
+            },
+            "data": [
+                {
+                    "cluster_id": "CLUSTER_ID_TO_BE_REPLACED",
+                    "cluster_version": "4.8.12",
+                    "release": "4.10.0-fc.4",
+                    "risk": "AlibabaStorageDriverDemo"
+                },
+                {
+                    "cluster_id": "CLUSTER_ID_TO_BE_REPLACED",
+                    "cluster_version": "4.8.12",
+                    "release": "4.10.0-fc.4",
+                    "risk": "AlibabaStorageDriverDemo"
+                }
+            ]
+        }
+    ]
+}

--- a/test_data/rules_message.json
+++ b/test_data/rules_message.json
@@ -1,0 +1,1732 @@
+{
+    "path": "archives/compressed/ef/CLUSTER_ID_TO_BE_REPLACED/201306/17/233359.tar.gz",
+    "metadata": {
+        "cluster_id": "CLUSTER_ID_TO_BE_REPLACED",
+        "external_organization": "ef"
+    },
+    "report": {
+        "system": {
+            "metadata": {},
+            "hostname": null
+        },
+        "reports": [
+            {
+                "rule_id": "machine_pool_check|MACHINE_POOL_NOT_OK",
+                "component": "ccx_rules_ocp.internal.rules.machine_pool_check.report",
+                "type": "rule",
+                "key": "MACHINE_POOL_NOT_OK",
+                "details": {
+                    "machines": [
+                        {
+                            "degraded": {
+                                "status": false,
+                                "last_trans_time": "2021-10-08T08:10:33Z",
+                                "reason": "",
+                                "message": ""
+                            },
+                            "name": "master",
+                            "node_degraded": {
+                                "status": false,
+                                "last_trans_time": "2021-10-08T08:10:33Z",
+                                "reason": "",
+                                "message": ""
+                            },
+                            "render_degraded": {
+                                "status": false,
+                                "last_trans_time": "2021-10-08T08:09:38Z",
+                                "reason": "",
+                                "message": ""
+                            },
+                            "updated": {
+                                "status": false,
+                                "last_trans_time": "2021-10-08T09:44:15Z",
+                                "reason": "",
+                                "message": ""
+                            },
+                            "updating": {
+                                "status": true,
+                                "last_trans_time": "2021-10-08T09:44:15Z",
+                                "reason": "",
+                                "message": "All nodes are updating to rendered-master-a40f9eb37039e079676527fd41bbef52"
+                            }
+                        },
+                        {
+                            "degraded": {
+                                "status": false,
+                                "last_trans_time": "2021-10-08T08:09:41Z",
+                                "reason": "",
+                                "message": ""
+                            },
+                            "name": "worker",
+                            "node_degraded": {
+                                "status": false,
+                                "last_trans_time": "2021-10-08T08:09:41Z",
+                                "reason": "",
+                                "message": ""
+                            },
+                            "render_degraded": {
+                                "status": false,
+                                "last_trans_time": "2021-10-08T08:09:38Z",
+                                "reason": "",
+                                "message": ""
+                            },
+                            "updated": {
+                                "status": false,
+                                "last_trans_time": "2021-10-08T09:44:15Z",
+                                "reason": "",
+                                "message": ""
+                            },
+                            "updating": {
+                                "status": true,
+                                "last_trans_time": "2021-10-08T09:44:15Z",
+                                "reason": "",
+                                "message": "All nodes are updating to rendered-worker-3c096f9626f3d5efb9113e1056ab71fa"
+                            }
+                        }
+                    ],
+                    "type": "rule",
+                    "error_key": "MACHINE_POOL_NOT_OK"
+                },
+                "tags": [],
+                "links": {}
+            },
+            {
+                "rule_id": "operators_check|OPERATOR_ISSUE",
+                "component": "ccx_rules_ocp.internal.rules.operators_check.report",
+                "type": "rule",
+                "key": "OPERATOR_ISSUE",
+                "details": {
+                    "operators": [
+                        {
+                            "operator": {
+                                "available": {
+                                    "status": true,
+                                    "last_trans_time": "2021-10-08T08:16:58Z",
+                                    "reason": "",
+                                    "message": "Cluster has deployed 4.8.12"
+                                },
+                                "degraded": {
+                                    "status": false,
+                                    "last_trans_time": "2021-10-08T08:16:56Z",
+                                    "reason": "",
+                                    "message": ""
+                                },
+                                "name": "machine-config",
+                                "progressing": {
+                                    "status": true,
+                                    "last_trans_time": "2021-10-08T09:40:54Z",
+                                    "reason": "",
+                                    "message": "Working towards 4.8.13"
+                                },
+                                "upgradeable": {
+                                    "status": true,
+                                    "last_trans_time": "2021-10-08T08:14:53Z",
+                                    "reason": "AsExpected",
+                                    "message": ""
+                                },
+                                "version": "4.8.12"
+                            },
+                            "issues": [
+                                [
+                                    "Progressing",
+                                    {
+                                        "status": true,
+                                        "last_trans_time": "2021-10-08T09:40:54Z",
+                                        "reason": "",
+                                        "message": "Working towards 4.8.13"
+                                    }
+                                ]
+                            ]
+                        },
+                        {
+                            "operator": {
+                                "available": {
+                                    "status": true,
+                                    "last_trans_time": "2021-10-08T08:08:27Z",
+                                    "reason": "AsExpected",
+                                    "message": "All is well"
+                                },
+                                "degraded": {
+                                    "status": false,
+                                    "last_trans_time": "2021-10-08T08:08:24Z",
+                                    "reason": "AsExpected",
+                                    "message": "All is well"
+                                },
+                                "name": "service-ca",
+                                "progressing": {
+                                    "status": true,
+                                    "last_trans_time": "2021-10-08T09:44:19Z",
+                                    "reason": "_ManagedDeploymentsAvailable",
+                                    "message": "Progressing: \nProgressing: service-ca does not have available replicas"
+                                },
+                                "upgradeable": {
+                                    "status": true,
+                                    "last_trans_time": "2021-10-08T08:08:27Z",
+                                    "reason": "AsExpected",
+                                    "message": "All is well"
+                                },
+                                "version": "4.8.13"
+                            },
+                            "issues": [
+                                [
+                                    "Progressing",
+                                    {
+                                        "status": true,
+                                        "last_trans_time": "2021-10-08T09:44:19Z",
+                                        "reason": "_ManagedDeploymentsAvailable",
+                                        "message": "Progressing: \nProgressing: service-ca does not have available replicas"
+                                    }
+                                ]
+                            ]
+                        }
+                    ],
+                    "type": "rule",
+                    "error_key": "OPERATOR_ISSUE"
+                },
+                "tags": [],
+                "links": {}
+            },
+            {
+                "rule_id": "version_check|CLUSTER_VERSION_WORKING_TOWARDS",
+                "component": "ccx_rules_ocp.internal.rules.version_check.report",
+                "type": "rule",
+                "key": "CLUSTER_VERSION_WORKING_TOWARDS",
+                "details": {
+                    "current": "4.8.12",
+                    "desired": "4.8.13",
+                    "available": {
+                        "status": true,
+                        "last_trans_time": "2021-10-08T08:35:15Z",
+                        "reason": "",
+                        "message": "Done applying 4.8.12"
+                    },
+                    "progressing": {
+                        "status": true,
+                        "last_trans_time": "2021-10-08T08:52:20Z",
+                        "reason": "ClusterOperatorUpdating",
+                        "message": "Working towards 4.8.13: 570 of 678 done (84% complete), waiting on machine-config"
+                    },
+                    "failing": {
+                        "status": false,
+                        "last_trans_time": "2021-10-08T09:31:14Z",
+                        "reason": "",
+                        "message": ""
+                    },
+                    "history_count": 2,
+                    "phased_gates_checks": [
+                        "3.1"
+                    ],
+                    "type": "rule",
+                    "error_key": "CLUSTER_VERSION_WORKING_TOWARDS"
+                },
+                "tags": [
+                    "phased_gates"
+                ],
+                "links": {
+                    "kcs": [
+                        "https://access.redhat.com/solutions/3799561"
+                    ],
+                    "jira": [
+                        "https://issues.redhat.com/browse/INSIGHTOCP-455"
+                    ]
+                }
+            },
+            {
+                "rule_id": "empty_prometheus_db_volume|PROMETHEUS_DB_VOLUME_IS_EMPTY",
+                "component": "ccx_rules_ocp.external.rules.empty_prometheus_db_volume.report",
+                "type": "rule",
+                "key": "PROMETHEUS_DB_VOLUME_IS_EMPTY",
+                "details": {
+                    "ocp_branch": "4.8",
+                    "type": "rule",
+                    "error_key": "PROMETHEUS_DB_VOLUME_IS_EMPTY"
+                },
+                "tags": [],
+                "links": {
+                    "jira": [
+                        "https://issues.redhat.com/browse/INSIGHTOCP-51",
+                        "https://issues.redhat.com/browse/INSIGHTOCP-258",
+                        "https://issues.redhat.com/browse/INSIGHTOCP-439"
+                    ]
+                }
+            }
+        ],
+        "fingerprints": [],
+        "skips": [
+            {
+                "rule_fqdn": "ccx_rules_ocp.ocs.check_storageclassname_storagecluster.report",
+                "reason": "MISSING_REQUIREMENTS",
+                "details": "All: ['ccx_ocp_core.specs.must_gather_ocs.StorageCluster'] Any: ",
+                "type": "skip"
+            },
+            {
+                "rule_fqdn": "ccx_rules_ocp.ocs.check_pods_scc.report",
+                "reason": "MISSING_REQUIREMENTS",
+                "details": "All: ['ccx_ocp_core.specs.must_gather_ocs.PodsMGOCS'] Any: ",
+                "type": "skip"
+            },
+            {
+                "rule_fqdn": "ccx_rules_ocp.internal.rhcos.rhcos_wrong_selinux_context.report",
+                "reason": "MISSING_REQUIREMENTS",
+                "details": "All: ['ccx_rules_ocp.internal.rhcos.rhcos_wrong_selinux_context.check_rhcos_host', 'ccx_rules_ocp.internal.rhcos.rhcos_wrong_selinux_context.check_journal_since_boot_error_log_3', 'ccx_rules_ocp.internal.rhcos.rhcos_wrong_selinux_context.is_ovs_vswitchd_failed'] Any: ",
+                "type": "skip"
+            },
+            {
+                "rule_fqdn": "ccx_rules_ocp.ocs.check_noobaa_disabled.report",
+                "reason": "MISSING_REQUIREMENTS",
+                "details": "All: ['ccx_ocp_core.specs.must_gather_ocs.StorageCluster'] Any: ",
+                "type": "skip"
+            },
+            {
+                "rule_fqdn": "ccx_rules_ocp.ocs.ocs_check_if_monitoring_enabled.report",
+                "reason": "MISSING_REQUIREMENTS",
+                "details": "All: ['ccx_ocp_core.specs.must_gather_ocs.OpenshiftStorageNamespace'] Any: ",
+                "type": "skip"
+            },
+            {
+                "rule_fqdn": "ccx_rules_ocp.ocs.ceph_cluster_health.report",
+                "reason": "MISSING_REQUIREMENTS",
+                "details": "All: ['ccx_ocp_core.specs.must_gather_ocs.CephHealthDetail'] Any: ",
+                "type": "skip"
+            },
+            {
+                "rule_fqdn": "ccx_rules_ocp.ocs.ceph_cluster_noout_flag_set.report",
+                "reason": "MISSING_REQUIREMENTS",
+                "details": "All: ['ccx_ocp_core.specs.must_gather_ocs.CephHealthDetail'] Any: ",
+                "type": "skip"
+            },
+            {
+                "rule_fqdn": "ccx_rules_ocp.ocs.check_ocs_version.report",
+                "reason": "MISSING_REQUIREMENTS",
+                "details": "All: ['ccx_ocp_core.specs.must_gather_ocs.OperatorsMGOCS'] Any: ",
+                "type": "skip"
+            },
+            {
+                "rule_fqdn": "ccx_rules_ocp.ocs.operator_phase_check.report",
+                "reason": "MISSING_REQUIREMENTS",
+                "details": "All: ['ccx_ocp_core.specs.must_gather_ocs.OperatorsMGOCS'] Any: ",
+                "type": "skip"
+            },
+            {
+                "rule_fqdn": "ccx_rules_ocp.ocs.check_noobaa_sts_replicas.report",
+                "reason": "MISSING_REQUIREMENTS",
+                "details": "All: ['ccx_ocp_core.specs.must_gather_ocs.OCSStatefulSets'] Any: ",
+                "type": "skip"
+            },
+            {
+                "rule_fqdn": "ccx_rules_ocp.ocs.pvc_phase_check.report",
+                "reason": "MISSING_REQUIREMENTS",
+                "details": "All: ['ccx_ocp_core.specs.must_gather_ocs.PersistentVolumeClaimsMGOCS'] Any: ",
+                "type": "skip"
+            },
+            {
+                "rule_fqdn": "ccx_rules_ocp.ocs.ceph_check_large_omap_object_in_cephfs_metadata_pool.report",
+                "reason": "MISSING_REQUIREMENTS",
+                "details": "All: ['ccx_ocp_core.specs.must_gather_ocs.RookCephMonCurrentLog'] Any: ",
+                "type": "skip"
+            },
+            {
+                "rule_fqdn": "ccx_rules_ocp.internal.rules.image_registry_failed_to_claim_nfs_volume.report",
+                "reason": "MISSING_REQUIREMENTS",
+                "details": "All: ['ccx_ocp_core.models.events.Events'] Any: ",
+                "type": "skip"
+            },
+            {
+                "rule_fqdn": "ccx_rules_ocp.internal.rules.machine_update_stuck.report",
+                "reason": "MISSING_REQUIREMENTS",
+                "details": "All: ['ccx_ocp_core.specs.must_gather.OCVersionCurrentLogs'] Any: ",
+                "type": "skip"
+            },
+            {
+                "rule_fqdn": "ccx_rules_ocp.ocs.noobaa_db_pod_crashloopbackoff.report",
+                "reason": "MISSING_REQUIREMENTS",
+                "details": "All: ['ccx_rules_ocp.ocs.noobaa_db_pod_crashloopbackoff.affected_ocs_version', 'ccx_rules_ocp.ocs.noobaa_db_pod_crashloopbackoff.check_noobaa_db_log'] Any: ",
+                "type": "skip"
+            },
+            {
+                "rule_fqdn": "ccx_rules_ocp.ocs.ocs_check_noobaa_operator_leader_mismatch.report",
+                "reason": "MISSING_REQUIREMENTS",
+                "details": "All: ['ccx_rules_ocp.ocs.ocs_check_noobaa_operator_leader_mismatch.check_the_running_noobaa_operator_pod', 'ccx_rules_ocp.ocs.ocs_check_noobaa_operator_leader_mismatch.check_the_noobaa_operator_pod_in_config_map'] Any: ",
+                "type": "skip"
+            },
+            {
+                "rule_fqdn": "ccx_rules_ocp.ocs.ocs_mon_pod_stuck.report",
+                "reason": "MISSING_REQUIREMENTS",
+                "details": "All: ['ccx_rules_ocp.ocs.ocs_mon_pod_stuck.check_rook_mon_log', 'ccx_rules_ocp.ocs.ocs_mon_pod_stuck.check_rook_operator_log'] Any: ",
+                "type": "skip"
+            },
+            {
+                "rule_fqdn": "ccx_rules_ocp.internal.rules.failed_to_create_scope_for_machine.report",
+                "reason": "MISSING_REQUIREMENTS",
+                "details": "All: ['ccx_rules_ocp.internal.rules.failed_to_create_scope_for_machine.check_logs'] Any: ",
+                "type": "skip"
+            },
+            {
+                "rule_fqdn": "ccx_rules_ocp.internal.rules.image_registry_failed_to_push_image.report",
+                "reason": "MISSING_REQUIREMENTS",
+                "details": "All: ['ccx_rules_ocp.internal.rules.image_registry_failed_to_push_image.check_logs_failed_to_push_image'] Any: ",
+                "type": "skip"
+            },
+            {
+                "rule_fqdn": "ccx_rules_ocp.internal.bug_rules.log_spam_after_applying_scheduler_policy_file.report",
+                "reason": "MISSING_REQUIREMENTS",
+                "details": "All: ['ccx_rules_ocp.internal.bug_rules.log_spam_after_applying_scheduler_policy_file.check_logs'] Any: ",
+                "type": "skip"
+            },
+            {
+                "rule_fqdn": "ccx_rules_ocp.ocs.ocs_mds_cache_too_large.report",
+                "reason": "MISSING_REQUIREMENTS",
+                "details": "All: ['ccx_rules_ocp.ocs.ocs_mds_cache_too_large.get_mds_reporting_cache_oversized'] Any: ",
+                "type": "skip"
+            },
+            {
+                "rule_fqdn": "ccx_rules_ocp.internal.rules.prometheus_duplicate_timestamps.report",
+                "reason": "MISSING_REQUIREMENTS",
+                "details": "All: ['ccx_rules_ocp.internal.rules.prometheus_duplicate_timestamps.check_logs_duplicate_timestamps'] Any: ",
+                "type": "skip"
+            },
+            {
+                "rule_fqdn": "ccx_rules_ocp.external.rules.container_max_root_partition_size.report",
+                "reason": "MISSING_REQUIREMENTS",
+                "details": "All: ['ccx_rules_ocp.external.rules.container_max_root_partition_size.check_container_runtime_config'] Any: ",
+                "type": "skip"
+            },
+            {
+                "rule_fqdn": "ccx_rules_ocp.internal.bug_rules.upgrade_fails_due_to_packageserver_cert.report",
+                "reason": "MISSING_REQUIREMENTS",
+                "details": "All: ['ccx_rules_ocp.internal.bug_rules.upgrade_fails_due_to_packageserver_cert.check_cluster_version_logs', 'ccx_rules_ocp.internal.bug_rules.upgrade_fails_due_to_packageserver_cert.check_packageserver_logs'] Any: ",
+                "type": "skip"
+            },
+            {
+                "rule_fqdn": "ccx_rules_ocp.internal.rules.api_server_miss_call_alert.report",
+                "reason": "MISSING_REQUIREMENTS",
+                "details": "All: ['ccx_rules_ocp.internal.rules.api_server_miss_call_alert.check_api_miss_call'] Any: ",
+                "type": "skip"
+            },
+            {
+                "rule_fqdn": "ccx_rules_ocp.internal.rules.service_mesh_op_forever_updating.report",
+                "reason": "MISSING_REQUIREMENTS",
+                "details": "All: ['ccx_rules_ocp.internal.rules.service_mesh_op_forever_updating.check_logs'] Any: ",
+                "type": "skip"
+            },
+            {
+                "rule_fqdn": "ccx_rules_ocp.internal.rules.volume_attach_failed.report",
+                "reason": "MISSING_REQUIREMENTS",
+                "details": "All: ['ccx_rules_ocp.internal.rules.volume_attach_failed.check_logs'] Any: ",
+                "type": "skip"
+            },
+            {
+                "rule_fqdn": "ccx_rules_ocp.internal.rules.certificates_not_approved.report",
+                "reason": "MISSING_REQUIREMENTS",
+                "details": "All: ['ccx_ocp_core.models.certificates.Certificates'] Any: ",
+                "type": "skip"
+            },
+            {
+                "rule_fqdn": "ccx_rules_ocp.internal.rules.auth_invalid_name_contain_slash.report",
+                "reason": "MISSING_REQUIREMENTS",
+                "details": "All: ['ccx_rules_ocp.internal.rules.auth_invalid_name_contain_slash.check_logs'] Any: ",
+                "type": "skip"
+            },
+            {
+                "rule_fqdn": "ccx_rules_ocp.internal.rules.auth_operator_unhonoring_oauth_configuration.report",
+                "reason": "MISSING_REQUIREMENTS",
+                "details": "All: ['ccx_rules_ocp.internal.rules.auth_operator_unhonoring_oauth_configuration.check_logs'] Any: ",
+                "type": "skip"
+            },
+            {
+                "rule_fqdn": "ccx_rules_ocp.internal.rules.openshift_samples_has_not_yet_rolled_out.report",
+                "reason": "MISSING_REQUIREMENTS",
+                "details": "All: ['ccx_rules_ocp.internal.rules.openshift_samples_has_not_yet_rolled_out.config_message_check', 'ccx_rules_ocp.internal.rules.openshift_samples_has_not_yet_rolled_out.check_logs'] Any: ",
+                "type": "skip"
+            },
+            {
+                "rule_fqdn": "ccx_rules_ocp.ocs.ceph_check_mon_clock_skew.report",
+                "reason": "MISSING_REQUIREMENTS",
+                "details": "All: ['ccx_rules_ocp.ocs.ceph_check_mon_clock_skew.get_mon_reporting_clock_skew'] Any: ",
+                "type": "skip"
+            },
+            {
+                "rule_fqdn": "ccx_rules_ocp.internal.rules.image_registry_unable_to_sync_object_modified.report",
+                "reason": "MISSING_REQUIREMENTS",
+                "details": "All: ['ccx_rules_ocp.internal.rules.image_registry_unable_to_sync_object_modified.check_logs_unable_to_sync', 'ccx_rules_ocp.internal.rules.image_registry_unable_to_sync_object_modified.check_status_section_for_defined_storage'] Any: ",
+                "type": "skip"
+            },
+            {
+                "rule_fqdn": "ccx_rules_ocp.internal.rules.openshift_sdn_cannot_access_kube_apiserver.report",
+                "reason": "MISSING_REQUIREMENTS",
+                "details": "All: ['ccx_rules_ocp.internal.rules.openshift_sdn_cannot_access_kube_apiserver.check_openshift_sdn_logs'] Any: ",
+                "type": "skip"
+            },
+            {
+                "rule_fqdn": "ccx_rules_ocp.ocs.ceph_check_osd_auth_rotating_clock_skew.report",
+                "reason": "MISSING_REQUIREMENTS",
+                "details": "All: ['ccx_rules_ocp.ocs.ceph_check_osd_auth_rotating_clock_skew.check_osd_log'] Any: ",
+                "type": "skip"
+            },
+            {
+                "rule_fqdn": "ccx_rules_ocp.internal.rules.etcd_low_backend_performance.report",
+                "reason": "MISSING_REQUIREMENTS",
+                "details": "All: ['ccx_rules_ocp.internal.rules.etcd_low_backend_performance.check_etcd_low_performance_log'] Any: ",
+                "type": "skip"
+            },
+            {
+                "rule_fqdn": "ccx_rules_ocp.ocs.ocs_cephcluster_with_5_mons.report",
+                "reason": "MISSING_REQUIREMENTS",
+                "details": "All: ['ccx_rules_ocp.ocs.ocs_cephcluster_with_5_mons.check_num_mons_configured', 'ccx_rules_ocp.ocs.ocs_cephcluster_with_5_mons.check_ocs_version'] Any: ",
+                "type": "skip"
+            },
+            {
+                "rule_fqdn": "ccx_rules_ocp.install_gather.kubelet_hostname_bad_format.report",
+                "reason": "MISSING_REQUIREMENTS",
+                "details": "All: ['ccx_rules_ocp.install_gather.kubelet_hostname_bad_format.check_control_plane_kubelet_logs'] Any: ",
+                "type": "skip"
+            },
+            {
+                "rule_fqdn": "ccx_rules_ocp.internal.rules.hpa_fails_getting_cpu_metrics.report",
+                "reason": "MISSING_REQUIREMENTS",
+                "details": "All: ['ccx_rules_ocp.internal.rules.hpa_fails_getting_cpu_metrics.check_error_log'] Any: ",
+                "type": "skip"
+            },
+            {
+                "rule_fqdn": "ccx_rules_ocp.internal.rules.mc_degraded_wrong_osimageurl.report",
+                "reason": "MISSING_REQUIREMENTS",
+                "details": "All: ['ccx_rules_ocp.internal.rules.mc_degraded_wrong_osimageurl.get_target_osimageurl_log'] Any: ",
+                "type": "skip"
+            },
+            {
+                "rule_fqdn": "ccx_rules_ocp.internal.rules.openshift_sdn_node_offline.report",
+                "reason": "MISSING_REQUIREMENTS",
+                "details": "All: ['ccx_rules_ocp.internal.rules.openshift_sdn_node_offline.check_openshift_sdn_logs'] Any: ",
+                "type": "skip"
+            },
+            {
+                "rule_fqdn": "ccx_rules_ocp.internal.rules.provision_volume_storageclass_thin_permission.report",
+                "reason": "MISSING_REQUIREMENTS",
+                "details": "All: ['ccx_rules_ocp.internal.rules.provision_volume_storageclass_thin_permission.check_error_log'] Any: ",
+                "type": "skip"
+            },
+            {
+                "rule_fqdn": "ccx_rules_ocp.ocs.ocs_check_for_mixed_size_osd.report",
+                "reason": "MISSING_REQUIREMENTS",
+                "details": "All: ['ccx_rules_ocp.ocs.ocs_check_for_mixed_size_osd.get_osd_sizes'] Any: ",
+                "type": "skip"
+            },
+            {
+                "rule_fqdn": "ccx_rules_ocp.internal.rules.mcd_logs_no_such_host_for_localhost.report",
+                "reason": "MISSING_REQUIREMENTS",
+                "details": "All: ['ccx_rules_ocp.internal.rules.mcd_logs_no_such_host_for_localhost.check_no_such_host_logs'] Any: ",
+                "type": "skip"
+            },
+            {
+                "rule_fqdn": "ccx_rules_ocp.internal.rules.pods_pending_for_pvc_cannot_be_bound.report",
+                "reason": "MISSING_REQUIREMENTS",
+                "details": "All: ['ccx_rules_ocp.internal.rules.pods_pending_for_pvc_cannot_be_bound.check_logs'] Any: ",
+                "type": "skip"
+            },
+            {
+                "rule_fqdn": "ccx_rules_ocp.internal.bug_rules.bug_1852545.report",
+                "reason": "MISSING_REQUIREMENTS",
+                "details": "All: ['ccx_rules_ocp.internal.bug_rules.bug_1852545.check_logs'] Any: ",
+                "type": "skip"
+            },
+            {
+                "rule_fqdn": "ccx_rules_ocp.internal.rules.image_push_fails_unknown_blob.report",
+                "reason": "MISSING_REQUIREMENTS",
+                "details": "All: ['ccx_rules_ocp.internal.rules.image_push_fails_unknown_blob.is_nfs', 'ccx_rules_ocp.internal.rules.image_push_fails_unknown_blob.check_logs'] Any: ",
+                "type": "skip"
+            },
+            {
+                "rule_fqdn": "ccx_rules_ocp.internal.rules.cmo_pod_rollout_stuck.report",
+                "reason": "MISSING_REQUIREMENTS",
+                "details": "All: ['ccx_rules_ocp.internal.rules.cmo_pod_rollout_stuck.check_error'] Any: ",
+                "type": "skip"
+            },
+            {
+                "rule_fqdn": "ccx_rules_ocp.internal.rules.build_slowness_due_to_dynatrace_oneagent.report",
+                "reason": "MISSING_REQUIREMENTS",
+                "details": "All: ['ccx_rules_ocp.internal.rules.build_slowness_due_to_dynatrace_oneagent.check_dynatrace_oneagent_operators'] Any: ",
+                "type": "skip"
+            },
+            {
+                "rule_fqdn": "ccx_rules_ocp.internal.rules.check_crio_ephemeral_storage.report",
+                "reason": "MISSING_REQUIREMENTS",
+                "details": "All: ['ccx_rules_ocp.internal.rules.check_crio_ephemeral_storage.check_events'] Any: ",
+                "type": "skip"
+            },
+            {
+                "rule_fqdn": "ccx_rules_ocp.internal.rules.high_severity_alerts.report",
+                "reason": "MISSING_REQUIREMENTS",
+                "details": "All: [] Any: ['ccx_rules_ocp.internal.rules.high_severity_alerts.get_key_alerts_io', 'ccx_rules_ocp.internal.rules.high_severity_alerts.get_key_alerts_mg']",
+                "type": "skip"
+            },
+            {
+                "rule_fqdn": "ccx_rules_ocp.internal.rules.invalid_url_scheme_for_ignition_config.report",
+                "reason": "MISSING_REQUIREMENTS",
+                "details": "All: ['ccx_rules_ocp.internal.rules.invalid_url_scheme_for_ignition_config.error_msg'] Any: ",
+                "type": "skip"
+            },
+            {
+                "rule_fqdn": "ccx_rules_ocp.internal.rules.auth_operator_unknown_state_due_to_route.report",
+                "reason": "MISSING_REQUIREMENTS",
+                "details": "All: ['ccx_rules_ocp.internal.rules.auth_operator_unknown_state_due_to_route.check_logs'] Any: ",
+                "type": "skip"
+            },
+            {
+                "rule_fqdn": "ccx_rules_ocp.internal.rules.machine_config_controller_degraded_during_upgrade.report",
+                "reason": "MISSING_REQUIREMENTS",
+                "details": "All: ['ccx_rules_ocp.internal.rules.machine_config_controller_degraded_during_upgrade.check_mcc_pod_log'] Any: ",
+                "type": "skip"
+            },
+            {
+                "rule_fqdn": "ccx_rules_ocp.internal.rules.azure_service_principals_keys_expired.report",
+                "reason": "MISSING_REQUIREMENTS",
+                "details": "All: ['ccx_rules_ocp.internal.rules.azure_service_principals_keys_expired.check_logs'] Any: ",
+                "type": "skip"
+            },
+            {
+                "rule_fqdn": "ccx_rules_ocp.external.rules.check_sdi_preload_kernel_modules.report",
+                "reason": "MISSING_REQUIREMENTS",
+                "details": "All: ['ccx_rules_ocp.external.rules.check_sdi_preload_kernel_modules.check_license_manager_logs'] Any: ",
+                "type": "skip"
+            },
+            {
+                "rule_fqdn": "ccx_rules_ocp.internal.rules.insights_operator_degraded_UHC_authentication_failed.report",
+                "reason": "MISSING_REQUIREMENTS",
+                "details": "All: ['ccx_rules_ocp.internal.rules.insights_operator_degraded_UHC_authentication_failed.check_insights_operator_logs'] Any: ",
+                "type": "skip"
+            },
+            {
+                "rule_fqdn": "ccx_rules_ocp.internal.rules.machine_config_controller_streams_line_too_long.report",
+                "reason": "MISSING_REQUIREMENTS",
+                "details": "All: ['ccx_rules_ocp.internal.rules.machine_config_controller_streams_line_too_long.check_log'] Any: ",
+                "type": "skip"
+            },
+            {
+                "rule_fqdn": "ccx_rules_ocp.internal.rules.node_degraded_due_to_deleted_rendered_config.report",
+                "reason": "MISSING_REQUIREMENTS",
+                "details": "All: ['ccx_rules_ocp.internal.rules.node_degraded_due_to_deleted_rendered_config.check_machine_degraded_logs'] Any: ",
+                "type": "skip"
+            },
+            {
+                "rule_fqdn": "ccx_rules_ocp.external.rules.image_registry_storage.report",
+                "reason": "MISSING_REQUIREMENTS",
+                "details": "All: ['ccx_rules_ocp.external.rules.image_registry_storage.image_registry_bad_storage'] Any: ",
+                "type": "skip"
+            },
+            {
+                "rule_fqdn": "ccx_rules_ocp.internal.rules.node_ip_does_not_match_machine_network.report",
+                "reason": "MISSING_REQUIREMENTS",
+                "details": "All: ['ccx_rules_ocp.internal.rules.node_ip_does_not_match_machine_network.check_nodes'] Any: ",
+                "type": "skip"
+            },
+            {
+                "rule_fqdn": "ccx_rules_ocp.internal.rules.mco_degraded_due_to_invalid_character_J.report",
+                "reason": "MISSING_REQUIREMENTS",
+                "details": "All: ['ccx_rules_ocp.internal.rules.mco_degraded_due_to_invalid_character_J.check_invalid_character_J_logs'] Any: ",
+                "type": "skip"
+            },
+            {
+                "rule_fqdn": "ccx_rules_ocp.internal.rules.nvidia_gpu_operator_sro_check.report",
+                "reason": "MISSING_REQUIREMENTS",
+                "details": "All: ['ccx_rules_ocp.internal.rules.nvidia_gpu_operator_sro_check.check_nvidia_current_logs'] Any: ",
+                "type": "skip"
+            },
+            {
+                "rule_fqdn": "ccx_rules_ocp.external.bug_rules.bug_1821905.report",
+                "reason": "MISSING_REQUIREMENTS",
+                "details": "All: ['ccx_ocp_core.utils.affected_version.ensure_is_affected_condition.<locals>.version_condition'] Any: ",
+                "type": "skip"
+            },
+            {
+                "rule_fqdn": "ccx_rules_ocp.internal.bug_rules.kube_scheduler_certs_not_renewed.report",
+                "reason": "MISSING_REQUIREMENTS",
+                "details": "All: ['ccx_rules_ocp.internal.bug_rules.kube_scheduler_certs_not_renewed.check_logs', 'ccx_rules_ocp.internal.bug_rules.kube_scheduler_certs_not_renewed.check_certs_content', 'ccx_ocp_core.utils.affected_version.ensure_is_affected_condition.<locals>.version_condition'] Any: ",
+                "type": "skip"
+            },
+            {
+                "rule_fqdn": "ccx_rules_ocp.external.rules.cmo_container_run_as_non_root.report",
+                "reason": "MISSING_REQUIREMENTS",
+                "details": "All: ['ccx_ocp_core.utils.affected_version.ensure_is_affected_condition.<locals>.version_condition'] Any: ",
+                "type": "skip"
+            },
+            {
+                "rule_fqdn": "ccx_rules_ocp.internal.rules.high_core_dns_errors_high_alerts.report",
+                "reason": "MISSING_REQUIREMENTS",
+                "details": "All: ['ccx_rules_ocp.internal.rules.high_core_dns_errors_high_alerts.check_logs'] Any: ",
+                "type": "skip"
+            },
+            {
+                "rule_fqdn": "ccx_rules_ocp.internal.rules.invalid_ca_cert_causing_install_failure.report",
+                "reason": "MISSING_REQUIREMENTS",
+                "details": "All: ['ccx_rules_ocp.internal.rules.invalid_ca_cert_causing_install_failure.log_check'] Any: ",
+                "type": "skip"
+            },
+            {
+                "rule_fqdn": "ccx_rules_ocp.internal.rules.portworx_unlinkat_private_json.report",
+                "reason": "MISSING_REQUIREMENTS",
+                "details": "All: ['ccx_rules_ocp.internal.rules.portworx_unlinkat_private_json.check_logs'] Any: ",
+                "type": "skip"
+            },
+            {
+                "rule_fqdn": "ccx_rules_ocp.internal.rules.high_disc_usage.report",
+                "reason": "MISSING_REQUIREMENTS",
+                "details": "All: ['ccx_ocp_core.utils.affected_version.ensure_is_affected_condition.<locals>.version_condition'] Any: ",
+                "type": "skip"
+            },
+            {
+                "rule_fqdn": "ccx_rules_ocp.internal.rules.invalid_image_reference.report",
+                "reason": "MISSING_REQUIREMENTS",
+                "details": "All: ['ccx_rules_ocp.internal.rules.invalid_image_reference.check_logs'] Any: ",
+                "type": "skip"
+            },
+            {
+                "rule_fqdn": "ccx_rules_ocp.internal.rules.upgrade_failed_for_network_operator.report",
+                "reason": "MISSING_REQUIREMENTS",
+                "details": "All: ['ccx_rules_ocp.internal.rules.upgrade_failed_for_network_operator.is_ocp_on_azure', 'ccx_rules_ocp.internal.rules.upgrade_failed_for_network_operator.check_version', 'ccx_rules_ocp.internal.rules.upgrade_failed_for_network_operator.network_co_degrade', 'ccx_rules_ocp.internal.rules.upgrade_failed_for_network_operator.check_log'] Any: ",
+                "type": "skip"
+            },
+            {
+                "rule_fqdn": "ccx_rules_ocp.internal.rules.prometheus_invalid_syntax.report",
+                "reason": "MISSING_REQUIREMENTS",
+                "details": "All: ['ccx_rules_ocp.internal.rules.prometheus_invalid_syntax.check_invalid_syntax_log', 'ccx_ocp_core.utils.affected_version.ensure_is_affected_condition.<locals>.version_condition'] Any: ",
+                "type": "skip"
+            },
+            {
+                "rule_fqdn": "ccx_rules_ocp.internal.rules.cluster_unstable_due_to_prometheus_operator_bug.report",
+                "reason": "MISSING_REQUIREMENTS",
+                "details": "All: ['ccx_rules_ocp.internal.rules.cluster_unstable_due_to_prometheus_operator_bug.check_error_log', 'ccx_ocp_core.utils.affected_version.ensure_is_affected_condition.<locals>.version_condition'] Any: ",
+                "type": "skip"
+            },
+            {
+                "rule_fqdn": "ccx_rules_ocp.internal.rules.prometheus_too_old_resource_version.report",
+                "reason": "MISSING_REQUIREMENTS",
+                "details": "All: ['ccx_rules_ocp.internal.rules.prometheus_too_old_resource_version.check_error_log', 'ccx_ocp_core.utils.affected_version.ensure_is_affected_condition.<locals>.version_condition'] Any: ",
+                "type": "skip"
+            },
+            {
+                "rule_fqdn": "ccx_rules_ocp.external.bug_rules.bug_1893386.report",
+                "reason": "MISSING_REQUIREMENTS",
+                "details": "All: ['ccx_ocp_core.utils.affected_version.ensure_is_affected_condition.<locals>.version_condition'] Any: ",
+                "type": "skip"
+            },
+            {
+                "rule_fqdn": "ccx_rules_ocp.internal.rules.kube_api_too_large_resource_version.report",
+                "reason": "MISSING_REQUIREMENTS",
+                "details": "All: ['ccx_rules_ocp.internal.rules.kube_api_too_large_resource_version.check_error_log', 'ccx_ocp_core.utils.affected_version.ensure_is_affected_condition.<locals>.version_condition'] Any: ",
+                "type": "skip"
+            },
+            {
+                "rule_fqdn": "ccx_rules_ocp.internal.rules.ingress_controller_node_placement.report",
+                "reason": "MISSING_REQUIREMENTS",
+                "details": "All: ['ccx_rules_ocp.internal.rules.ingress_controller_node_placement.check_ingress_controllers'] Any: ",
+                "type": "skip"
+            },
+            {
+                "rule_fqdn": "ccx_rules_ocp.external.rules.sap_data_intelligence_permissions.report",
+                "reason": "MISSING_REQUIREMENTS",
+                "details": "All: ['ccx_rules_ocp.external.rules.sap_data_intelligence_permissions.get_sdi_namespaces', 'ccx_rules_ocp.external.rules.sap_data_intelligence_permissions.check_security_context_constraint', 'ccx_rules_ocp.external.rules.sap_data_intelligence_permissions.check_cluster_role_bindings'] Any: ",
+                "type": "skip"
+            },
+            {
+                "rule_fqdn": "ccx_rules_ocp.external.rules.azure_ssh_not_work.report",
+                "reason": "MISSING_REQUIREMENTS",
+                "details": "All: ['ccx_ocp_core.utils.affected_version.ensure_is_affected_condition.<locals>.version_condition'] Any: ",
+                "type": "skip"
+            },
+            {
+                "rule_fqdn": "ccx_rules_ocp.internal.rules.cluster_version_operator_hung_during_shutdown.report",
+                "reason": "MISSING_REQUIREMENTS",
+                "details": "All: ['ccx_ocp_core.utils.affected_version.ensure_is_affected_condition.<locals>.version_condition', 'ccx_rules_ocp.internal.rules.cluster_version_operator_hung_during_shutdown.check_openshift_cluster_version_logs'] Any: ",
+                "type": "skip"
+            },
+            {
+                "rule_fqdn": "ccx_rules_ocp.external.rules.subnets_migration_failure_massive_egressip.report",
+                "reason": "MISSING_REQUIREMENTS",
+                "details": "All: ['ccx_ocp_core.utils.affected_version.ensure_is_affected_condition.<locals>.version_condition'] Any: ",
+                "type": "skip"
+            },
+            {
+                "rule_fqdn": "ccx_rules_ocp.internal.rules.pruner_degrades_image_registry_operator_if_registry_removed.report",
+                "reason": "MISSING_REQUIREMENTS",
+                "details": "All: ['ccx_ocp_core.utils.affected_version.ensure_is_affected_condition.<locals>.version_condition'] Any: ",
+                "type": "skip"
+            },
+            {
+                "rule_fqdn": "ccx_rules_ocp.internal.rules.ingress_op_degraded_unmatched_hosted_zone.report",
+                "reason": "MISSING_REQUIREMENTS",
+                "details": "All: ['ccx_rules_ocp.internal.rules.ingress_op_degraded_unmatched_hosted_zone.check_ingress_dnsrecord_yaml'] Any: ",
+                "type": "skip"
+            },
+            {
+                "rule_fqdn": "ccx_rules_ocp.external.rules.check_sap_sdi_observer_pods.report",
+                "reason": "MISSING_REQUIREMENTS",
+                "details": "All: ['ccx_rules_ocp.external.rules.check_sap_sdi_observer_pods.get_sdi_namespaces'] Any: ",
+                "type": "skip"
+            },
+            {
+                "rule_fqdn": "ccx_rules_ocp.internal.bug_rules.monitoring_updating_openshift_state_metrics_failed.report",
+                "reason": "MISSING_REQUIREMENTS",
+                "details": "All: ['ccx_rules_ocp.internal.bug_rules.monitoring_updating_openshift_state_metrics_failed.check_logs', 'ccx_ocp_core.utils.affected_version.ensure_is_affected_condition.<locals>.version_condition'] Any: ",
+                "type": "skip"
+            },
+            {
+                "rule_fqdn": "ccx_rules_ocp.internal.rules.CSI_resultServer_pods_schedule_issue.report",
+                "reason": "MISSING_REQUIREMENTS",
+                "details": "All: ['ccx_rules_ocp.internal.rules.CSI_resultServer_pods_schedule_issue.check_logs'] Any: ",
+                "type": "skip"
+            },
+            {
+                "rule_fqdn": "ccx_rules_ocp.internal.rules.kube_rbac_proxy_crashloop_during_authentication.report",
+                "reason": "MISSING_REQUIREMENTS",
+                "details": "All: ['ccx_ocp_core.utils.affected_version.ensure_is_affected_condition.<locals>.version_condition', 'ccx_rules_ocp.internal.rules.kube_rbac_proxy_crashloop_during_authentication.check_logs'] Any: ",
+                "type": "skip"
+            },
+            {
+                "rule_fqdn": "ccx_rules_ocp.internal.rules.authentication_operator_memory_leak.report",
+                "reason": "MISSING_REQUIREMENTS",
+                "details": "All: ['ccx_ocp_core.utils.affected_version.ensure_is_affected_condition.<locals>.version_condition'] Any: ",
+                "type": "skip"
+            },
+            {
+                "rule_fqdn": "ccx_rules_ocp.external.rules.tls_handshake_fails_in_azure.report",
+                "reason": "MISSING_REQUIREMENTS",
+                "details": "All: ['ccx_ocp_core.utils.affected_version.ensure_is_affected_condition.<locals>.version_condition'] Any: ",
+                "type": "skip"
+            },
+            {
+                "rule_fqdn": "ccx_rules_ocp.internal.bug_rules.apiserver_degraded_not_available.report",
+                "reason": "MISSING_REQUIREMENTS",
+                "details": "All: ['ccx_rules_ocp.internal.bug_rules.apiserver_degraded_not_available.check_kube_apiserver_logs', 'ccx_ocp_core.utils.affected_version.ensure_is_affected_condition.<locals>.version_condition'] Any: ",
+                "type": "skip"
+            },
+            {
+                "rule_fqdn": "ccx_rules_ocp.internal.bug_rules.networkpolicy_flows_for_non_pod_network_pods.report",
+                "reason": "MISSING_REQUIREMENTS",
+                "details": "All: ['ccx_rules_ocp.internal.bug_rules.networkpolicy_flows_for_non_pod_network_pods.check_openshift_sdn_logs'] Any: ",
+                "type": "skip"
+            },
+            {
+                "rule_fqdn": "ccx_rules_ocp.internal.rules.failed_to_set_up_mount_unit_for_garbage_collect_mode.report",
+                "reason": "MISSING_REQUIREMENTS",
+                "details": "All: ['ccx_ocp_core.utils.affected_version.ensure_is_affected_condition.<locals>.version_condition', 'ccx_rules_ocp.internal.rules.failed_to_set_up_mount_unit_for_garbage_collect_mode.check_events'] Any: ",
+                "type": "skip"
+            },
+            {
+                "rule_fqdn": "ccx_rules_ocp.internal.bug_rules.apiserver_down_on_vsphere_48.report",
+                "reason": "MISSING_REQUIREMENTS",
+                "details": "All: ['ccx_rules_ocp.internal.bug_rules.apiserver_down_on_vsphere_48.on_vsphere'] Any: ",
+                "type": "skip"
+            },
+            {
+                "rule_fqdn": "ccx_rules_ocp.internal.bug_rules.node_exporter_fails_parsing_mountstat_with_invalid_nfs_operation_stats.report",
+                "reason": "MISSING_REQUIREMENTS",
+                "details": "All: ['ccx_rules_ocp.internal.bug_rules.node_exporter_fails_parsing_mountstat_with_invalid_nfs_operation_stats.check_node_exporter_failed_to_parse_logs', 'ccx_ocp_core.utils.affected_version.ensure_is_affected_condition.<locals>.version_condition'] Any: ",
+                "type": "skip"
+            },
+            {
+                "rule_fqdn": "ccx_rules_ocp.internal.rules.fluentd_buffer_queue_length_burst.report",
+                "reason": "MISSING_REQUIREMENTS",
+                "details": "All: ['ccx_ocp_core.utils.affected_version.ensure_is_affected_condition.<locals>.version_condition'] Any: ",
+                "type": "skip"
+            },
+            {
+                "rule_fqdn": "ccx_rules_ocp.internal.bug_rules.bug_1801300.report",
+                "reason": "MISSING_REQUIREMENTS",
+                "details": "All: ['ccx_ocp_core.specs.must_gather.DeploymentsMG', 'ccx_ocp_core.utils.affected_version.ensure_is_affected_condition.<locals>.version_condition'] Any: ",
+                "type": "skip"
+            },
+            {
+                "rule_fqdn": "ccx_rules_ocp.ocs.ocs_not_find_attached_vmdk.report",
+                "reason": "MISSING_REQUIREMENTS",
+                "details": "All: ['ccx_rules_ocp.ocs.ocs_not_find_attached_vmdk.check_event_message'] Any: ",
+                "type": "skip"
+            },
+            {
+                "rule_fqdn": "ccx_rules_ocp.internal.rules.helm_chart_proxy_connection_timed_out.report",
+                "reason": "MISSING_REQUIREMENTS",
+                "details": "All: ['ccx_rules_ocp.internal.rules.helm_chart_proxy_connection_timed_out.check_error_log', 'ccx_ocp_core.utils.affected_version.ensure_is_affected_condition.<locals>.version_condition'] Any: ",
+                "type": "skip"
+            },
+            {
+                "rule_fqdn": "ccx_rules_ocp.external.bug_rules.bug_1798049.report",
+                "reason": "MISSING_REQUIREMENTS",
+                "details": "All: ['ccx_ocp_core.utils.affected_version.ensure_is_affected_condition.<locals>.version_condition'] Any: ",
+                "type": "skip"
+            },
+            {
+                "rule_fqdn": "ccx_rules_ocp.internal.bug_rules.bug_1802248.report",
+                "reason": "MISSING_REQUIREMENTS",
+                "details": "All: ['ccx_ocp_core.specs.must_gather.DeploymentsMG', 'ccx_ocp_core.utils.affected_version.ensure_is_affected_condition.<locals>.version_condition'] Any: ",
+                "type": "skip"
+            },
+            {
+                "rule_fqdn": "ccx_rules_ocp.internal.bug_rules.node_ip_changes_to_api_vip.report",
+                "reason": "MISSING_REQUIREMENTS",
+                "details": "All: ['ccx_rules_ocp.internal.bug_rules.node_ip_changes_to_api_vip.api_vip_check', 'ccx_ocp_core.utils.affected_version.ensure_is_affected_condition.<locals>.version_condition'] Any: ",
+                "type": "skip"
+            },
+            {
+                "rule_fqdn": "ccx_rules_ocp.external.rules.prometheus_rule_evaluation_fail.report",
+                "reason": "MISSING_REQUIREMENTS",
+                "details": "All: ['ccx_rules_ocp.external.rules.prometheus_rule_evaluation_fail.check_found_duplicate_logs', 'ccx_ocp_core.utils.affected_version.ensure_is_affected_condition.<locals>.version_condition'] Any: ",
+                "type": "skip"
+            },
+            {
+                "rule_fqdn": "ccx_rules_ocp.internal.rules.canary_check_repeat_fail.report",
+                "reason": "MISSING_REQUIREMENTS",
+                "details": "All: ['ccx_rules_ocp.internal.rules.canary_check_repeat_fail.degraded_operator', 'ccx_rules_ocp.internal.rules.canary_check_repeat_fail.check_logs'] Any: ",
+                "type": "skip"
+            },
+            {
+                "rule_fqdn": "ccx_rules_ocp.internal.rules.mcp_unexpected_on_disk_state_mode_mismatch.report",
+                "reason": "MISSING_REQUIREMENTS",
+                "details": "All: ['ccx_rules_ocp.common.mcp_unexpected_on_disk_state.pods_with_mode_mismatch'] Any: ",
+                "type": "skip"
+            },
+            {
+                "rule_fqdn": "ccx_rules_ocp.internal.rules.openshift_route_annotations.report",
+                "reason": "MISSING_REQUIREMENTS",
+                "details": "All: ['ccx_ocp_core.utils.affected_version.ensure_is_affected_condition.<locals>.version_condition', 'ccx_rules_ocp.internal.rules.openshift_route_annotations.check_route_annotations'] Any: ",
+                "type": "skip"
+            },
+            {
+                "rule_fqdn": "ccx_rules_ocp.ocs.pod_stuck_for_whereabouts_ip_assigned.report",
+                "reason": "MISSING_REQUIREMENTS",
+                "details": "All: ['ccx_rules_ocp.ocs.pod_stuck_for_whereabouts_ip_assigned.check_pods_in_events'] Any: ",
+                "type": "skip"
+            },
+            {
+                "rule_fqdn": "ccx_rules_ocp.internal.rules.certificates_expiring_soon_info.report",
+                "reason": "MISSING_REQUIREMENTS",
+                "details": "All: ['ccx_ocp_core.models.certificates.Certificates'] Any: ",
+                "type": "skip"
+            },
+            {
+                "rule_fqdn": "ccx_rules_ocp.internal.rules.certificates_expired.report",
+                "reason": "MISSING_REQUIREMENTS",
+                "details": "All: ['ccx_ocp_core.models.certificates.Certificates'] Any: ",
+                "type": "skip"
+            },
+            {
+                "rule_fqdn": "ccx_rules_ocp.internal.rules.openshift_router_duplicate_targetports.report",
+                "reason": "MISSING_REQUIREMENTS",
+                "details": "All: ['ccx_rules_ocp.internal.rules.openshift_router_duplicate_targetports.check_error_log', 'ccx_ocp_core.utils.affected_version.ensure_is_affected_condition.<locals>.version_condition'] Any: ",
+                "type": "skip"
+            },
+            {
+                "rule_fqdn": "ccx_rules_ocp.internal.bug_rules.catalog_operator_index_out_of_range_with_length_0.report",
+                "reason": "MISSING_REQUIREMENTS",
+                "details": "All: ['ccx_rules_ocp.internal.bug_rules.catalog_operator_index_out_of_range_with_length_0.check_index_index_out_of_range_logs', 'ccx_ocp_core.utils.affected_version.ensure_is_affected_condition.<locals>.version_condition'] Any: ",
+                "type": "skip"
+            },
+            {
+                "rule_fqdn": "ccx_rules_ocp.internal.bug_rules.openshift_apiserver_pnf_featuregates.report",
+                "reason": "MISSING_REQUIREMENTS",
+                "details": "All: ['ccx_rules_ocp.internal.bug_rules.openshift_apiserver_pnf_featuregates.check_pnf_featuregates', 'ccx_rules_ocp.internal.bug_rules.openshift_apiserver_pnf_featuregates.check_openshift_apiserver_operator_logs', 'ccx_rules_ocp.internal.bug_rules.openshift_apiserver_pnf_featuregates.check_kube_apiserver_logs', 'ccx_rules_ocp.internal.bug_rules.openshift_apiserver_pnf_featuregates.check_openshift_apiserver_logs', 'ccx_ocp_core.utils.affected_version.ensure_is_affected_condition.<locals>.version_condition'] Any: ",
+                "type": "skip"
+            },
+            {
+                "rule_fqdn": "ccx_rules_ocp.internal.rules.nil_pointer_dereference_panic_in_mcc_or_mco.report",
+                "reason": "MISSING_REQUIREMENTS",
+                "details": "All: ['ccx_rules_ocp.internal.rules.nil_pointer_dereference_panic_in_mcc_or_mco.check_nil_pointer_dereference_logs'] Any: ",
+                "type": "skip"
+            },
+            {
+                "rule_fqdn": "ccx_rules_ocp.internal.rules.master_mcp_degraded_due_to_etcd_manifest_validation.report",
+                "reason": "MISSING_REQUIREMENTS",
+                "details": "All: ['ccx_rules_ocp.internal.rules.master_mcp_degraded_due_to_etcd_manifest_validation.check_etcd_member_yaml_validation_logs', 'ccx_rules_ocp.internal.rules.master_mcp_degraded_due_to_etcd_manifest_validation.check_master_mcp_dgr'] Any: ",
+                "type": "skip"
+            },
+            {
+                "rule_fqdn": "ccx_rules_ocp.internal.bug_rules.check_pods_stuck_in_NodeAffinity_state.report",
+                "reason": "MISSING_REQUIREMENTS",
+                "details": "All: ['ccx_ocp_core.utils.affected_version.ensure_is_affected_condition.<locals>.version_condition'] Any: ",
+                "type": "skip"
+            },
+            {
+                "rule_fqdn": "ccx_rules_ocp.internal.bug_rules.vsphere_reconnects_an_updated_secret.report",
+                "reason": "MISSING_REQUIREMENTS",
+                "details": "All: ['ccx_rules_ocp.internal.bug_rules.vsphere_reconnects_an_updated_secret.is_vsphere', 'ccx_rules_ocp.internal.bug_rules.vsphere_reconnects_an_updated_secret.check_pods_logs', 'ccx_ocp_core.utils.affected_version.ensure_is_affected_condition.<locals>.version_condition'] Any: ",
+                "type": "skip"
+            },
+            {
+                "rule_fqdn": "ccx_rules_ocp.internal.bug_rules.openshift_cluster_csi_drivers_pods_pending_during_upgrade.report",
+                "reason": "MISSING_REQUIREMENTS",
+                "details": "All: ['ccx_ocp_core.utils.affected_version.ensure_is_affected_condition.<locals>.version_condition'] Any: ",
+                "type": "skip"
+            },
+            {
+                "rule_fqdn": "ccx_rules_ocp.internal.bug_rules.cloud_credential_operator_s3_not_found.report",
+                "reason": "MISSING_REQUIREMENTS",
+                "details": "All: ['ccx_rules_ocp.internal.bug_rules.cloud_credential_operator_s3_not_found.check_cco_logs', 'ccx_ocp_core.utils.affected_version.ensure_is_affected_condition.<locals>.version_condition'] Any: ",
+                "type": "skip"
+            },
+            {
+                "rule_fqdn": "ccx_rules_ocp.internal.rules.check_machine_config_ignition_version.report",
+                "reason": "MISSING_REQUIREMENTS",
+                "details": "All: ['ccx_rules_ocp.internal.rules.check_machine_config_ignition_version.check_machine_config_ign'] Any: ",
+                "type": "skip"
+            },
+            {
+                "rule_fqdn": "ccx_rules_ocp.external.rules.lib_bucket_provisioner_check.report",
+                "reason": "MISSING_REQUIREMENTS",
+                "details": "All: ['ccx_ocp_core.utils.affected_version.ensure_is_affected_condition.<locals>.version_condition', 'ccx_rules_ocp.external.rules.lib_bucket_provisioner_check.check_install_plans'] Any: ",
+                "type": "skip"
+            },
+            {
+                "rule_fqdn": "ccx_rules_ocp.internal.bug_rules.continous_reconciling_op_messages.report",
+                "reason": "MISSING_REQUIREMENTS",
+                "details": "All: ['ccx_rules_ocp.internal.bug_rules.continous_reconciling_op_messages.check_logs', 'ccx_ocp_core.utils.affected_version.ensure_is_affected_condition.<locals>.version_condition'] Any: ",
+                "type": "skip"
+            },
+            {
+                "rule_fqdn": "ccx_rules_ocp.internal.rules.ovnkube_master_stuck_in_crashloopbackoff.report",
+                "reason": "MISSING_REQUIREMENTS",
+                "details": "All: ['ccx_rules_ocp.internal.rules.ovnkube_master_stuck_in_crashloopbackoff.check_op_status', 'ccx_rules_ocp.internal.rules.ovnkube_master_stuck_in_crashloopbackoff.check_pod_status'] Any: ",
+                "type": "skip"
+            },
+            {
+                "rule_fqdn": "ccx_rules_ocp.internal.bug_rules.coredns_panic_without_probe_failures.report",
+                "reason": "MISSING_REQUIREMENTS",
+                "details": "All: ['ccx_rules_ocp.internal.bug_rules.coredns_panic_without_probe_failures.check_logs', 'ccx_ocp_core.utils.affected_version.ensure_is_affected_condition.<locals>.version_condition'] Any: ",
+                "type": "skip"
+            },
+            {
+                "rule_fqdn": "ccx_rules_ocp.internal.bug_rules.prometheus_load_too_many_samples_into_memory.report",
+                "reason": "MISSING_REQUIREMENTS",
+                "details": "All: ['ccx_rules_ocp.internal.bug_rules.prometheus_load_too_many_samples_into_memory.check_load_too_many_samples_into_memory_logs', 'ccx_ocp_core.utils.affected_version.ensure_is_affected_condition.<locals>.version_condition'] Any: ",
+                "type": "skip"
+            },
+            {
+                "rule_fqdn": "ccx_rules_ocp.internal.rules.mcp_degraded_due_to_osimage_newer_version.report",
+                "reason": "MISSING_REQUIREMENTS",
+                "details": "All: ['ccx_rules_ocp.internal.rules.mcp_degraded_due_to_osimage_newer_version.mcp_status', 'ccx_rules_ocp.internal.rules.mcp_degraded_due_to_osimage_newer_version.check_logs'] Any: ",
+                "type": "skip"
+            },
+            {
+                "rule_fqdn": "ccx_rules_ocp.internal.bug_rules.etcd_operator_tries_connecting_to_defunct_bootstrap_etcd_member.report",
+                "reason": "MISSING_REQUIREMENTS",
+                "details": "All: ['ccx_rules_ocp.internal.bug_rules.etcd_operator_tries_connecting_to_defunct_bootstrap_etcd_member.is_etcd_operator_connecting_to_bootstrap', 'ccx_ocp_core.utils.affected_version.ensure_is_affected_condition.<locals>.version_condition'] Any: ",
+                "type": "skip"
+            },
+            {
+                "rule_fqdn": "ccx_rules_ocp.internal.bug_rules.prometheus_mount_nfs_volumes_permission_denied.report",
+                "reason": "MISSING_REQUIREMENTS",
+                "details": "All: ['ccx_rules_ocp.internal.bug_rules.prometheus_mount_nfs_volumes_permission_denied.check_openshift_monitoring_logs'] Any: ",
+                "type": "skip"
+            },
+            {
+                "rule_fqdn": "ccx_rules_ocp.internal.rules.mcp_unexpected_on_disk_state_content_mismatch.report",
+                "reason": "MISSING_REQUIREMENTS",
+                "details": "All: ['ccx_rules_ocp.common.mcp_unexpected_on_disk_state.pods_with_content_mismatch'] Any: ",
+                "type": "skip"
+            },
+            {
+                "rule_fqdn": "ccx_rules_ocp.internal.rules.pod_thanos_ruler_user_workload_failed.report",
+                "reason": "MISSING_REQUIREMENTS",
+                "details": "All: ['ccx_ocp_core.utils.affected_version.ensure_is_affected_condition.<locals>.version_condition'] Any: ",
+                "type": "skip"
+            },
+            {
+                "rule_fqdn": "ccx_rules_ocp.internal.rules.mcp_unexpected_on_disk_state_content_mismatch_chrony_conf.report",
+                "reason": "MISSING_REQUIREMENTS",
+                "details": "All: ['ccx_rules_ocp.common.mcp_unexpected_on_disk_state.pods_with_content_mismatch'] Any: ",
+                "type": "skip"
+            },
+            {
+                "rule_fqdn": "ccx_rules_ocp.internal.rules.mcp_unexpected_on_disk_state_content_mismatch_kubelet_ca_cert.report",
+                "reason": "MISSING_REQUIREMENTS",
+                "details": "All: ['ccx_rules_ocp.common.mcp_unexpected_on_disk_state.pods_with_content_mismatch'] Any: ",
+                "type": "skip"
+            },
+            {
+                "rule_fqdn": "ccx_rules_ocp.internal.bug_rules.prometheus_operator_deployment_misses_part_of_labels.report",
+                "reason": "MISSING_REQUIREMENTS",
+                "details": "All: ['ccx_rules_ocp.internal.bug_rules.prometheus_operator_deployment_misses_part_of_labels.check_openshift_monitoring_logs'] Any: ",
+                "type": "skip"
+            },
+            {
+                "rule_fqdn": "ccx_rules_ocp.internal.bug_rules.mco_controller_version_mismatch.report",
+                "reason": "MISSING_REQUIREMENTS",
+                "details": "All: ['ccx_rules_ocp.internal.bug_rules.mco_controller_version_mismatch.check_logs', 'ccx_rules_ocp.internal.bug_rules.mco_controller_version_mismatch.check_multiple_mc'] Any: ",
+                "type": "skip"
+            },
+            {
+                "rule_fqdn": "ccx_rules_ocp.internal.bug_rules.route_resolves_to_localhost.report",
+                "reason": "MISSING_REQUIREMENTS",
+                "details": "All: ['ccx_rules_ocp.internal.bug_rules.route_resolves_to_localhost.check_logs'] Any: ",
+                "type": "skip"
+            },
+            {
+                "rule_fqdn": "ccx_rules_ocp.internal.bug_rules.image_registry_removed_state_reports_degraded.report",
+                "reason": "MISSING_REQUIREMENTS",
+                "details": "All: ['ccx_rules_ocp.internal.bug_rules.image_registry_removed_state_reports_degraded.check_op_status'] Any: ",
+                "type": "skip"
+            },
+            {
+                "rule_fqdn": "ccx_rules_ocp.external.rules.prometheus_backed_by_pvc.report",
+                "reason": "MISSING_REQUIREMENTS",
+                "details": "All: ['ccx_rules_ocp.external.rules.prometheus_backed_by_pvc.check_desired_version', 'ccx_rules_ocp.external.rules.prometheus_backed_by_pvc.check_cluster_monitoring_config_map'] Any: ",
+                "type": "skip"
+            },
+            {
+                "rule_fqdn": "ccx_rules_ocp.internal.rules.mcp_unexpected_on_disk_state_content_mismatch_resolv_conf.report",
+                "reason": "MISSING_REQUIREMENTS",
+                "details": "All: ['ccx_rules_ocp.internal.rules.mcp_unexpected_on_disk_state_content_mismatch_resolv_conf.affected_pods'] Any: ",
+                "type": "skip"
+            },
+            {
+                "rule_fqdn": "ccx_rules_ocp.internal.bug_rules.marketplace_operatorexited_while_upgrade.report",
+                "reason": "MISSING_REQUIREMENTS",
+                "details": "All: ['ccx_rules_ocp.internal.bug_rules.marketplace_operatorexited_while_upgrade.check_logs'] Any: ",
+                "type": "skip"
+            },
+            {
+                "rule_fqdn": "ccx_rules_ocp.internal.bug_rules.pod_creation_failures_due_to_sdn_segfaults.report",
+                "reason": "MISSING_REQUIREMENTS",
+                "details": "All: ['ccx_rules_ocp.internal.bug_rules.pod_creation_failures_due_to_sdn_segfaults.check_logs'] Any: ",
+                "type": "skip"
+            }
+        ],
+        "info": [
+            {
+                "info_id": "machine_pool_info|MACHINE_POOL_INFO",
+                "component": "ccx_rules_ocp.internal.rules.machine_pool_info.report",
+                "type": "info",
+                "key": "MACHINE_POOL_INFO",
+                "details": {
+                    "machines": [
+                        {
+                            "degraded": {
+                                "status": false,
+                                "last_trans_time": "2021-10-08T08:10:33Z",
+                                "reason": "",
+                                "message": ""
+                            },
+                            "name": "master",
+                            "node_degraded": {
+                                "status": false,
+                                "last_trans_time": "2021-10-08T08:10:33Z",
+                                "reason": "",
+                                "message": ""
+                            },
+                            "render_degraded": {
+                                "status": false,
+                                "last_trans_time": "2021-10-08T08:09:38Z",
+                                "reason": "",
+                                "message": ""
+                            },
+                            "updated": {
+                                "status": false,
+                                "last_trans_time": "2021-10-08T09:44:15Z",
+                                "reason": "",
+                                "message": ""
+                            },
+                            "updating": {
+                                "status": true,
+                                "last_trans_time": "2021-10-08T09:44:15Z",
+                                "reason": "",
+                                "message": "All nodes are updating to rendered-master-a40f9eb37039e079676527fd41bbef52"
+                            }
+                        },
+                        {
+                            "degraded": {
+                                "status": false,
+                                "last_trans_time": "2021-10-08T08:09:41Z",
+                                "reason": "",
+                                "message": ""
+                            },
+                            "name": "worker",
+                            "node_degraded": {
+                                "status": false,
+                                "last_trans_time": "2021-10-08T08:09:41Z",
+                                "reason": "",
+                                "message": ""
+                            },
+                            "render_degraded": {
+                                "status": false,
+                                "last_trans_time": "2021-10-08T08:09:38Z",
+                                "reason": "",
+                                "message": ""
+                            },
+                            "updated": {
+                                "status": false,
+                                "last_trans_time": "2021-10-08T09:44:15Z",
+                                "reason": "",
+                                "message": ""
+                            },
+                            "updating": {
+                                "status": true,
+                                "last_trans_time": "2021-10-08T09:44:15Z",
+                                "reason": "",
+                                "message": "All nodes are updating to rendered-worker-3c096f9626f3d5efb9113e1056ab71fa"
+                            }
+                        }
+                    ],
+                    "type": "info",
+                    "info_key": "MACHINE_POOL_INFO"
+                },
+                "tags": [],
+                "links": {}
+            },
+            {
+                "info_id": "version_info|CLUSTER_VERSION_INFO",
+                "component": "ccx_rules_ocp.internal.rules.version_info.report",
+                "type": "info",
+                "key": "CLUSTER_VERSION_INFO",
+                "details": {
+                    "desired": "4.8.13",
+                    "current": "4.8.12",
+                    "aborted_updates": 0,
+                    "last_update_start": "2021-10-08T08:52:20Z",
+                    "last_update_start_delta": "66 days 6 hours 58 minutes 43 seconds",
+                    "type": "info",
+                    "info_key": "CLUSTER_VERSION_INFO"
+                },
+                "tags": [],
+                "links": {}
+            },
+            {
+                "info_id": "cluster_id|GRAFANA_LINK",
+                "component": "ccx_rules_ocp.external.rules.cluster_id.report",
+                "type": "info",
+                "key": "GRAFANA_LINK",
+                "details": {
+                    "cluster_id": "CLUSTER_ID_TO_BE_REPLACED",
+                    "grafana_link": "https://telemeter-lts-dashboards.datahub.redhat.com/d/kSomLV7Wk/pre-production-cluster-by-id?orgId=1&var-_id=CLUSTER_ID_TO_BE_REPLACED",
+                    "type": "info",
+                    "info_key": "GRAFANA_LINK"
+                },
+                "tags": [],
+                "links": {}
+            },
+            {
+                "info_id": "cluster_status_overview|CLUSTER_STATUS_OVERVIEW",
+                "component": "ccx_rules_ocp.internal.rules.cluster_status_overview.report",
+                "type": "info",
+                "key": "CLUSTER_STATUS_OVERVIEW",
+                "details": {
+                    "phased_gates_checks": [
+                        "2.3.1",
+                        "2.3.2"
+                    ],
+                    "node_status": [
+                        {
+                            "name": "ip-10-0-134-149.us-east-2.compute.internal",
+                            "ready": true,
+                            "roles": "master",
+                            "created_on": "2021-10-08T08:07:08Z",
+                            "version": "v1.21.1+d8043e1",
+                            "os": "Red Hat Enterprise Linux CoreOS 48.84.202109100857-0 (Ootpa)"
+                        },
+                        {
+                            "name": "ip-10-0-141-55.us-east-2.compute.internal",
+                            "ready": true,
+                            "roles": "worker",
+                            "created_on": "2021-10-08T08:13:05Z",
+                            "version": "v1.21.1+d8043e1",
+                            "os": "Red Hat Enterprise Linux CoreOS 48.84.202109100857-0 (Ootpa)"
+                        },
+                        {
+                            "name": "ip-10-0-166-189.us-east-2.compute.internal",
+                            "ready": true,
+                            "roles": "master",
+                            "created_on": "2021-10-08T08:07:32Z",
+                            "version": "v1.21.1+d8043e1",
+                            "os": "Red Hat Enterprise Linux CoreOS 48.84.202109100857-0 (Ootpa)"
+                        },
+                        {
+                            "name": "ip-10-0-169-10.us-east-2.compute.internal",
+                            "ready": true,
+                            "roles": "worker",
+                            "created_on": "2021-10-08T08:13:02Z",
+                            "version": "v1.21.1+d8043e1",
+                            "os": "Red Hat Enterprise Linux CoreOS 48.84.202109100857-0 (Ootpa)"
+                        },
+                        {
+                            "name": "ip-10-0-204-77.us-east-2.compute.internal",
+                            "ready": true,
+                            "roles": "worker",
+                            "created_on": "2021-10-08T08:12:48Z",
+                            "version": "v1.21.1+d8043e1",
+                            "os": "Red Hat Enterprise Linux CoreOS 48.84.202109100857-0 (Ootpa)"
+                        },
+                        {
+                            "name": "ip-10-0-220-70.us-east-2.compute.internal",
+                            "ready": true,
+                            "roles": "master",
+                            "created_on": "2021-10-08T08:07:33Z",
+                            "version": "v1.21.1+d8043e1",
+                            "os": "Red Hat Enterprise Linux CoreOS 48.84.202109100857-0 (Ootpa)"
+                        }
+                    ],
+                    "node_command_show": 0,
+                    "nd_column_length": [
+                        44,
+                        6,
+                        8,
+                        22,
+                        17,
+                        62
+                    ],
+                    "cluster_version": {
+                        "Cluster ID": "CLUSTER_ID_TO_BE_REPLACED",
+                        "Cluster Version": "4.8.12",
+                        "Desired Version": "4.8.13",
+                        "Channel": "stable-4.8",
+                        "Previous Version(s)": "4.8.12"
+                    },
+                    "clusteroperators": [
+                        {
+                            "name": "authentication",
+                            "version": "4.8.13",
+                            "available": "True",
+                            "progressing": "False",
+                            "degraded": "False"
+                        },
+                        {
+                            "name": "baremetal",
+                            "version": "4.8.13",
+                            "available": "True",
+                            "progressing": "False",
+                            "degraded": "False"
+                        },
+                        {
+                            "name": "cloud-credential",
+                            "version": "4.8.13",
+                            "available": "True",
+                            "progressing": "False",
+                            "degraded": "False"
+                        },
+                        {
+                            "name": "cluster-autoscaler",
+                            "version": "4.8.13",
+                            "available": "True",
+                            "progressing": "False",
+                            "degraded": "False"
+                        },
+                        {
+                            "name": "config-operator",
+                            "version": "4.8.13",
+                            "available": "True",
+                            "progressing": "False",
+                            "degraded": "False"
+                        },
+                        {
+                            "name": "console",
+                            "version": "4.8.13",
+                            "available": "True",
+                            "progressing": "False",
+                            "degraded": "False"
+                        },
+                        {
+                            "name": "csi-snapshot-controller",
+                            "version": "4.8.13",
+                            "available": "True",
+                            "progressing": "False",
+                            "degraded": "False"
+                        },
+                        {
+                            "name": "dns",
+                            "version": "4.8.13",
+                            "available": "True",
+                            "progressing": "False",
+                            "degraded": "False"
+                        },
+                        {
+                            "name": "etcd",
+                            "version": "4.8.13",
+                            "available": "True",
+                            "progressing": "False",
+                            "degraded": "False"
+                        },
+                        {
+                            "name": "image-registry",
+                            "version": "4.8.13",
+                            "available": "True",
+                            "progressing": "False",
+                            "degraded": "False"
+                        },
+                        {
+                            "name": "ingress",
+                            "version": "4.8.13",
+                            "available": "True",
+                            "progressing": "False",
+                            "degraded": "False"
+                        },
+                        {
+                            "name": "insights",
+                            "version": "4.8.13",
+                            "available": "True",
+                            "progressing": "False",
+                            "degraded": "False"
+                        },
+                        {
+                            "name": "kube-apiserver",
+                            "version": "4.8.13",
+                            "available": "True",
+                            "progressing": "False",
+                            "degraded": "False"
+                        },
+                        {
+                            "name": "kube-controller-manager",
+                            "version": "4.8.13",
+                            "available": "True",
+                            "progressing": "False",
+                            "degraded": "False"
+                        },
+                        {
+                            "name": "kube-scheduler",
+                            "version": "4.8.13",
+                            "available": "True",
+                            "progressing": "False",
+                            "degraded": "False"
+                        },
+                        {
+                            "name": "kube-storage-version-migrator",
+                            "version": "4.8.13",
+                            "available": "True",
+                            "progressing": "False",
+                            "degraded": "False"
+                        },
+                        {
+                            "name": "machine-api",
+                            "version": "4.8.13",
+                            "available": "True",
+                            "progressing": "False",
+                            "degraded": "False"
+                        },
+                        {
+                            "name": "machine-approver",
+                            "version": "4.8.13",
+                            "available": "True",
+                            "progressing": "False",
+                            "degraded": "False"
+                        },
+                        {
+                            "name": "machine-config",
+                            "version": "4.8.12",
+                            "available": "True",
+                            "progressing": "True",
+                            "degraded": "False"
+                        },
+                        {
+                            "name": "marketplace",
+                            "version": "4.8.13",
+                            "available": "True",
+                            "progressing": "False",
+                            "degraded": "False"
+                        },
+                        {
+                            "name": "monitoring",
+                            "version": "4.8.13",
+                            "available": "True",
+                            "progressing": "False",
+                            "degraded": "False"
+                        },
+                        {
+                            "name": "network",
+                            "version": "4.8.13",
+                            "available": "True",
+                            "progressing": "False",
+                            "degraded": "False"
+                        },
+                        {
+                            "name": "node-tuning",
+                            "version": "4.8.13",
+                            "available": "True",
+                            "progressing": "False",
+                            "degraded": "False"
+                        },
+                        {
+                            "name": "openshift-apiserver",
+                            "version": "4.8.13",
+                            "available": "True",
+                            "progressing": "False",
+                            "degraded": "False"
+                        },
+                        {
+                            "name": "openshift-controller-manager",
+                            "version": "4.8.13",
+                            "available": "True",
+                            "progressing": "False",
+                            "degraded": "False"
+                        },
+                        {
+                            "name": "openshift-samples",
+                            "version": "4.8.13",
+                            "available": "True",
+                            "progressing": "False",
+                            "degraded": "False"
+                        },
+                        {
+                            "name": "operator-lifecycle-manager",
+                            "version": "4.8.13",
+                            "available": "True",
+                            "progressing": "False",
+                            "degraded": "False"
+                        },
+                        {
+                            "name": "operator-lifecycle-manager-catalog",
+                            "version": "4.8.13",
+                            "available": "True",
+                            "progressing": "False",
+                            "degraded": "False"
+                        },
+                        {
+                            "name": "operator-lifecycle-manager-packageserver",
+                            "version": "4.8.13",
+                            "available": "True",
+                            "progressing": "False",
+                            "degraded": "False"
+                        },
+                        {
+                            "name": "service-ca",
+                            "version": "4.8.13",
+                            "available": "True",
+                            "progressing": "True",
+                            "degraded": "False"
+                        },
+                        {
+                            "name": "storage",
+                            "version": "4.8.13",
+                            "available": "True",
+                            "progressing": "False",
+                            "degraded": "False"
+                        }
+                    ],
+                    "op_column_length": [
+                        42,
+                        8,
+                        6,
+                        7,
+                        7
+                    ],
+                    "machineconfigpools": [
+                        {
+                            "name": "master",
+                            "config": "rendered-master-a40f9eb37039e079676527fd41bbef52",
+                            "paused": false,
+                            "updated": "False",
+                            "updating": "True",
+                            "degraded": "False",
+                            "machine_count": 3,
+                            "ready_machine_count": 0,
+                            "updated_machine_count": 0,
+                            "degraded_machine_count": 0
+                        },
+                        {
+                            "name": "worker",
+                            "config": "rendered-worker-3c096f9626f3d5efb9113e1056ab71fa",
+                            "paused": false,
+                            "updated": "False",
+                            "updating": "True",
+                            "degraded": "False",
+                            "machine_count": 3,
+                            "ready_machine_count": 0,
+                            "updated_machine_count": 0,
+                            "degraded_machine_count": 0
+                        }
+                    ],
+                    "mcp_column_length": [
+                        8,
+                        50,
+                        7,
+                        7,
+                        6,
+                        7,
+                        3,
+                        3,
+                        3,
+                        3
+                    ],
+                    "machinesets": [
+                        {
+                            "name": "rvokal-insights-notif-n8wkl-worker-us-east-2a",
+                            "desired": 1,
+                            "current": 1,
+                            "ready": 1,
+                            "available": 1
+                        },
+                        {
+                            "name": "rvokal-insights-notif-n8wkl-worker-us-east-2b",
+                            "desired": 1,
+                            "current": 1,
+                            "ready": 1,
+                            "available": 1
+                        },
+                        {
+                            "name": "rvokal-insights-notif-n8wkl-worker-us-east-2c",
+                            "desired": 1,
+                            "current": 1,
+                            "ready": 1,
+                            "available": 1
+                        }
+                    ],
+                    "ms_column_length": [
+                        47,
+                        3,
+                        3,
+                        3,
+                        3
+                    ],
+                    "infrastructure": {
+                        "Platform": "AWS",
+                        "Install Type": "IPI",
+                        "region": "us-east-2"
+                    },
+                    "network_info": {
+                        "Network Type": "OpenShiftSDN",
+                        "httpProxy": null,
+                        "httpsProxy": null,
+                        "Cluster network": "10.128.0.0/14",
+                        "Host prefix": 23,
+                        "Max nodes": 512,
+                        "Max pods per node": 510
+                    },
+                    "type": "info",
+                    "info_key": "CLUSTER_STATUS_OVERVIEW"
+                },
+                "tags": [
+                    "phased_gates"
+                ],
+                "links": {
+                    "jira": [
+                        "https://issues.redhat.com/browse/INSIGHTOCP-347",
+                        "https://issues.redhat.com/browse/INSIGHTOCP-406",
+                        "https://issues.redhat.com/browse/INSIGHTOCP-407"
+                    ]
+                }
+            }
+        ],
+        "pass": [
+            {
+                "pass_id": "pods_check|POD_HEALTHY",
+                "component": "ccx_rules_ocp.internal.rules.pods_check.report",
+                "type": "pass",
+                "key": "POD_HEALTHY",
+                "details": {
+                    "type": "pass",
+                    "pass_key": "POD_HEALTHY"
+                },
+                "tags": [],
+                "links": {}
+            },
+            {
+                "pass_id": "master_nodes_are_schedulable|MASTER_NODES_ARE_SCHEDULABLE_PASS",
+                "component": "ccx_rules_ocp.internal.rules.master_nodes_are_schedulable.report",
+                "type": "pass",
+                "key": "MASTER_NODES_ARE_SCHEDULABLE_PASS",
+                "details": {
+                    "phased_gates_checks": [
+                        "1.3.1.5"
+                    ],
+                    "nodes": [
+                        {
+                            "name": "ip-10-0-134-149.us-east-2.compute.internal",
+                            "schedulable": false,
+                            "other_roles": []
+                        },
+                        {
+                            "name": "ip-10-0-166-189.us-east-2.compute.internal",
+                            "schedulable": false,
+                            "other_roles": []
+                        },
+                        {
+                            "name": "ip-10-0-220-70.us-east-2.compute.internal",
+                            "schedulable": false,
+                            "other_roles": []
+                        }
+                    ],
+                    "schedulable_count": 0,
+                    "other_roles": false,
+                    "type": "pass",
+                    "pass_key": "MASTER_NODES_ARE_SCHEDULABLE_PASS"
+                },
+                "tags": [
+                    "phased_gates"
+                ],
+                "links": {
+                    "jira": [
+                        "https://issues.redhat.com/browse/INSIGHTOCP-408"
+                    ]
+                }
+            },
+            {
+                "pass_id": "nodes_not_ready|ALL_NODES_READY",
+                "component": "ccx_rules_ocp.internal.rules.nodes_not_ready.report",
+                "type": "pass",
+                "key": "ALL_NODES_READY",
+                "details": {
+                    "nodes": [
+                        {
+                            "name": "ip-10-0-134-149.us-east-2.compute.internal",
+                            "ready": true,
+                            "roles": "master",
+                            "message": ""
+                        },
+                        {
+                            "name": "ip-10-0-166-189.us-east-2.compute.internal",
+                            "ready": true,
+                            "roles": "master",
+                            "message": ""
+                        },
+                        {
+                            "name": "ip-10-0-220-70.us-east-2.compute.internal",
+                            "ready": true,
+                            "roles": "master",
+                            "message": ""
+                        },
+                        {
+                            "name": "ip-10-0-141-55.us-east-2.compute.internal",
+                            "ready": true,
+                            "roles": "worker",
+                            "message": ""
+                        },
+                        {
+                            "name": "ip-10-0-169-10.us-east-2.compute.internal",
+                            "ready": true,
+                            "roles": "worker",
+                            "message": ""
+                        },
+                        {
+                            "name": "ip-10-0-204-77.us-east-2.compute.internal",
+                            "ready": true,
+                            "roles": "worker",
+                            "message": ""
+                        }
+                    ],
+                    "not_ready_count": 0,
+                    "phased_gates_checks": [
+                        "1.4.4"
+                    ],
+                    "type": "pass",
+                    "pass_key": "ALL_NODES_READY"
+                },
+                "tags": [
+                    "phased_gates"
+                ],
+                "links": {}
+            }
+        ],
+        "analysis_metadata": {
+            "start": "2021-12-13T15:51:02.895120+00:00",
+            "finish": "2021-12-13T15:51:03.187495+00:00",
+            "execution_context": "ccx_ocp_core.context.InsightsOperatorContext",
+            "plugin_sets": {
+                "insights-core": {
+                    "version": "insights-core-3.0.202-1",
+                    "commit": "placeholder"
+                },
+                "ccx_rules_ocp": {
+                    "version": "ccx_rules_ocp-2021.10.4-1",
+                    "commit": null
+                },
+                "ccx_ocp_core": {
+                    "version": "ccx_ocp_core-2021.10.7-1",
+                    "commit": null
+                }
+            }
+        }
+    }
+}

--- a/test_list/parquet_factory.txt
+++ b/test_list/parquet_factory.txt
@@ -1,2 +1,5 @@
+../features/parquet-factory/kafka_messages.feature
 ../features/parquet-factory/parquet_files.feature
 ../features/parquet-factory/indexes.feature
+../features/parquet-factory/metrics.feature
+../features/parquet-factory/s3.feature

--- a/test_list/parquet_factory.txt
+++ b/test_list/parquet_factory.txt
@@ -1,1 +1,2 @@
 ../features/parquet-factory/parquet_files.feature
+../features/parquet-factory/indexes.feature

--- a/test_list/parquet_factory.txt
+++ b/test_list/parquet_factory.txt
@@ -1,0 +1,1 @@
+../features/parquet-factory/parquet_files.feature


### PR DESCRIPTION
# Description

Migrating the parquet-factory BDD tests from ccx-bdd-tests to this repository.

Fixes # (issue)

## Type of change

- New test feature file
- Non-breaking change in test steps implementation

## Testing steps

`docker-compose --profile test-parquet-factory up -d && make parquet-factory-tests`

## Checklist
* [ ] Pylint passes for Python sources
* [ ] sources has been pre-processed by Black
* [ ] updated documentation wherever necessary
* [ ] new tests can be executed both locally and within docker container
* [ ] new tests have been included in scenario list (make update-scenarios)
