### PR TITLE
[CCXDEV-12111] Adapt run_in_docker.sh script to Github workflows

### DIFF
--- a/run_in_docker.sh
+++ b/run_in_docker.sh
@@ -134,5 +134,5 @@ copy_files "$cid" "$tests_target" "$path_to_service"
 # Step 9: Execute the specified make target
 
 
-docker exec -it "$cid" /bin/bash -c "source \$VIRTUAL_ENV/bin/activate && env && $(with_mocked_dependencies "$3") make $tests_target"
+docker exec "$cid" /bin/bash -c "source \$VIRTUAL_ENV/bin/activate && env && $(with_mocked_dependencies "$3") make $tests_target"
 


### PR DESCRIPTION
# Description

Remove the `-it` parameters from the `docker exec` command used to run the BDD tests. It's a leftover from using the command in manual tests, and it does not work in GitHub workflows as the pseudo TTY is not allocated.

Fixes CCXDEV-12111

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Testing steps

CI of our services should be able to run the script

## Checklist
* [ ] Pylint passes for Python sources
* [ ] sources has been pre-processed by Black
* [ ] updated documentation wherever necessary
* [ ] new tests can be executed both locally and within docker container
* [ ] new tests have been included in scenario list (make update-scenarios)
