### PR TITLE
[CCXDEV-11831] Update log message expected when report to notify is detected

### DIFF
--- a/features/ccx-notification-service/customer_notifications.feature
+++ b/features/ccx-notification-service/customer_notifications.feature
@@ -31,9 +31,9 @@ Feature: Customer Notifications
      Then it should have sent 0 notification events to Kafka
       And the process should exit with status code set to 0
       And the logs should match
-          | log                              | contains   |
-          | Report with high impact detected | yes        |
-          | No new issues to notify          | no         |
+          | log                                                          | contains   |
+          | Report with impact higher than configured threshold detected | yes        |
+          | No new issues to notify                                      | no         |
      When I select all rows from table reported
      Then I should get 1 rows
 

--- a/features/ccx-notification-service/service_log.feature
+++ b/features/ccx-notification-service/service_log.feature
@@ -23,9 +23,9 @@ Feature: Service Log
      Then it should have sent 0 notification events to Service Log
       And the process should exit with status code set to 0
       And the logs should match
-          | log                              | contains |
-          | Report with high impact detected | yes      |
-          | No new issues to notify          | no       |
+          | log                                                          | contains |
+          | Report with impact higher than configured threshold detected | yes      |
+          | No new issues to notify                                      | no       |
 
 
   @rest-api


### PR DESCRIPTION
# Description

As part of CCXDEV-11831, I updated the log message that indicates when a report with enough impact to be notified is detected. This updates the tests where said log message is checked.

Fix for https://github.com/RedHatInsights/ccx-notification-service/pull/650.
## Type of change

- Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Testing steps

`run_in_docker.sh notification-service-tests <path_to_local_notification_service_repo_with_latest_changes>`

```
7 features passed, 0 failed, 0 skipped
56 scenarios passed, 0 failed, 3 skipped
674 steps passed, 0 failed, 6 skipped, 0 undefined
Took 0m57.116s
+ bddExecutionExitCode=0
```
## Checklist
* [ ] Pylint passes for Python sources
* [ ] sources has been pre-processed by Black
* [ ] updated documentation wherever necessary
* [ ] new tests can be executed both locally and within docker container
* [ ] new tests have been included in scenario list (make update-scenarios)
