### PR TITLE
Using the right value for minio hostname

### DIFF
--- a/parquet_factory_tests.sh
+++ b/parquet_factory_tests.sh
@@ -44,7 +44,7 @@ function get_binary() {
 
 function set_env_vars(){
     export S3_OLDER_MINIO_COMPATIBILITY=1 \
-        PARQUET_FACTORY__S3__ENDPOINT=localhost:9000 \
+        PARQUET_FACTORY__S3__ENDPOINT=minio:9000 \
         PARQUET_FACTORY__S3__BUCKET=test \
         PARQUET_FACTORY__S3__ACCESS_KEY=test_access_key \
         PARQUET_FACTORY__S3__SECRET_KEY=test_secret_access_key


### PR DESCRIPTION
# Description

Fix the parquet-factory script in order to export the right value for the environment variables.

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Testing steps

N/A

## Checklist
* [ ] Pylint passes for Python sources
* [ ] sources has been pre-processed by Black
* [ ] updated documentation wherever necessary
* [ ] new tests can be executed both locally and within docker container
* [ ] new tests have been included in scenario list (make update-scenarios)
