### PR TITLE
Don't fail other tests if pandas cannot be imported

### DIFF
--- a/features/steps/parquet_files.py
+++ b/features/steps/parquet_files.py
@@ -2,9 +2,12 @@
 
 from behave import then
 
-import pandas as pd
-
 from src.minio import read_object_into_bytes_buffer
+
+try:
+    import pandas as pd
+except ImportError as e:
+    print("Warning: unable to import module:", e)
 
 
 @then("The parquet file {object_name} is exactly this one")


### PR DESCRIPTION
# Description

`pandas` module is installed only in case of running parquet factory tests. Because of that, other tests are failing.

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Testing steps

Run the tests locally (using `run_in_docker.sh` script)

## Checklist
* [ ] Pylint passes for Python sources
* [ ] sources has been pre-processed by Black
* [ ] updated documentation wherever necessary
* [ ] new tests can be executed both locally and within docker container
* [ ] new tests have been included in scenario list (make update-scenarios)
