### PR TITLE
Expose postgres DB on port 25432 instead of 5432

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,7 +9,7 @@ services:
       - "sleep infinity"
   database:
     ports:
-      - 5432:5432
+      - 25432:5432
     image: postgres:13.9
     environment:
       - POSTGRES_USER=postgres


### PR DESCRIPTION
# Description

The exposed port is not used by any of the automation of this repository. Instead, it is just used for debugging when needed. Let's use 25432 so it does not conflict with any locally running PSQL server

## Type of change

- Refactor (refactoring code, removing useless files)

## Testing steps

Tested locally

## Checklist
* [ ] Pylint passes for Python sources
* [ ] sources has been pre-processed by Black
* [ ] updated documentation wherever necessary
* [ ] new tests can be executed both locally and within docker container
* [ ] new tests have been included in scenario list (make update-scenarios)
