### PR TITLE
Removing GCC dependency

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -27,7 +27,7 @@ COPY . $HOME
 
 ENV PATH="$VIRTUAL_ENV/bin:$PATH"
 
-RUN dnf install --nodocs -y python3.11 unzip make lsof git libpq-devel gcc
+RUN dnf install --nodocs -y python3.11 unzip make lsof git libpq-devel
 
 RUN python3.11  -m venv $VIRTUAL_ENV && source $VIRTUAL_ENV/bin/activate
 


### PR DESCRIPTION
# Description

GCC (and its dependencies) are installed on the container image, so we can get some CVE reports that can be avoided, as it's not used inside the generated container.

Fixes #[CCXDEV-11677](https://issues.redhat.com/browse/CCXDEV-11677)

## Type of change

- Security fix in dependent library (no changes in the code)

## Testing steps

Please describe how the change was tested locally. If, for some reason, the testing was not done or not done fully, please describe what are the testing steps.

## Checklist
* [ ] Pylint passes for Python sources
* [ ] sources has been pre-processed by Black
* [ ] updated documentation wherever necessary
* [ ] new tests can be executed both locally and within docker container
* [ ] new tests have been included in scenario list (make update-scenarios)
