### PR TITLE
Mock OCM service log /v1/clusters/cluster_log endpoint

### DIFF
--- a/mocks/service-log/service_log.py
+++ b/mocks/service-log/service_log.py
@@ -213,7 +213,7 @@ def get_logs(request: Request, cluster_id: str = None, cluster_uuid: str = None)
                 "total": 0,
                 "items": [],
             },
-            status_code=200,
+            status_code=400,
         )
 
     res = []


### PR DESCRIPTION
# Description

OSL made a change in their v1 API, removing the GET method from the `v1/cluster_logs` endpoint. This change:
- removes that endpoint from our FastAPI implementation of the mock OSL
- implements the `v1/clusters/cluster_log` endpoint, which replaces the deprecated endpoint.

Fixes CCXDEV-12330

## Type of change

- Non-breaking change in mock services

## Testing steps

`uvicorn service_log:app --port 8000` and test the new endpoint in multiple scenarios (create the events first).

## Checklist
* [x] Pylint passes for Python sources
* [x] sources has been pre-processed by Black
* [x] updated documentation wherever necessary
* [ ] new tests can be executed both locally and within docker container
* [ ] new tests have been included in scenario list (make update-scenarios)
