### PR TITLE
[CCXDEV-11676] Don't run ocm-service-log image in compose as we have a mock already

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -126,28 +126,6 @@ services:
         -f /tmp/setup-scripts/ocm_service_log.sql
         "
 
-  service-log:
-    depends_on:
-      init-service-log-db:
-        condition: service_completed_successfully
-    profiles:
-      - no-mock
-    image: quay.io/ccxdev/ocm-service-log
-    ports:
-      - 8000:8000 # API server
-      - 8083:8083 # Healthcheck
-      - 8080:8080 # Metrics
-    entrypoint:
-      - /bin/sh
-      - -c
-      - "echo database > secrets/db.host
-        ./ocm-service-log serve \
-        --api-server-bindaddress 'localhost:8000' \
-        --health-check-server-bindaddress 'localhost:8083' \
-        --metrics-server-bindaddress 'localhost:8080' \
-        --enable-ocm-mock
-        "
-
   mock-oauth2-server:
     profiles:
       - test-upgrades-data-eng


### PR DESCRIPTION
# Description

We don't need to maintain this image anymore as we have a [mock for service log](https://github.com/RedHatInsights/insights-behavioral-spec/blob/main/mocks/service-log/service_log.py).

## Type of change

- Configuration update

## Testing steps


## Checklist
* [ ] Pylint passes for Python sources
* [ ] sources has been pre-processed by Black
* [ ] updated documentation wherever necessary
* [ ] new tests can be executed both locally and within docker container
* [ ] new tests have been included in scenario list (make update-scenarios)
