### PR TITLE
Modifying steps for launching sha-extractor and its configuration

### DIFF
--- a/config/insights_sha_extractor.yaml
+++ b/config/insights_sha_extractor.yaml
@@ -1,7 +1,6 @@
 plugins:
   packages:
     - insights.specs.default
-    - insights_sha_extractor
     - pythonjsonlogger
     - pythonjsonlogger.jsonlogger
   configs:

--- a/features/steps/insights_sha_extractor.py
+++ b/features/steps/insights_sha_extractor.py
@@ -74,7 +74,7 @@ def start_sha_extractor(context, group_id=None):
         os.environ["CDP_GROUP_ID"] = group_id
 
     sha_extractor = subprocess.Popen(
-        ["insights-sha-extractor", "config/insights_sha_extractor.yaml"],
+        ["ccx-messaging", "config/insights_sha_extractor.yaml"],
         stdout=subprocess.PIPE,
         stderr=subprocess.PIPE,
         text=True,


### PR DESCRIPTION
# Description

Newest versions of SHA extractor use the ccx-messaging command line instead of defining a new one, so the step to launch it should be adapted.

The configuration file needs an update too

Fixes # (issue)

## Type of change

- Bug fix (non-breaking change which fixes an issue)
- Configuration update

## Testing steps

Tested locally

## Checklist
* [ ] Pylint passes for Python sources
* [ ] sources has been pre-processed by Black
* [ ] updated documentation wherever necessary
* [ ] new tests can be executed both locally and within docker container
* [ ] new tests have been included in scenario list (make update-scenarios)
