### PR TITLE
fix aggregator start_service with broken DB log messages

### DIFF
--- a/features/insights-results-aggregator/starting_service.feature
+++ b/features/insights-results-aggregator/starting_service.feature
@@ -16,7 +16,7 @@ Feature: Checking Aggregator behaviour during starting the service
      When I store current environment without Insights Results Aggregator variables
       And I run the Insights Results Aggregator with the start-service command line flag and config file name set to config/insights_results_aggregator_wrong_db.toml
      Then The process should finish with exit code 2
-      And I should see following message in service output: "unable to check DB migration version"
+      And I should see following message in service output: "Unable to initialize DB schema"
       And I should see following message in service output: "database preparation exited with error code 2"
 
 


### PR DESCRIPTION
# Description
the old log message doesn't appear as the function to create a DB schema fails first. 

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- Bug fix (non-breaking change which fixes an issue)

## Testing steps
locally

## Checklist
* [ ] Pylint passes for Python sources
* [ ] sources has been pre-processed by Black
* [ ] updated documentation wherever necessary
* [ ] new tests can be executed both locally and within docker container
* [ ] new tests have been included in scenario list (make update-scenarios)
