### PR TITLE
[CCXDEV-11573] Remove krb5-libs from the image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -38,6 +38,7 @@ RUN pip install --no-cache-dir -U pip setuptools wheel
 RUN pip install --no-cache-dir -r requirements/requirements_docker.txt
 
 RUN dnf clean all
+RUN rpm -e --nodeps krb5-libs
 RUN chmod -R g=u $HOME $VIRTUAL_ENV /etc/passwd
 RUN chgrp -R 0 $HOME $VIRTUAL_ENV
 


### PR DESCRIPTION
# Description

Remove the krb5-libs package from the image due to vulnerability.

## Type of change

- Security fix in dependent library (no changes in the code)

## Testing steps

Successfully built the image.

## Checklist
* [ ] Pylint passes for Python sources
* [ ] sources has been pre-processed by Black
* [ ] updated documentation wherever necessary
* [ ] new tests can be executed both locally and within docker container
* [ ] new tests have been included in scenario list (make update-scenarios)
