### PR TITLE
Add _id field in returned RHOBS metrics

### DIFF
--- a/mocks/rhobs/rhobs_service.py
+++ b/mocks/rhobs/rhobs_service.py
@@ -107,7 +107,7 @@ DUPLICATED_METRICS_RESULT = [
     },
 ]
 
-# Used to check the the condition is changed to 'Not Available'
+# Used to check the condition is changed to 'Not Available'
 AVAILABLE_FOC = [
     {
         "metric": {
@@ -160,4 +160,7 @@ def get_random_results(query: str):
     cluster_id = match.group()
     if cluster_id not in ANSWERS:
         return {"data": {"result": []}}
-    return {"data": {"result": ANSWERS[cluster_id]}}
+    res = {"data": {"result": ANSWERS[cluster_id]}}
+    for item in res["data"]["result"]:
+        item["metric"]["_id"] = cluster_id
+    return res


### PR DESCRIPTION
# Description

RHOBS mock now includes the query's cluster ID in the returned metrics

Fixes CCXDEV-12396

## Type of change

- Non-breaking change in test steps implementation (existing tests use the 'single-cluster' query, therefore the response is not affected)

## Testing steps

- Go to `mocks/rhobs` folder and launch the mock with `rhobs_service:app --port 8002`
- Test it out with some of the valid cluster IDs, e.g `curl 'http://127.0.0.1:8002/api/metrics/v1/telemeter/api/v1/query?query=alerts%7B_id%3D%22${00000000-1111-2222-3333-444444444444}%22%7D'`
 
## Checklist
* [x] Pylint passes for Python sources
* [x] sources has been pre-processed by Black
* [ ] updated documentation wherever necessary
* [x] new tests can be executed both locally and within docker container
* [ ] new tests have been included in scenario list (make update-scenarios)
