### PR TITLE
[CCXDEV-12376] Replace deprecated service log endpoint in the tests

### DIFF
--- a/features/ccx-notification-service/configuration.feature
+++ b/features/ccx-notification-service/configuration.feature
@@ -21,7 +21,6 @@ Feature: Customer Notifications configuration and exit codes
           | CCX_NOTIFICATION_SERVICE__KAFKA_BROKER__ENABLED       | false       |
           | CCX_NOTIFICATION_SERVICE__SERVICE_LOG__ENABLED        | false       |
      Then it should have sent 0 notification events to Kafka
-      And it should have sent 0 notification events to Service Log
       And the process should exit with status code set to 1
       And the logs should match
           | log                                              | contains   |
@@ -36,7 +35,6 @@ Feature: Customer Notifications configuration and exit codes
           | CCX_NOTIFICATION_SERVICE__SERVICE_LOG__ENABLED         | false                      |
           | CCX_NOTIFICATION_SERVICE__DEPENDENCIES__CONTENT_SERVER | unresolved_url:8082/api/v1 |
      Then it should have sent 0 notification events to Kafka
-      And it should have sent 0 notification events to Service Log
       And the process should exit with status code set to 4
 
   Scenario: Check that notification-to-service-log is not started and exits with status 4 if rules cannot be fetched
@@ -47,5 +45,4 @@ Feature: Customer Notifications configuration and exit codes
           | CCX_NOTIFICATION_SERVICE__SERVICE_LOG__ENABLED         | true                       |
           | CCX_NOTIFICATION_SERVICE__DEPENDENCIES__CONTENT_SERVER | unresolved_url:8082/api/v1 |
      Then it should have sent 0 notification events to Kafka
-      And it should have sent 0 notification events to Service Log
       And the process should exit with status code set to 4

--- a/features/ccx-notification-service/service_log.feature
+++ b/features/ccx-notification-service/service_log.feature
@@ -6,7 +6,7 @@ Feature: Service Log
       And database password is set to postgres
       And database connection is established
       And CCX Notification database is set up
-      And service-log service is empty
+      And service-log service has no records for cluster 5d5892d4-1f74-4ccf-91af-548dfc9767aa
       And insights-content service is available on localhost:8082
       And service-log service is available on localhost:8000
       And token refreshment server is available on localhost:8001
@@ -16,11 +16,11 @@ Feature: Service Log
   Scenario: Check that notification service does not send messages to service log if it is disabled
      When I insert 1 report with important total risk for the following clusters
           | org id |  account number | cluster name                         |
-          | 1      |  1              | 5d5892d4-2g85-4ccf-02bg-548dfc9767aa |
+          | 1      |  1              | 5d5892d4-1f74-4ccf-91af-548dfc9767aa |
       And I start the CCX Notification Service with the --instant-reports command line flag
           | val                                             | var   |
           | CCX_NOTIFICATION_SERVICE__SERVICE_LOG__ENABLED  | false |
-     Then it should have sent 0 notification events to Service Log
+     Then it should have sent 0 notification events to Service Log for cluster 5d5892d4-1f74-4ccf-91af-548dfc9767aa
       And the process should exit with status code set to 0
       And the logs should match
           | log                                                          | contains |
@@ -32,52 +32,52 @@ Feature: Service Log
   Scenario: Check that notification service sends messages to service log if it is enabled
      When I insert 1 report with important total risk for the following clusters
           | org id |  account number | cluster name                         |
-          | 1      |  1              | 5d5892d4-2g85-4ccf-02bg-548dfc9767aa |
+          | 1      |  1              | 5d5892d4-1f74-4ccf-91af-548dfc9767aa |
       And I start the CCX Notification Service with the --instant-reports command line flag
           | val                                             | var   |
           | CCX_NOTIFICATION_SERVICE__KAFKA_BROKER__ENABLED | false |
           | CCX_NOTIFICATION_SERVICE__SERVICE_LOG__ENABLED  | true  |
-     Then it should have sent 1 notification events to Service Log
+     Then it should have sent 1 notification events to Service Log for cluster 5d5892d4-1f74-4ccf-91af-548dfc9767aa
       And the process should exit with status code set to 0
      When I retrieve the service log events for the following clusters
           | cluster name                         |
-          | 5d5892d4-2g85-4ccf-02bg-548dfc9767aa |
+          | 5d5892d4-1f74-4ccf-91af-548dfc9767aa |
      Then I should find the following log events for each cluster
           | cluster name                         | num logs | service name             |
-          | 5d5892d4-2g85-4ccf-02bg-548dfc9767aa | 1        | CCX Notification Service |
+          | 5d5892d4-1f74-4ccf-91af-548dfc9767aa | 1        | CCX Notification Service |
 
 
   @rest-api
   Scenario: Check that notification service includes correct service name if set
      When I insert 1 report with important total risk for the following clusters
           | org id |  account number | cluster name                         |
-          | 1      |  1              | 5d5892d4-2g85-4ccf-02bg-548dfc9767aa |
+          | 1      |  1              | 5d5892d4-1f74-4ccf-91af-548dfc9767aa |
       And I start the CCX Notification Service with the --instant-reports command line flag
           | val                                                | var   |
           | CCX_NOTIFICATION_SERVICE__KAFKA_BROKER__ENABLED    | false |
           | CCX_NOTIFICATION_SERVICE__SERVICE_LOG__ENABLED     | true  |
           | CCX_NOTIFICATION_SERVICE__SERVICE_LOG__CREATED_BY  | test  |
-     Then it should have sent 1 notification events to Service Log
+     Then it should have sent 1 notification events to Service Log for cluster 5d5892d4-1f74-4ccf-91af-548dfc9767aa
       And the process should exit with status code set to 0
      When I retrieve the service log events for the following clusters
           | cluster name                         |
-          | 5d5892d4-2g85-4ccf-02bg-548dfc9767aa |
+          | 5d5892d4-1f74-4ccf-91af-548dfc9767aa |
      Then I should find the following log events for each cluster
           | cluster name                         | num logs | service name |
-          | 5d5892d4-2g85-4ccf-02bg-548dfc9767aa | 1        | test         |
+          | 5d5892d4-1f74-4ccf-91af-548dfc9767aa | 1        | test         |
 
 
   @rest-api
   Scenario: Check that notification service does not send messages to service log if it cannot be rendered
      When I insert 1 report with important total risk for the following clusters
           | org id |  account number | cluster name                         |
-          | 1      |  1              | 5d5892d4-2g85-4ccf-02bg-548dfc9767aa |
+          | 1      |  1              | 5d5892d4-1f74-4ccf-91af-548dfc9767aa |
       And I start the CCX Notification Service with the --instant-reports command line flag
           | val                                                               | var         |
           | CCX_NOTIFICATION_SERVICE__KAFKA_BROKER__ENABLED                   | false       |
           | CCX_NOTIFICATION_SERVICE__SERVICE_LOG__ENABLED                    | true        |
           | CCX_NOTIFICATION_SERVICE__DEPENDENCIES__TEMPLATE_RENDERER_SERVER  | unknown_url |
-     Then it should have sent 0 notification events to Service Log
+     Then it should have sent 0 notification events to Service Log for cluster 5d5892d4-1f74-4ccf-91af-548dfc9767aa
       And the logs should match
           | log                                       | contains |
           | Rendering reports failed for this cluster | yes      |
@@ -88,42 +88,42 @@ Feature: Service Log
   Scenario: Check that notification service doesn't send message to service log if it is not moderate
      When I insert 1 report with low total risk for the following clusters
           | org id |  account number | cluster name                         |
-          | 1      |  1              | 5d5892d4-2g85-4ccf-02bg-548dfc9767aa |
+          | 1      |  1              | 5d5892d4-1f74-4ccf-91af-548dfc9767aa |
       And I start the CCX Notification Service with the --instant-reports command line flag
           | val                                             | var   |
           | CCX_NOTIFICATION_SERVICE__KAFKA_BROKER__ENABLED | false |
           | CCX_NOTIFICATION_SERVICE__SERVICE_LOG__ENABLED  | true  |
-     Then it should have sent 0 notification events to Service Log
+     Then it should have sent 0 notification events to Service Log for cluster 5d5892d4-1f74-4ccf-91af-548dfc9767aa
       And the process should exit with status code set to 0
-    Given service-log service is empty
+    Given service-log service has no records for cluster 5d5892d4-1f74-4ccf-91af-548dfc9767aa
     When I insert 1 report with moderate total risk for the following clusters
           | org id |  account number | cluster name                         |
-          | 1      |  1              | 5d5892d4-2g85-4ccf-02bg-548dfc9767aa |
+          | 1      |  1              | 5d5892d4-1f74-4ccf-91af-548dfc9767aa |
       And I start the CCX Notification Service with the --instant-reports command line flag
           | val                                             | var   |
           | CCX_NOTIFICATION_SERVICE__KAFKA_BROKER__ENABLED | false |
           | CCX_NOTIFICATION_SERVICE__SERVICE_LOG__ENABLED  | true  |
-     Then it should have sent 1 notification events to Service Log
+     Then it should have sent 1 notification events to Service Log for cluster 5d5892d4-1f74-4ccf-91af-548dfc9767aa
       And the process should exit with status code set to 0
-    Given service-log service is empty
+    Given service-log service has no records for cluster 5d5892d4-1f74-4ccf-91af-548dfc9767aa
     When I insert 1 report with important total risk for the following clusters
           | org id |  account number | cluster name                         |
-          | 1      |  1              | 5d5892d4-2g85-4ccf-02bg-548dfc9767aa |
+          | 1      |  1              | 5d5892d4-1f74-4ccf-91af-548dfc9767aa |
       And I start the CCX Notification Service with the --instant-reports command line flag
           | val                                             | var   |
           | CCX_NOTIFICATION_SERVICE__KAFKA_BROKER__ENABLED | false |
           | CCX_NOTIFICATION_SERVICE__SERVICE_LOG__ENABLED  | true  |
-     Then it should have sent 1 notification events to Service Log
+     Then it should have sent 1 notification events to Service Log for cluster 5d5892d4-1f74-4ccf-91af-548dfc9767aa
       And the process should exit with status code set to 0
-    Given service-log service is empty
+    Given service-log service has no records for cluster 5d5892d4-1f74-4ccf-91af-548dfc9767aa
     When I insert 1 report with critical total risk for the following clusters
           | org id |  account number | cluster name                         |
-          | 1      |  1              | 5d5892d4-2g85-4ccf-02bg-548dfc9767aa |
+          | 1      |  1              | 5d5892d4-1f74-4ccf-91af-548dfc9767aa |
       And I start the CCX Notification Service with the --instant-reports command line flag
           | val                                             | var   |
           | CCX_NOTIFICATION_SERVICE__KAFKA_BROKER__ENABLED | false |
           | CCX_NOTIFICATION_SERVICE__SERVICE_LOG__ENABLED  | true  |
-     Then it should have sent 1 notification events to Service Log
+     Then it should have sent 1 notification events to Service Log for cluster 5d5892d4-1f74-4ccf-91af-548dfc9767aa
       And the process should exit with status code set to 0
 
 
@@ -131,14 +131,14 @@ Feature: Service Log
   Scenario: Check that notification service sends log events for the configured total risk threshold
      When I insert 1 report with low total risk for the following clusters
           | org id |  account number | cluster name                         |
-          | 1      |  1              | 5d5892d4-2g85-4ccf-02bg-548dfc9767aa |
+          | 1      |  1              | 5d5892d4-1f74-4ccf-91af-548dfc9767aa |
       And I start the CCX Notification Service with the --instant-reports command line flag
           | val                                                         | var   |
           | CCX_NOTIFICATION_SERVICE__KAFKA_BROKER__ENABLED             | false |
           | CCX_NOTIFICATION_SERVICE__SERVICE_LOG__ENABLED              | true  |
           | CCX_NOTIFICATION_SERVICE__SERVICE_LOG__TOTAL_RISK_THRESHOLD | 0     |
           | CCX_NOTIFICATION_SERVICE__SERVICE_LOG__EVENT_FILTER         | totalRisk >= totalRiskThreshold |
-     Then it should have sent 1 notification events to Service Log
+     Then it should have sent 1 notification events to Service Log for cluster 5d5892d4-1f74-4ccf-91af-548dfc9767aa
       And the process should exit with status code set to 0
 
 
@@ -154,7 +154,7 @@ Feature: Service Log
           | val                                             | var   |
           | CCX_NOTIFICATION_SERVICE__KAFKA_BROKER__ENABLED | false |
           | CCX_NOTIFICATION_SERVICE__SERVICE_LOG__ENABLED  | true  |
-     Then it should have sent 0 notification events to Service Log
+     Then it should have sent 0 notification events to Service Log for cluster 5d5892d4-1f74-4ccf-91af-548dfc9767aa
       And the process should exit with status code set to 0
 
 
@@ -170,23 +170,23 @@ Feature: Service Log
           | val                                             | var   |
           | CCX_NOTIFICATION_SERVICE__KAFKA_BROKER__ENABLED | false |
           | CCX_NOTIFICATION_SERVICE__SERVICE_LOG__ENABLED  | true  |
-     Then it should have sent 1 notification events to Service Log
+     Then it should have sent 1 notification events to Service Log for cluster 5d5892d4-1f74-4ccf-91af-548dfc9767aa
       And the process should exit with status code set to 0
 
 
   @rest-api
   Scenario: Check that notification service produces a single notification event for cluster with multiple new reports
      When I insert 1 report with important total risk for the following clusters
-          | org id |  account number | cluster name                       |
-          | 1      |  1              | 5d5892d4-2g85-4ccf-02bg-548dfc9767 |
+          | org id |  account number | cluster name                         |
+          | 1      |  1              | 5d5892d4-1f74-4ccf-91af-548dfc9767aa |
     When I insert 1 report with important total risk for the following clusters
-          | org id |  account number | cluster name                       |
-          | 1      |  1              | 5d5892d4-2g85-4ccf-02bg-548dfc9767 |
+          | org id |  account number | cluster name                         |
+          | 1      |  1              | 5d5892d4-1f74-4ccf-91af-548dfc9767aa |
       And I start the CCX Notification Service with the --instant-reports command line flag
           | val                                             | var   |
           | CCX_NOTIFICATION_SERVICE__KAFKA_BROKER__ENABLED | false |
           | CCX_NOTIFICATION_SERVICE__SERVICE_LOG__ENABLED  | true  |
-     Then it should have sent 1 notification events to Service Log
+     Then it should have sent 1 notification events to Service Log for cluster 5d5892d4-1f74-4ccf-91af-548dfc9767aa
       And the process should exit with status code set to 0
 
 
@@ -202,5 +202,5 @@ Feature: Service Log
           | val                                             | var   |
           | CCX_NOTIFICATION_SERVICE__KAFKA_BROKER__ENABLED | false |
           | CCX_NOTIFICATION_SERVICE__SERVICE_LOG__ENABLED  | true  |
-     Then it should have sent 1 notification events to Service Log
+     Then it should have sent 1 notification events to Service Log for cluster 5d5892d4-1f74-4ccf-91af-548dfc9767aa
       And the process should exit with status code set to 0

--- a/features/steps/notification_service.py
+++ b/features/steps/notification_service.py
@@ -129,7 +129,10 @@ def start_ccx_notification_service_with_flag(context, flag):
             env[row["val"]] = row["var"]
 
     out = subprocess.Popen(
-        params, stdout=subprocess.PIPE, stderr=subprocess.STDOUT, env=env,
+        params,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        env=env,
     )
     assert out is not None
     context.add_cleanup(out.terminate)
@@ -521,7 +524,9 @@ def remove_service_log_logs(context, cluster_id):
         ), f'unexpected status code: got "{response.status_code}" want "204"'
 
 
-@then("it should have sent {num_event:d} notification events to Service Log for cluster {cluster_id}")
+@then(
+    "it should have sent {num_event:d} notification events to Service Log for cluster {cluster_id}",
+)
 def count_notification_events_service_log(context, num_event, cluster_id):
     """Get events from Service Log and count them to check if it matches."""
     events = get_service_log_event_by_cluster(cluster_id)

--- a/features/steps/notification_service_dependencies.py
+++ b/features/steps/notification_service_dependencies.py
@@ -21,7 +21,7 @@ from behave import given, then, when
 from common_http import check_service_started
 
 CONTENT_SERVICE_OPENAPI_ENDPOINT = "/api/v1/openapi.json"
-SERVICE_LOG_CLUSTER_LOGS_ENDPOINT = "/api/service_logs/v1/cluster_logs"
+SERVICE_LOG_OPENAPI_ENDPOINT = "/api/service_logs/v1/openapi"
 PUSH_GATEWAY_METRICS_ENDPOINT = "/metrics"
 TOKEN_REFRESHMENT_ENDPOINT = (
     "/auth/realms/redhat-external/protocol/openid-connect/token"
@@ -52,7 +52,7 @@ def check_content_service_availability(context, host=None, port=None):
 def check_service_log_availability(context, host, port):
     """Check if service-log is available at given address."""
     check_service_started(context, host, port)
-    url = create_url(host, port, SERVICE_LOG_CLUSTER_LOGS_ENDPOINT)
+    url = create_url(host, port, SERVICE_LOG_OPENAPI_ENDPOINT)
     response = requests.get(url, headers={"Authorization": "TEST_TOKEN"})
     assert response.status_code == requests.codes.ok, "service log is not up"
 

--- a/mocks/service-log/service_log.py
+++ b/mocks/service-log/service_log.py
@@ -271,6 +271,12 @@ def delete_logs(id: str, request: Request):
     )
 
 
+@app.get("/api/service_logs/v1/openapi")
+def get_openapi():
+    """Get mock response from openapi endpoint."""
+    return JSONResponse({}, status_code=200)
+
+
 def fill_default_fields(log: Log) -> Log:
     """Add timestamp and event ID fields to the received log."""
     if log.timestamp is None:


### PR DESCRIPTION
# Description

Tests have been using deprecated endpoint from Service log from retrieving all logs, which is now impossible. Change remove this endpoint from the tests (or replace it with one for the given cluster if possible). In order to use endpoint for specific cluster in the tests, all cluster IDs in tests have been replaced with a single one.

Also, in two rows `response` object have been used instead of `requests` package when accessing HTTP response codes. This has been fixed as well.

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Testing steps

Run notification tests in Docker locally.

## Checklist
* [x] Pylint passes for Python sources
* [ ] sources has been pre-processed by Black
* [ ] updated documentation wherever necessary
* [ ] new tests can be executed both locally and within docker container
* [ ] new tests have been included in scenario list (make update-scenarios)
