### PR TITLE
Adding log storage and more checks to the kcat metadata execution

### DIFF
--- a/features/steps/kafka_steps.py
+++ b/features/steps/kafka_steps.py
@@ -60,7 +60,7 @@ def retrieve_broker_metadata(context, hostname=None, port=None):
         with open(stdout_file, "w") as f:
             f.write(output)
 
-    assert output is not None, f"The output shouldn't be empty:\nOut: {output}"
+    assert output is not None, "The output shouldn't be empty"
     # JSON format is expected
     encoded = json.loads(output)
 

--- a/features/steps/kafka_steps.py
+++ b/features/steps/kafka_steps.py
@@ -22,9 +22,7 @@ from behave import given, then, when
 from src.kafka_util import create_topic, delete_topic
 from src.process_output import (
     filepath_from_context,
-    process_generated_output,
 )
-
 
 
 @when("I retrieve metadata from Kafka broker")
@@ -47,8 +45,6 @@ def retrieve_broker_metadata(context, hostname=None, port=None):
     )
 
     stdout_file = filepath_from_context(context, "logs/insights-results-aggregator/", "_stdout")
-    stderr_file = filepath_from_context(context, "logs/insights-results-aggregator/", "_stderr")
-    # process_generated_output(context, out, stdout_file=stdout_file, stderr_file=stderr_file)
 
     # interact with the process:
     # read data from stdout and stderr, until end-of-file is reached
@@ -64,7 +60,7 @@ def retrieve_broker_metadata(context, hostname=None, port=None):
         with open(stdout_file, "w") as f:
             f.write(output)
 
-    assert output is not None, f"The output shouldn't be empty:\nOut: {output}\nErr: {error}"
+    assert output is not None, f"The output shouldn't be empty:\nOut: {output}"
     # JSON format is expected
     encoded = json.loads(output)
 


### PR DESCRIPTION
# Description

Due to an error in Aggregator's BDD execution, we need more logs generated for Kcat execution

## Type of change

- Refactor (refactoring code, removing useless files)

## Testing steps

Built and tested locally

## Checklist
* [ ] Pylint passes for Python sources
* [ ] sources has been pre-processed by Black
* [ ] updated documentation wherever necessary
* [ ] new tests can be executed both locally and within docker container
* [ ] new tests have been included in scenario list (make update-scenarios)
