### PR TITLE
Avoid redirecting kcat error output, as it doesn't honour the JSON format

### DIFF
--- a/features/steps/kafka_steps.py
+++ b/features/steps/kafka_steps.py
@@ -41,24 +41,29 @@ def retrieve_broker_metadata(context, hostname=None, port=None):
     out = subprocess.Popen(
         ["kcat", "-b", address, "-L", "-J"],
         stdout=subprocess.PIPE,
-        stderr=subprocess.STDOUT,
+        stderr=subprocess.PIPE,
     )
 
     stdout_file = filepath_from_context(context, "logs/insights-results-aggregator/", "_stdout")
+    stderr_file = filepath_from_context(context, "logs/insights-results-aggregator/", "_stderr")
 
     # interact with the process:
     # read data from stdout and stderr, until end-of-file is reached
     stdout, stderr = out.communicate()
 
-    assert stderr is None, "Error during check"
     assert stdout is not None, "No output from process"
 
     # try to decode output
     output = stdout.decode("utf-8")
+    error = stderr.decode("utf-8")
 
     if stdout_file is not None and stdout is not None:
         with open(stdout_file, "w") as f:
             f.write(output)
+
+    if stderr_file is not None and stderr is not None:
+        with open(stderr_file, "w") as f:
+            f.write(error)
 
     assert output is not None, "The output shouldn't be empty"
     # JSON format is expected

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,6 @@
 [tool.ruff]
+line-length = 100
+
+[tool.ruff.lint]
 select = ["E", "F", "W", "UP", "C", "D", "I", "Q", "COM"]
 ignore = ["D211", "C401", "D213", "UP006", "UP007", "UP009", "UP015", "UP035"]
-
-line-length = 100

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,5 @@
 [tool.ruff]
-line-length = 100
-
-[tool.ruff.lint]
 select = ["E", "F", "W", "UP", "C", "D", "I", "Q", "COM"]
 ignore = ["D211", "C401", "D213", "UP006", "UP007", "UP009", "UP015", "UP035"]
+
+line-length = 100


### PR DESCRIPTION
# Description

When running `kcat -b ... -L -J`, a JSON output is expected, but `kcat` prints in its stderr non-json error log messages.

As one of the steps expect a JSON, separating stderr and stdout seems legit.

## Type of change

- Refactor (refactoring code, removing useless files)

## Testing steps

Tested locally

## Checklist
* [x] Pylint passes for Python sources
* [ ] sources has been pre-processed by Black
* [ ] updated documentation wherever necessary
* [ ] new tests can be executed both locally and within docker container
* [ ] new tests have been included in scenario list (make update-scenarios)
