### PR TITLE
Fix sha extractor test

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,7 +25,7 @@ WORKDIR $HOME
 
 ENV PATH="$VIRTUAL_ENV/bin:$PATH"
 
-RUN microdnf install --nodocs -y python3.11 unzip make lsof git libpq-devel
+RUN microdnf install --nodocs -y python3.11 unzip make lsof git libpq-devel tar
 
 RUN python3.11  -m venv $VIRTUAL_ENV && source $VIRTUAL_ENV/bin/activate
 

--- a/config/insights_sha_extractor.yaml
+++ b/config/insights_sha_extractor.yaml
@@ -49,6 +49,11 @@ service:
         class: logging.StreamHandler
         stream: ext://sys.stdout
         formatter: json
+      logfile:
+        level: DEBUG
+        class: logging.FileHandler
+        filename: logs/insights_sha_extractor.log
+        formatter: json
     formatters:
       brief:
         format: "%(message)s"
@@ -60,6 +65,7 @@ service:
     root:
       handlers:
         - default
+        - logfile
     loggers:
       insights_messaging:
         level: DEBUG

--- a/features/SHA_Extractor/sha_extractor.feature
+++ b/features/SHA_Extractor/sha_extractor.feature
@@ -54,5 +54,5 @@ Feature: SHA Extractor
       And SHA extractor retrieves the "url" attribute from the message
       And SHA extractor should download tarball from given URL attribute
      When the file "config/workload_info.json" is found by SHA extractor
-     Then message has been sent by SHA extractor into topic "archive_results"
+     Then message has been sent by SHA extractor into topic "archive-results"
       And published message should not be compressed


### PR DESCRIPTION
# Description

The SHA extractor tests were failing because it cannot run the `tar` command.

In addition, I modified the sha-extractor configuration to include logging to a file, which can help a lot to debug the results of any possible failure in the future.

## Type of change
- Bug fix (non-breaking change which fixes an issue)

## Testing steps

Tested locally

## Checklist
* [ ] Pylint passes for Python sources
* [ ] sources has been pre-processed by Black
* [ ] updated documentation wherever necessary
* [ ] new tests can be executed both locally and within docker container
* [ ] new tests have been included in scenario list (make update-scenarios)
