### PR TITLE
Adding timeout handling for reading messages from subprocess

### DIFF
--- a/features/steps/ccx_messaging.py
+++ b/features/steps/ccx_messaging.py
@@ -303,5 +303,3 @@ def message_in_buffer(message, buffer, timeout=60.0):
         else:
             # Timeout!
             return False
-
-    return found

--- a/features/steps/ccx_messaging.py
+++ b/features/steps/ccx_messaging.py
@@ -17,6 +17,7 @@
 import gzip
 import json
 import os
+import select
 import subprocess
 
 from behave import given, then, when
@@ -285,15 +286,22 @@ def no_compressed_archive_sent_to_topic(context):
     assert decoded is None and error is not None
 
 
-def message_in_buffer(message, buffer):
+def message_in_buffer(message, buffer, timeout=60.0):
     """Check if service prints given message on its output."""
-    found = False
     while True:
-        # readline can be blocking, run this
-        # test with a timeout
-        line = buffer.readline()
-        if message in line:
-            found = True
-            break
+        ready = select.select([buffer], [], [], timeout)[0]
+        if ready:
+            line = buffer.readline()
+
+            if not line:
+                # empty readline means EOF
+                return False
+
+            if message in line:
+                return True
+
+        else:
+            # Timeout!
+            return False
 
     return found


### PR DESCRIPTION
# Description

Adding a minimal timeout mechanism to handle the possible `readline` block when using `subprocess` for ccx-messaging

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Testing steps

Tested locally removing `tar` from the container image in order to repeat the previous errors and then check that it fails, but not blocks the execution.

## Checklist
* [ ] Pylint passes for Python sources
* [ ] sources has been pre-processed by Black
* [ ] updated documentation wherever necessary
* [ ] new tests can be executed both locally and within docker container
* [ ] new tests have been included in scenario list (make update-scenarios)
