### PR TITLE
[CCXDEV-12896] Fix path to new sha-extractor repo

### DIFF
--- a/insights_sha_extractor_test.sh
+++ b/insights_sha_extractor_test.sh
@@ -33,8 +33,8 @@ function prepare_venv() {
 
 function install_extractor() {
     if [[ ! -d $PATH_TO_LOCAL_SHA_EXTRACTOR ]] ; then
-    	git clone --depth=1 git@gitlab.cee.redhat.com:ccx/ccx-sha-extractor.git $PATH_TO_LOCAL_SHA_EXTRACTOR
-	add_trap "rm -rf ./ccx-sha-extractor"
+       git clone --depth=1 git@github.com:RedHatInsights/insights-sha-extractor.git $PATH_TO_LOCAL_SHA_EXTRACTOR
+       add_trap "rm -rf ./ccx-sha-extractor"
     fi
     cwd=$(pwd)
     cd $PATH_TO_LOCAL_SHA_EXTRACTOR || exit


### PR DESCRIPTION
# Description

Repository of sha-extractor was moved to github. Update the repository path for running sha-extractor bdd tests.

## Type of change

- Bug fix (non-breaking change which fixes an issue)