### PR TITLE
Prepare run_in_docker script to use podman or docker

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -37,6 +37,12 @@ services:
     environment:
       - KAFKA_ADVERTISED_HOST_NAME=kafka
       - KAFKA_CREATE_TOPICS="platform.notifications.ingress:1:1"
+    healthcheck:
+      test: ["CMD", "bash", "-c", "echo > /dev/tcp/localhost/9092"]
+      interval: 5s
+      timeout: 2s
+      retries: 5
+      start_period: 5s
 
   minio:
     profiles:

--- a/run_in_docker.sh
+++ b/run_in_docker.sh
@@ -10,16 +10,15 @@ command_exists() {
 # Check if Podman is installed
 if command_exists podman; then
   CONTAINER_TOOL="podman"
+  COMPOSER="podman-compose"
 # Check if Docker is installed
 elif command_exists docker; then
   CONTAINER_TOOL="docker"
+  COMPOSER="docker compose"
 else
   echo "Neither Docker nor Podman is installed on this system."
   exit 1
 fi
-
-# shellcheck disable=SC2016
-REMOTE_PATH_FOR_SERVICE="$cid:$("$CONTAINER_TOOL" exec "$cid" bash -c 'echo "$HOME"')"
 
 # Function to get the correct profile to add based on service name specified by the user
 with_profile() {
@@ -161,10 +160,13 @@ fi
 
 # Step 4: Launch containers
 # shellcheck disable=SC2046
-POSTGRES_DB_NAME="$db_name" "$CONTAINER_TOOL compose" $(with_profile "$1") $(with_no_mock "$3") up -d
+POSTGRES_DB_NAME="$db_name" "$COMPOSER" $(with_profile "$1") $(with_no_mock "$3") up -d
 
 # Step 5: Find the container ID of the insights-behavioral-spec container
 cid=$("$CONTAINER_TOOL" ps | grep 'insights-behavioral-spec:latest' | cut -d ' ' -f 1)
+
+# shellcheck disable=SC2016
+REMOTE_PATH_FOR_SERVICE="$cid:$("$CONTAINER_TOOL" exec "$cid" bash -c 'echo "$HOME"')"
 
 # Step 6: Copy the executable and needed dependencies or Python service into the container
 # TODO: Discuss including archives in compiled Go executables for testing

--- a/run_in_docker.sh
+++ b/run_in_docker.sh
@@ -7,16 +7,17 @@ command_exists() {
   command -v "$1" &> /dev/null
 }
 
-# Check if Podman is installed
-if command_exists podman; then
-  CONTAINER_TOOL="podman"
-  COMPOSER="podman-compose"
+
 # Check if Docker is installed
-elif command_exists docker; then
+if command_exists docker; then
   CONTAINER_TOOL="docker"
   COMPOSER="docker compose"
+# Check if Podman is installed
+elif command_exists podman; then
+  CONTAINER_TOOL="podman"
+  COMPOSER="podman-compose"
 else
-  echo "Neither Docker nor Podman is installed on this system."
+  echo "Neither Docker nor Podman are installed on this system."
   exit 1
 fi
 


### PR DESCRIPTION
# Description

Small improvement to try to run the script using podman or docker if they are installed.

As long as docker and podman's arguments remain compatible, this should do the trick.

## Type of change

Improvement 

## Testing steps

I just used `run_in_docker` with podman

## Checklist
* [ ] Pylint passes for Python sources
* [ ] sources has been pre-processed by Black
* [ ] updated documentation wherever necessary
* [ ] new tests can be executed both locally and within docker container
* [ ] new tests have been included in scenario list (make update-scenarios)
