### PR TITLE
Remove RH IT certificates from image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -29,9 +29,6 @@ RUN microdnf install --nodocs -y python3.11 unzip make lsof git libpq-devel tar
 
 RUN python3.11  -m venv $VIRTUAL_ENV && source $VIRTUAL_ENV/bin/activate
 
-RUN curl -ksL https://certs.corp.redhat.com/certs/2015-IT-Root-CA.pem -o /etc/pki/ca-trust/source/anchors/RH-IT-Root-CA.crt
-RUN curl -ksL https://certs.corp.redhat.com/certs/2022-IT-Root-CA.pem -o /etc/pki/ca-trust/source/anchors/2022-IT-Root-CA.pem
-RUN update-ca-trust
 RUN pip install --no-cache-dir -U pip setuptools wheel
 
 COPY requirements/requirements_docker.txt $HOME/requirements/


### PR DESCRIPTION
# Description

The RH cert is not needed in this repository

## Type of change

- Cleanup

## Testing steps

`docker / podman build .`

## Checklist
* [ ] Pylint passes for Python sources
* [ ] sources has been pre-processed by Black
* [ ] updated documentation wherever necessary
* [ ] new tests can be executed both locally and within docker container
* [ ] new tests have been included in scenario list (make update-scenarios)
