### PR TITLE
Remove BASE_IMAGES_DIGESTS reference in Konflux tekton pipelines

### DIFF
--- a/.tekton/insights-behavioral-spec-pull-request.yaml
+++ b/.tekton/insights-behavioral-spec-pull-request.yaml
@@ -256,8 +256,6 @@ spec:
       params:
       - name: BINARY_IMAGE
         value: $(params.output-image)
-      - name: BASE_IMAGES
-        value: $(tasks.build-container.results.BASE_IMAGES_DIGESTS)
       runAfter:
       - build-container
       taskRef:
@@ -283,8 +281,6 @@ spec:
         workspace: workspace
     - name: deprecated-base-image-check
       params:
-      - name: BASE_IMAGES_DIGESTS
-        value: $(tasks.build-container.results.BASE_IMAGES_DIGESTS)
       - name: IMAGE_URL
         value: $(tasks.build-container.results.IMAGE_URL)
       - name: IMAGE_DIGEST

--- a/.tekton/insights-behavioral-spec-push.yaml
+++ b/.tekton/insights-behavioral-spec-push.yaml
@@ -253,8 +253,6 @@ spec:
       params:
       - name: BINARY_IMAGE
         value: $(params.output-image)
-      - name: BASE_IMAGES
-        value: $(tasks.build-container.results.BASE_IMAGES_DIGESTS)
       runAfter:
       - build-container
       taskRef:
@@ -280,8 +278,6 @@ spec:
         workspace: workspace
     - name: deprecated-base-image-check
       params:
-      - name: BASE_IMAGES_DIGESTS
-        value: $(tasks.build-container.results.BASE_IMAGES_DIGESTS)
       - name: IMAGE_URL
         value: $(tasks.build-container.results.IMAGE_URL)
       - name: IMAGE_DIGEST


### PR DESCRIPTION
# Description

Based on https://github.com/konflux-ci/build-definitions/blob/main/task/buildah/0.2/MIGRATION.md and the current failures in the pipelines (see https://github.com/RedHatInsights/insights-behavioral-spec/pull/608/checks?check_run_id=28042291222, f.e), the `BASE_IMAGE_DIGESTS` references should be removed 

Fixes Konflux pipelines, hopefully

## Type of change

- Change needed to fix something that should be automatically fixed...

## Testing steps

CI
