### PR TITLE
Use docker compose (v2) instead of docker-compose (v1)

### DIFF
--- a/run_in_docker.sh
+++ b/run_in_docker.sh
@@ -141,7 +141,7 @@ fi
 
 # Step 4: Launch containers
 # shellcheck disable=SC2046
-POSTGRES_DB_NAME="$db_name" docker-compose $(with_profile "$1") $(with_no_mock "$3") up -d
+POSTGRES_DB_NAME="$db_name" docker compose $(with_profile "$1") $(with_no_mock "$3") up -d
 
 # Step 5: Find the container ID of the insights-behavioral-spec container
 cid=$(docker ps | grep 'insights-behavioral-spec:latest' | cut -d ' ' -f 1)


### PR DESCRIPTION
# Description

v1 of docker-compose API has been deprecated on July 29. This change is to use v2's API.

Fixes CCXDEV-14034

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Testing steps

Runner will be used in other PR's CI to check correct behavior

## Checklist
* [ ] Pylint passes for Python sources
* [ ] sources has been pre-processed by Black
* [ ] updated documentation wherever necessary
* [ ] new tests can be executed both locally and within docker container
* [ ] new tests have been included in scenario list (make update-scenarios)
