### PR TITLE
Add sentry-sdk to data-eng and inference service requirements

### DIFF
--- a/requirements/requirements_docker.txt
+++ b/requirements/requirements_docker.txt
@@ -15,3 +15,4 @@ pyarrow
 numpy
 boto3
 toml
+sentry-sdk

--- a/requirements/upgrades_data_eng_service.txt
+++ b/requirements/upgrades_data_eng_service.txt
@@ -4,3 +4,4 @@ requests
 psycopg2-binary
 minio
 jsonschema
+sentry-sdk

--- a/requirements/upgrades_inference_service.txt
+++ b/requirements/upgrades_inference_service.txt
@@ -4,3 +4,4 @@ requests
 psycopg2-binary
 minio
 jsonschema
+sentry-sdk


### PR DESCRIPTION
# Description

BDD tests break when Glitchtip integration is added to our Python services. This PR adds sentry-sdk dependency, which is required to run services with Glitchtip.

## Type of change

- Configuration update

## Testing steps

Run BDD tests locally.

## Checklist
* [ ] Pylint passes for Python sources
* [ ] sources has been pre-processed by Black
* [ ] updated documentation wherever necessary
* [ ] new tests can be executed both locally and within docker container
* [ ] new tests have been included in scenario list (make update-scenarios)
