### PR TITLE
Assert the BuildTime matches the regex pattern

### DIFF
--- a/features/steps/insights_content_service.py
+++ b/features/steps/insights_content_service.py
@@ -35,6 +35,7 @@ def check_build_time(context):
         r".{3} .{3}[ ]{1,2}[0-9]{1,2} [0-9]{2}:[0-9]{2}:[0-9]{2} ([AP]M )?[A-Z]{1,5} [0-9]{4}",
     )
     match = re.match(pattern, buildTime)
+    assert match is not None, f"BuildTime doesn't match the pattern: {buildTime}"
     assert match.group(0), f"BuildTime is not a date time: {buildTime}"
 
 


### PR DESCRIPTION
# Description

BDD tests are failing for https://github.com/RedHatInsights/insights-content-service/pull/637 because the BuildTime doesn't match the RegExp.

## Type of change

- Non-breaking change in test steps implementation

## Testing steps

Locally, although in MacOS it fails because the `date` command is not the same as in other Linux systems...

## Checklist
* [ ] Pylint passes for Python sources
* [ ] sources has been pre-processed by Black
* [ ] updated documentation wherever necessary
* [ ] new tests can be executed both locally and within docker container
* [ ] new tests have been included in scenario list (make update-scenarios)
