### PR TITLE
[CCXDEV-14801] Update content-service support

### DIFF
--- a/insights_content_service_test.sh
+++ b/insights_content_service_test.sh
@@ -14,13 +14,19 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+if [ -z "$ENV_DOCKER" ]; then
+    PATH_TO_LOCAL_CONTENT_SERVICE=${PATH_TO_LOCAL_CONTENT_SERVICE:="../content-service"}
+else
+    PATH_TO_LOCAL_CONTENT_SERVICE=${PATH_TO_LOCAL_CONTENT_SERVICE:="content-service"}
+fi
+
 #set NOVENV is current environment is not a python virtual env
 [ "$VIRTUAL_ENV" != "" ] || NOVENV=1
 
 function prepare_venv() {
     echo "Preparing environment"
     # shellcheck disable=SC1091
-    virtualenv -p python3 venv
+    python3 -m venv venv
     # shellcheck disable=SC1091
     source venv/bin/activate
     pip install --no-cache -r requirements.txt || exit 1
@@ -28,20 +34,20 @@ function prepare_venv() {
 }
 
 function clone_service() {
-    git clone --depth=1 https://github.com/RedHatInsights/insights-content-service.git
+    git clone --depth=1 git@gitlab.cee.redhat.com:ccx/content-service.git "${PATH_TO_LOCAL_CONTENT_SERVICE}"
 }
 
 function install_service() {
-    cd insights-content-service || exit
+    cd "${PATH_TO_LOCAL_CONTENT_SERVICE}" || exit
     ./update_rules_content.sh
     ./build.sh
     cd ..
 }
 
 function run_service() {
-    cd insights-content-service || exit
+    pushd "${PATH_TO_LOCAL_CONTENT_SERVICE}" || exit
     ./insights-content-service > /dev/null &
-    cd ..
+    popd || exit
 }
 
 # prepare virtual environment if necessary
@@ -50,18 +56,18 @@ case "$NOVENV" in
     "1") prepare_venv;;
 esac
 
-if [ ! -d "insights-content-service" ]; then
+if [ ! -d "${PATH_TO_LOCAL_CONTENT_SERVICE}" ]; then
     if [[ -z $ENV_DOCKER ]]
     then
         clone_service && \
         install_service
         REMOVE_CONTENT_SERVICE_DIRECTORY=1
     else
-        echo "insights-content-service directory not found in working directory. Please add it (with the compiled executable)!"
+        echo "content-service directory not found in working directory. Please add it (with the compiled executable)!"
         exit 1
     fi
 else
-    echo "insights-content-service directory found in working directory"
+    echo "content-service directory found in working directory"
 fi
 
 run_service

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ behave
 boto3
 fastapi
 jsonschema
-kafka-python
+kafka-python-ng
 minio
 numpy
 pandas

--- a/run_in_docker.sh
+++ b/run_in_docker.sh
@@ -126,6 +126,10 @@ copy_files() {
   esac
 }
 
+cleanup() {
+  docker compose down
+}
+
 # Step 1: Specify the make target for tests to run
 tests_target="$1"
 
@@ -154,3 +158,5 @@ copy_files "$cid" "$tests_target" "$path_to_service"
 
 
 docker exec "$cid" /bin/bash -c "source \$VIRTUAL_ENV/bin/activate && env && $(with_mocked_dependencies "$3") make $tests_target"
+
+trap cleanup EXIT ERR SIGINT SIGTERM


### PR DESCRIPTION
# Description

As the Content service has been moved from GitHub to GitLab, the scripts and tools need some update.

## Type of change

- Bug fix (non-breaking change which fixes an issue)
- Refactor (refactoring code, removing useless files)
- Bump-up dependent library (no changes in the code)
- Configuration update

## Testing steps

Tested locally, both with `make` and `run_in_docker.sh`

## Checklist
* [ ] Pylint passes for Python sources
* [ ] sources has been pre-processed by Black
* [ ] updated documentation wherever necessary
* [ ] new tests can be executed both locally and within docker container
* [ ] new tests have been included in scenario list (make update-scenarios)
