### PR TITLE
Build the service, even in a docker build

### DIFF
--- a/features/insights-content-service/endpoints.feature
+++ b/features/insights-content-service/endpoints.feature
@@ -59,7 +59,7 @@ Feature: Test the service endpoints
           }
           """
          And BuildCommit is a proper sha1
-         And BuildTime is a proper date
+         And BuildTime is a proper datetime stamp
          And BuildVersion is in the proper format
          And OCPRulesVersion is in the proper format
          And UtilsVersion is in the proper format

--- a/run_in_docker.sh
+++ b/run_in_docker.sh
@@ -158,5 +158,7 @@ copy_files "$cid" "$tests_target" "$path_to_service"
 
 
 docker exec "$cid" /bin/bash -c "source \$VIRTUAL_ENV/bin/activate && env && $(with_mocked_dependencies "$3") make $tests_target"
+exitCode=$?
 
 trap cleanup EXIT ERR SIGINT SIGTERM
+exit $exitCode


### PR DESCRIPTION
# Description

Force the build of the content service when the binary is not found

Fixes # (issue)

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Testing steps

Tested locally

## Checklist
* [ ] Pylint passes for Python sources
* [ ] sources has been pre-processed by Black
* [ ] updated documentation wherever necessary
* [ ] new tests can be executed both locally and within docker container
* [ ] new tests have been included in scenario list (make update-scenarios)
