### PR TITLE
Content service script installs the certificates when needed

### DIFF
--- a/insights_content_service_test.sh
+++ b/insights_content_service_test.sh
@@ -23,6 +23,16 @@ fi
 #set NOVENV is current environment is not a python virtual env
 [ "$VIRTUAL_ENV" != "" ] || NOVENV=1
 
+function install_certificates() {
+    if [ -z "$ENV_DOCKER" ]; then
+        return
+    fi
+
+    curl -ksL https://certs.corp.redhat.com/certs/2022-IT-Root-CA.pem -o /etc/pki/ca-trust/source/anchors/2022-IT-Root-CA.pem
+    curl -ksL https://certs.corp.redhat.com/certs/Current-IT-Root-CAs.pem -o /etc/pki/ca-trust/source/anchors/Current-IT-Root-CAs.pem
+    update-ca-trust
+}
+
 function prepare_venv() {
     echo "Preparing environment"
     # shellcheck disable=SC1091
@@ -44,6 +54,7 @@ function build_service() {
     fi
 
     if [ ! -d "rules-content" ]; then
+        install_certificates
         ./update_rules_content.sh
     fi
     popd || exit


### PR DESCRIPTION
# Description

When running in a container, content-service tests needs to download the rules content from the ccx-rules-ocp repository. As it is in an internal repository, the certificates to access it are needed.

In that case, the new version of the script downloads and install them.

## Type of change

- Refactor (refactoring code, removing useless files)

## Testing steps

Tested locally

## Checklist
* [ ] Pylint passes for Python sources
* [ ] sources has been pre-processed by Black
* [ ] updated documentation wherever necessary
* [ ] new tests can be executed both locally and within docker container
* [ ] new tests have been included in scenario list (make update-scenarios)
