### PR TITLE
Increase waiting time for RHOBS and inference mock services

### DIFF
--- a/features/steps/ccx_data_engineering_service.py
+++ b/features/steps/ccx_data_engineering_service.py
@@ -54,11 +54,11 @@ def start_RHOBS_mock_service(context, port):
     """Run RHOBS service mock for a test and prepare its stop."""
     params = ["uvicorn", "mocks.rhobs.rhobs_service:app", "--port", str(port)]
 
-    f = open(f"logs/ccx-upgrades-data-eng/{context.scenario}.log", "w")
+    f = open(f"logs/ccx-upgrades-data-eng/{context.scenario}-rhobs-mock.log", "w")
     popen = subprocess.Popen(params, stdout=f, stderr=f)
     assert popen is not None
     # time.sleep(0.5)
-    check_service_started(context, "localhost", port)
+    check_service_started(context, "localhost", port, attempts=10, seconds_between_attempts=1)
     context.add_cleanup(popen.terminate)
     context.mock_rhobs = popen
 

--- a/features/steps/ccx_inference_service.py
+++ b/features/steps/ccx_inference_service.py
@@ -33,19 +33,20 @@ def start_ccx_inference_service(context, port):
     assert popen is not None
     check_service_started(context, "localhost", port, seconds_between_attempts=1)
     context.add_cleanup(popen.terminate)
+    context.add_cleanup(f.close)
 
 
 @given("The mock CCX Inference Service is running on port {port:d}")
 def start_ccx_inference_mock_service(context, port):
     """Run ccx-inference-service for a test and prepare its stop."""
     params = ["uvicorn", "mocks.inference-service.inference_service:app", "--port", str(port)]
-
-    f = open(f"logs/ccx-upgrades-inference/{context.scenario}.log", "w")
+    f = open(f"logs/ccx-upgrades-data-eng/{context.scenario}-rhobs-mock.log", "w")
     popen = subprocess.Popen(params, stdout=f, stderr=f)
     assert popen is not None
-    check_service_started(context, "localhost", port)
+    check_service_started(context, "localhost", port, attempts=10, seconds_between_attempts=1)
 
     context.add_cleanup(popen.terminate)
+    context.add_cleanup(f.close)
     context.mock_inference = popen
 
 


### PR DESCRIPTION
# Description

Inference and RHOBS mock services needs to be launched from the test for some of the scenarios. The current waiting time for them is too low (5 attempts every 0.1s, so only 0.5s). It caused that they cannot start on the given time and make some tests fail.

Increasing to 10 attempts every 1s

## Type of change
- Refactor (refactoring code, removing useless files)

## Testing steps

Tested locally and in pipeline

## Checklist
* [ ] Pylint passes for Python sources
* [ ] sources has been pre-processed by Black
* [ ] updated documentation wherever necessary
* [ ] new tests can be executed both locally and within docker container
* [ ] new tests have been included in scenario list (make update-scenarios)
