### PR TITLE
[CCXDEV-14947] Make container cleanup in run_in_docker.sh optional

### DIFF
--- a/docs/tools.md
+++ b/docs/tools.md
@@ -44,6 +44,10 @@ script can be used. It expects the following arguments:
 The script will take care of starting all the required containers, copying the necessary files into the
 docker container, and starting the corresponding tests.
 
+By default, script shuts down and removes containers it has created to run the tests. If you want to keep
+containers running (e.g. for debugging purposes), you can disable container cleanup with `CLEANUP_ENABLED=0`
+environment variable.
+
 #### Usage
 
 Example command:

--- a/run_in_docker.sh
+++ b/run_in_docker.sh
@@ -2,6 +2,9 @@
 
 # This script assumes that a Go service is already built, and the Python service can be interpreted without errors
 
+# This parameter determines whether to shut down containers when the script finishes
+cleanup_enabled=${CLEANUP_ENABLED:-1}
+
 # Function to get docker compose profile to add based on service name specified by the user
 with_profile() {
   local target="$1"
@@ -127,7 +130,9 @@ copy_files() {
 }
 
 cleanup() {
-  docker compose down
+  if [[ $cleanup_enabled != 0 ]]; then
+    docker compose down
+  fi
 }
 
 # Step 1: Specify the make target for tests to run


### PR DESCRIPTION
# Description

Add environment variable that enables/disables container cleanup in the `run_in_docker.sh` script, that was added in [this PR](https://github.com/RedHatInsights/insights-behavioral-spec/pull/672/files). Unfortunatelly the cleanup breaks the BDD run in CI, for example [here](https://github.com/RedHatInsights/insights-results-aggregator/actions/runs/13807720470/job/38621986083?pr=2120).

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Testing steps

Run the script with the variable values set locally.

## Checklist
* [ ] Pylint passes for Python sources
* [ ] sources has been pre-processed by Black
* [x] updated documentation wherever necessary
* [ ] new tests can be executed both locally and within docker container
* [ ] new tests have been included in scenario list (make update-scenarios)
