### PR TITLE
[CCXDEV-15219]Adding check that test bucket was created so the bdd tests wont fail in CI

### DIFF
--- a/features/insights-results-aggregator-exporter/s3_export.feature
+++ b/features/insights-results-aggregator-exporter/s3_export.feature
@@ -15,6 +15,7 @@ Feature: Ability to export tables into S3
       And S3 secret access key is set
       And S3 bucket name is set to test
       And S3 connection is established
+      And S3 test bucket exists
 
 
   @database @s3 @export

--- a/features/steps/exporter_s3.py
+++ b/features/steps/exporter_s3.py
@@ -94,6 +94,12 @@ def establish_s3_connection(context):
     minio_client(context)
 
 
+@given("S3 test bucket exists")
+def create_s3_bucket(context):
+    """Create bucket in S3."""
+    create_bucket(context)
+
+
 @given("I should see no objects in S3")
 @then("I should see no objects in S3")
 def assert_s3_bucket_is_empty(context):


### PR DESCRIPTION
# Description

The bdd tests for aggregator exporter is currently failing in CI. In the error logs from scenario i saw the test bucket was not created. `'{"level":"error","error":"The specified bucket does not exist","Table name":"advisor_ratings","time":"2025-06-23T12:54:31Z","message":"Store table into S3 failed"}', '{"level":"error","error":"The specified bucket does not exist","time":"2025-06-23T12:54:31Z","message":"Do selected operation"}'` I have added step that make sure that test bucket exists (if not it will create a new one).
Example of bdd test passing for changes i made https://github.com/RedHatInsights/insights-results-aggregator-exporter/actions/runs/15849287688/job/44683939525
Fixes # [CCXDEV-15219](https://issues.redhat.com/browse/CCXDEV-15219)

## Type of change

Please delete options that are not relevant.

- Bug fix (non-breaking change which fixes an issue)


## Testing steps
On my fork i made the changes which should fix the issue with bucket creation. Then i created test PR in which i used the image for this PR to run the BDD tests

## Checklist
* [ ] Pylint passes for Python sources
* [ ] sources has been pre-processed by Black
* [ ] updated documentation wherever necessary
* [ ] new tests can be executed both locally and within docker container
* [ ] new tests have been included in scenario list (make update-scenarios)
