### PR TITLE
[CCXDEV-15219]Updating mc config command to newer mc alias command

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -70,9 +70,10 @@ services:
     entrypoint:
       - /bin/sh
       - -c
-      - "
-      /usr/bin/mc config host add myminio http://minio:9000 test_access_key test_secret_access_key;
-      /usr/bin/mc mb myminio/test;"
+      - |
+        set -e
+        /usr/bin/mc alias set myminio http://minio:9000 test_access_key test_secret_access_key
+        /usr/bin/mc mb myminio/test
 
   pushgateway:
     profiles:


### PR DESCRIPTION
# Description

Updating outdated `mc config host add myminio http://minio:9000 test_access_key test_secret_access_key` command which caused the test bucket to not create with silent failure for `mc alias set myminio http://minio:9000 test_access_key test_secret_access_key` which fixes the issue. I have tested this with generated image in konflux from my fork and PR https://github.com/RedHatInsights/insights-results-aggregator-exporter/actions/runs/15871118309/job/44754862248?pr=419. I also added the `set -e` to prevent this in the future.

Fixes # [CCXDEV-15219](https://issues.redhat.com/browse/CCXDEV-15219)

## Type of change

Please delete options that are not relevant.

- Bug fix (non-breaking change which fixes an issue)


## Checklist
* [ ] Pylint passes for Python sources
* [ ] sources has been pre-processed by Black
* [ ] updated documentation wherever necessary
* [ ] new tests can be executed both locally and within docker container
* [ ] new tests have been included in scenario list (make update-scenarios)
