### PR TITLE
chore: small changes to successfully pass sha-extractor tests

### DIFF
--- a/features/steps/ccx_messaging.py
+++ b/features/steps/ccx_messaging.py
@@ -20,6 +20,7 @@ import os
 import select
 import subprocess
 import time
+from pathlib import Path
 
 from behave import given, then, when
 from src import kafka_util
@@ -145,7 +146,7 @@ def check_workload_info_present(context, service):
 def check_b64_decode(context, service):
     """Check if ccx-messaging service was able to decode b64_identity attribute from a message."""
     service_name = transform_service_name(service)
-    expected_msg = "Message context: OrgId="
+    expected_msg = "Extracted URL from input message"
     stdout_file = context.service_logs[service_name]["stdout"]
 
     assert message_in_buffer(
@@ -278,6 +279,9 @@ def start_service_compressed(context, service, group_id=None):
         context.services = {}
 
     context.services[service_name] = process
+    if not hasattr(context, "service_logs"):
+        context.service_logs = {}
+    context.service_logs[service_name] = {"stdout": process.stdout, "stderr": process.stderr}
 
 
 @then("published message has to be compressed")
@@ -314,17 +318,16 @@ def no_compressed_archive_sent_to_topic(context):
 
 def message_in_buffer(message, buffer, timeout=60.0):
     """Check if service prints given message on its output."""
-    # If buffer is a string (file path), read from file
     if isinstance(buffer, str):
+        buffer = Path(buffer)
+
+    if isinstance(buffer, Path):
         start_time = time.time()
         while time.time() - start_time < timeout:
-            try:
-                with open(buffer) as f:
-                    content = f.read()
-                    if message in content:
-                        return True
-            except FileNotFoundError:
-                pass
+            if buffer.exists():
+                content = buffer.read_text()
+                if message in content:
+                    return True
             time.sleep(0.1)
         return False
 


### PR DESCRIPTION
Description
This PR fixes three bugs in features/steps/ccx_messaging.py that caused all SHA extractor BDD test scenarios to fail.
Link on failed tests - https://github.com/RedHatInsights/insights-sha-extractor/actions/runs/29752551309/job/88386549534?pr=172

Bug 1 — message_in_buffer: Path object not handled in isinstance check

The function checked isinstance(buffer, str) to decide whether to read from a file path or a pipe. However, start_ccx_messaging_service stores pathlib.Path objects (not plain strings) in context.service_logs. Since Path is not a subtype of str, the condition evaluated to False and the code fell through to the select.select() branch, which requires an object with fileno() — causing TypeError: argument must be an int, or have a fileno() method.

Fix: changed to isinstance(buffer, (str, Path)).

Bug 2 — start_service_compressed: missing context.service_logs initialization

Unlike start_ccx_messaging_service, the start_service_compressed function never initialized or populated context.service_logs. Any subsequent step that accessed context.service_logs[service_name] raised AttributeError: 'Context' object has no attribute 'service_logs'.

Fix: added context.service_logs initialization and stored process.stdout/process.stderr pipes directly (not wrapped in Path(), since compressed service uses subprocess.PIPE rather than file redirection as start_ccx_messaging_service does).

Bug 3 — check_b64_decode: wrong expected log message

The step checked for "Message context: OrgId=" in service logs. However, this string is only logged inside WorkloadInfoPublisher.publish(), which is only reached when an archive contains workload_info.json. The scenario sha_extractor.feature:21 uses an archive without workload_info, so the publisher returns early and this log line never appears.

Fix: changed to "Extracted URL from input message", which is logged by KafkaConsumer.get_url() — called after parse_ingress_message() successfully decodes b64_identity. This message appears for any successfully processed archive regardless of workload info presence.

Type of change
Bug fix

## Testing steps
Changes were tested locally by running the **insights_sha_extractor_test.sh** script against a local clone of the insights-sha-extractor repository.


