### PR TITLE
add `--ignore-disabled-rules` to all existing notification BDD scenarios

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,3 @@
+coverage:
+  status:
+    patch: off

--- a/features/steps/notification_service.py
+++ b/features/steps/notification_service.py
@@ -110,7 +110,7 @@ def start_ccx_notification_service_with_flag(context, flag):
         | val                                             | var   |
         | CCX_NOTIFICATION_SERVICE__KAFKA_BROKER__ENABLED | false |
     """
-    params = ["ccx-notification-service", flag]
+    params = ["ccx-notification-service", flag, "--ignore-disabled-rules"]
     if hasattr(context, "max_age"):
         params.append("--max-age=" + context.max_age)
     if hasattr(context, "cleanup_on_startup"):


### PR DESCRIPTION
# Description
- the new BDD scenarios regarding disabled rules are skipped / not yet implemented, but here we're adding a breaking check https://github.com/RedHatInsights/ccx-notification-service/pull/1264
- to prevent the existing notification scenarios from failing, I'm adding the `--ignore-disabled-rules` flag to all executions of the `ccx-notification-service`. 
- once we add the definitions for the new database, this will be turned into a regular parsable CLI flag, **this is not a permanent change**

Additional change:
- remove Codecov patch check. Whoever enabled Codecov here didn't think this through. There is basically zero coverage in the entire repo, no coverage at all for the majority of files (this one included). Project coverage is still enabled.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- Bug fix (non-breaking change which fixes an issue)
- Configuration update

## Testing steps

Please describe how the change was tested locally. If, for some reason, the testing was not done or not done fully, please describe what are the testing steps.

## Checklist
* [ ] pre-commit run --all-files passes for Python sources
* [ ] updated documentation wherever necessary
* [ ] new tests can be executed both locally and within docker container
* [ ] new tests have been included in scenario list (make update-scenarios)
